### PR TITLE
Implement file attachment previews and related features

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 ### Features
 
+- File attachment previews: inline snippets for text, PDF, .xlsx, and .docx; tap to open full viewer with download button; warning before downloading risky file types
 - Desktop system tray (Linux, Windows, macOS): close hides to tray by default, unread badge, Tor status and pending queue in tooltip/menu
 - Message reactions (emoji) on all message types in 1:1 and group chats — one emoji per user, synced over Tor
 

--- a/lib/screens/chat.dart
+++ b/lib/screens/chat.dart
@@ -19,7 +19,9 @@ import 'package:prysm/screens/message_composer.dart';
 import 'package:prysm/screens/widgets/contact_avatar.dart';
 import 'package:prysm/screens/widgets/message_reaction_bar.dart';
 import 'package:prysm/screens/widgets/message_reaction_picker.dart';
+import 'package:prysm/screens/widgets/file_attachment_bubble.dart';
 import 'package:prysm/screens/widgets/voice_message_bubble.dart';
+import 'package:prysm/services/file_attachment_resolver.dart';
 import 'package:prysm/services/reaction_service.dart';
 import 'package:prysm/util/reaction_refresh_notifier.dart';
 import 'package:prysm/util/waveform_extractor.dart';
@@ -29,7 +31,6 @@ import 'package:prysm/util/file_encrypt.dart';
 import 'package:prysm/util/tor_service.dart';
 import 'package:prysm/util/group_crypto.dart';
 import 'package:prysm/util/key_manager.dart';
-import 'package:prysm/util/download_location.dart';
 import 'package:image_picker/image_picker.dart';
 import 'package:file_picker/file_picker.dart';
 import 'package:scroll_to_index/scroll_to_index.dart';
@@ -592,13 +593,10 @@ class _ChatScreenState extends State<ChatScreen> {
     Map<String, dynamic> msg,
     KeyManager keyManager,
   ) async {
-    final hybrid = jsonDecode(msg['message']) as Map<String, dynamic>;
-    final aesKeyBytes = keyManager.decryptMyMessageBytes(hybrid['aes_key']);
-    return compute(_aesDecryptFilePayload, {
-      'aesKey': aesKeyBytes,
-      'iv': hybrid['iv'],
-      'data': hybrid['data'],
-    });
+    return FileAttachmentResolver.decryptEncryptedSource(
+      msg['message'] as String,
+      keyManager,
+    );
   }
 
   // ==================== MESSAGE LOADING (KEEP AS-IS) ====================
@@ -1768,190 +1766,39 @@ class _ChatScreenState extends State<ChatScreen> {
     required bool isSentByMe,
     MessageGroupStatus? groupStatus,
   }) {
-    // Detect voice messages
-    if (message.name.contains('voice_message') || message.source.startsWith('audio:')) {
-      return _voiceMessageBuilder(context, message, index, isSentByMe: isSentByMe);
-    }
-
-    final maxWidth = MediaQuery.of(context).size.width * 0.4;
-    final ValueNotifier<bool> isDownloading = ValueNotifier(false);
-
-    Future<void> downloadBase64File() async {
-      if (isDownloading.value == true) return;
-
-      isDownloading.value = true;
-
-      await Future.delayed(Duration(milliseconds: 50));
-      if (!context.mounted) return;
-      final messenger = ScaffoldMessenger.of(context);
-      try {
-        if (message.source.isEmpty) {
-          messenger.showSnackBar(
-            const SnackBar(
-              content: Text('No encrypted data available for this file'),
-            ),
-          );
-          return;
-        }
-
-        final Map<String, dynamic> decryptInput = {'message': message.source};
-
-        Uint8List bytes = await decryptFileInBackground(
-          decryptInput,
-          widget.keyManager,
-        );
-
-        if (!context.mounted) return;
-        if (bytes.isEmpty) {
-          messenger.showSnackBar(
-            SnackBar(
-              content: Text(
-                '${message.name} is still decrypting, please wait.',
-              ),
-            ),
-          );
-          return;
-        }
-        final file = await DownloadLocation.saveBytes(bytes, message.name);
-        if (!context.mounted) return;
-        messenger.showSnackBar(
-          SnackBar(
-            content: Text(
-              'Successfully downloaded ${file.path.split(Platform.pathSeparator).last}',
-            ),
-          ),
-        );
-      } catch (e) {
-        if (!context.mounted) return;
-        messenger.showSnackBar(SnackBar(content: Text('Error downloading file: $e')));
-      } finally {
-        isDownloading.value = false;
-      }
+    if (message.name.contains('voice_message') ||
+        message.source.startsWith('audio:')) {
+      return _voiceMessageBuilder(
+        context,
+        message,
+        index,
+        isSentByMe: isSentByMe,
+      );
     }
 
     final msgDate = DateTime.fromMillisecondsSinceEpoch(
       message.createdAt!.millisecondsSinceEpoch,
     );
     final timeString =
-        "${msgDate.hour.toString().padLeft(2, '0')}:${msgDate.minute.toString().padLeft(2, '0')}";
+        '${msgDate.hour.toString().padLeft(2, '0')}:${msgDate.minute.toString().padLeft(2, '0')}';
 
-    String fileSizeString = '';
-    if (message.size != null) {
-      final sizeInKB = message.size! / 1024;
-      if (sizeInKB < 1024) {
-        fileSizeString = "${sizeInKB.toStringAsFixed(1)} KB";
-      } else {
-        fileSizeString = "${(sizeInKB / 1024).toStringAsFixed(1)} MB";
-      }
-    }
-
-    // ✅ Determine tick status
     Widget tickWidget = const SizedBox.shrink();
     if (isSentByMe) {
       final tickColor = Theme.of(context).colorScheme.onPrimary;
-      tickWidget = _buildStatusWidget(message, isSentByMe, tickColor.withAlpha(220));
+      tickWidget =
+          _buildStatusWidget(message, isSentByMe, tickColor.withAlpha(220));
     }
 
-    return Column(
-      crossAxisAlignment: isSentByMe
-          ? CrossAxisAlignment.end
-          : CrossAxisAlignment.start,
-      children: [
-        ConstrainedBox(
-          constraints: BoxConstraints(maxWidth: maxWidth),
-          child: GestureDetector(
-            onTap: downloadBase64File,
-            child: Container(
-              padding: const EdgeInsets.all(8),
-              decoration: BoxDecoration(
-                color: Theme.of(context).colorScheme.primary.withAlpha(225),
-                borderRadius: BorderRadius.circular(8),
-              ),
-              child: Row(
-                mainAxisSize: MainAxisSize.min,
-                children: [
-                  ValueListenableBuilder<bool>(
-                    valueListenable: isDownloading,
-                    builder: (context, downloading, _) {
-                      if (downloading) {
-                        return SizedBox(
-                          width: 36,
-                          height: 36,
-                          child: CircularProgressIndicator(
-                            valueColor: AlwaysStoppedAnimation<Color>(
-                              Theme.of(context).colorScheme.onPrimary,
-                            ),
-                            strokeWidth: 2.5,
-                          ),
-                        );
-                      } else {
-                        return CircleAvatar(
-                          backgroundColor: Theme.of(
-                            context,
-                          ).colorScheme.primary.withAlpha(120),
-                          child: Icon(
-                            Icons.insert_drive_file,
-                            size: 24,
-                            color: Theme.of(context).colorScheme.onPrimary,
-                          ),
-                        );
-                      }
-                    },
-                  ),
-                  const SizedBox(width: 8),
-                  Flexible(
-                    child: Column(
-                      crossAxisAlignment: CrossAxisAlignment.start,
-                      children: [
-                        Text(
-                          message.name,
-                          style: TextStyle(
-                            color: Theme.of(context).colorScheme.onPrimary,
-                          ),
-                          overflow: TextOverflow.visible,
-                        ),
-                        // ✅ File size + Time + Tick indicators
-                        Row(
-                          mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                          children: [
-                            if (fileSizeString.isNotEmpty)
-                              Padding(
-                                padding: const EdgeInsets.only(right: 4),
-                                child: Text(
-                                  fileSizeString,
-                                  style: TextStyle(
-                                    fontSize: 10,
-                                    color: Theme.of(context).colorScheme.onPrimary.withAlpha(180),
-                                  ),
-                                ),
-                              ),
-                            Row(
-                              mainAxisSize: MainAxisSize.min,
-                              children: [
-                                Text(
-                                  timeString,
-                                  style: TextStyle(
-                                    fontSize: 10,
-                                    color: Theme.of(context).colorScheme.onPrimary.withAlpha(180),
-                                  ),
-                                ),
-                                if (isSentByMe) ...[
-                                  const SizedBox(width: 4),
-                                  tickWidget,
-                                ],
-                              ],
-                            ),
-                          ],
-                        ),
-                      ],
-                    ),
-                  ),
-                ],
-              ),
-            ),
-          ),
-        ),
-      ],
+    return FileAttachmentBubble(
+      fileName: message.name,
+      fileSize: message.size,
+      timeString: timeString,
+      isSentByMe: isSentByMe,
+      tickWidget: tickWidget,
+      resolveBytes: () => FileAttachmentResolver.resolve(
+        message,
+        keyManager: widget.keyManager,
+      ),
     );
   }
 
@@ -2134,9 +1981,3 @@ class _ViewOnceScreenState extends State<_ViewOnceScreen> {
   }
 }
 
-Uint8List _aesDecryptFilePayload(Map<String, dynamic> args) {
-  final aesKey = e.Key(Uint8List.fromList(List<int>.from(args['aesKey'] as List)));
-  final iv = e.IV.fromBase64(args['iv'] as String);
-  final encryptedData = base64Decode(args['data'] as String);
-  return AESHelper.decryptBytes(encryptedData, aesKey, iv);
-}

--- a/lib/screens/file_preview_screen.dart
+++ b/lib/screens/file_preview_screen.dart
@@ -1,0 +1,171 @@
+import 'dart:typed_data';
+
+import 'package:flutter/material.dart';
+import 'package:pdfx/pdfx.dart';
+import 'package:prysm/screens/widgets/file_preview_content.dart';
+import 'package:prysm/services/file_preview_service.dart';
+import 'package:prysm/util/file_download_helper.dart';
+import 'package:prysm/util/readable_file_policy.dart';
+
+class FilePreviewScreen extends StatefulWidget {
+  final String fileName;
+  final int? fileSize;
+  final Future<Uint8List> bytesFuture;
+  final FilePreviewCategory category;
+
+  const FilePreviewScreen({
+    required this.fileName,
+    required this.bytesFuture,
+    required this.category,
+    this.fileSize,
+    super.key,
+  });
+
+  @override
+  State<FilePreviewScreen> createState() => _FilePreviewScreenState();
+}
+
+class _FilePreviewScreenState extends State<FilePreviewScreen> {
+  FilePreviewData? _preview;
+  Uint8List? _bytes;
+  PdfControllerPinch? _pdfController;
+  bool _loading = true;
+  bool _tooLarge = false;
+  String? _error;
+
+  @override
+  void initState() {
+    super.initState();
+    _load();
+  }
+
+  @override
+  void dispose() {
+    _pdfController?.dispose();
+    super.dispose();
+  }
+
+  Future<void> _load() async {
+    try {
+      if (widget.fileSize != null &&
+          ReadableFilePolicy.exceedsPreviewLimit(widget.fileSize!)) {
+        setState(() {
+          _loading = false;
+          _tooLarge = true;
+        });
+        return;
+      }
+
+      final bytes = await widget.bytesFuture;
+      if (!mounted) return;
+      if (bytes.isEmpty) {
+        setState(() {
+          _loading = false;
+          _error = 'File is still decrypting or empty';
+          _preview = FilePreviewData.binary();
+        });
+        return;
+      }
+
+      if (ReadableFilePolicy.exceedsPreviewLimit(bytes.length)) {
+        setState(() {
+          _bytes = bytes;
+          _loading = false;
+          _tooLarge = true;
+        });
+        return;
+      }
+
+      final preview = await FilePreviewService.buildPreview(
+        fileName: widget.fileName,
+        bytes: bytes,
+        inline: false,
+      );
+
+      PdfControllerPinch? pdfController;
+      if (preview.category == FilePreviewCategory.pdf && preview.pdf != null) {
+        pdfController =
+            await FilePreviewService.openPdfController(preview.pdf!.documentBytes);
+      }
+
+      if (!mounted) return;
+      setState(() {
+        _bytes = bytes;
+        _preview = preview;
+        _pdfController = pdfController;
+        _loading = false;
+      });
+    } catch (e) {
+      if (!mounted) return;
+      setState(() {
+        _loading = false;
+        _error = '$e';
+        _preview = FilePreviewData.binary();
+      });
+    }
+  }
+
+  Future<void> _download() async {
+    final bytes = _bytes ?? await widget.bytesFuture;
+    if (!mounted || bytes.isEmpty) return;
+    await FileDownloadHelper.download(
+      context,
+      fileName: widget.fileName,
+      bytes: bytes,
+      category: widget.category,
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: Text(
+          widget.fileName,
+          overflow: TextOverflow.ellipsis,
+        ),
+        actions: [
+          IconButton(
+            icon: const Icon(Icons.download_outlined),
+            tooltip: 'Download',
+            onPressed: _loading ? null : _download,
+          ),
+        ],
+      ),
+      body: _loading
+          ? const Center(child: CircularProgressIndicator())
+          : _tooLarge
+              ? Center(
+                  child: Padding(
+                    padding: const EdgeInsets.all(24),
+                    child: Column(
+                      mainAxisSize: MainAxisSize.min,
+                      children: [
+                        const Icon(Icons.insert_drive_file, size: 48),
+                        const SizedBox(height: 16),
+                        Text(
+                          'File too large to preview',
+                          style: Theme.of(context).textTheme.titleLarge,
+                        ),
+                        const SizedBox(height: 8),
+                        Text(
+                          '${widget.fileName} exceeds the '
+                          '${ReadableFilePolicy.maxPreviewBytes ~/ (1024 * 1024)} MB preview limit.',
+                          textAlign: TextAlign.center,
+                          style: TextStyle(color: Theme.of(context).hintColor),
+                        ),
+                      ],
+                    ),
+                  ),
+                )
+              : _preview == null
+              ? Center(child: Text(_error ?? 'Could not load preview'))
+              : FilePreviewContent(
+                  preview: _preview!,
+                  fileName: widget.fileName,
+                  pdfController: _pdfController,
+                  bytes: _bytes,
+                ),
+    );
+  }
+}

--- a/lib/screens/group_chat.dart
+++ b/lib/screens/group_chat.dart
@@ -11,7 +11,6 @@ import 'package:flutter_chat_ui/flutter_chat_ui.dart';
 import 'package:flutter_image_compress/flutter_image_compress.dart';
 import 'package:image_picker/image_picker.dart';
 import 'package:path_provider/path_provider.dart';
-import 'package:prysm/util/download_location.dart';
 import 'package:prysm/constants/group_constants.dart';
 import 'package:prysm/database/message_reactions.dart';
 import 'package:prysm/database/messages.dart';
@@ -22,7 +21,9 @@ import 'package:prysm/screens/message_composer.dart';
 import 'package:prysm/screens/widgets/contact_avatar.dart';
 import 'package:prysm/screens/widgets/message_reaction_bar.dart';
 import 'package:prysm/screens/widgets/message_reaction_picker.dart';
+import 'package:prysm/screens/widgets/file_attachment_bubble.dart';
 import 'package:prysm/screens/widgets/voice_message_bubble.dart';
+import 'package:prysm/services/file_attachment_resolver.dart';
 import 'package:prysm/services/reaction_service.dart';
 import 'package:prysm/util/reaction_refresh_notifier.dart';
 import 'package:prysm/util/waveform_extractor.dart';
@@ -1167,15 +1168,17 @@ class _GroupChatScreenState extends State<GroupChatScreen> {
     required bool isSentByMe,
     MessageGroupStatus? groupStatus,
   }) {
-    if (message.name.contains('voice_message') || message.source.startsWith('audio:')) {
-      final msgDate = DateTime.fromMillisecondsSinceEpoch(
-        message.createdAt!.millisecondsSinceEpoch,
-      );
-      final timeString =
-          '${msgDate.hour.toString().padLeft(2, '0')}:${msgDate.minute.toString().padLeft(2, '0')}';
-      final tickColor = isSentByMe
-          ? Theme.of(context).colorScheme.onPrimary.withAlpha(200)
-          : Theme.of(context).colorScheme.onSecondary.withAlpha(200);
+    final msgDate = DateTime.fromMillisecondsSinceEpoch(
+      message.createdAt!.millisecondsSinceEpoch,
+    );
+    final timeString =
+        '${msgDate.hour.toString().padLeft(2, '0')}:${msgDate.minute.toString().padLeft(2, '0')}';
+    final tickColor = isSentByMe
+        ? Theme.of(context).colorScheme.onPrimary.withAlpha(200)
+        : Theme.of(context).colorScheme.onSecondary.withAlpha(200);
+
+    if (message.name.contains('voice_message') ||
+        message.source.startsWith('audio:')) {
       return Column(
         crossAxisAlignment:
             isSentByMe ? CrossAxisAlignment.end : CrossAxisAlignment.start,
@@ -1191,78 +1194,14 @@ class _GroupChatScreenState extends State<GroupChatScreen> {
       );
     }
 
-    final msgDate = DateTime.fromMillisecondsSinceEpoch(
-      message.createdAt!.millisecondsSinceEpoch,
-    );
-    final timeString =
-        '${msgDate.hour.toString().padLeft(2, '0')}:${msgDate.minute.toString().padLeft(2, '0')}';
-    final tickColor = isSentByMe
-        ? Theme.of(context).colorScheme.onPrimary.withAlpha(200)
-        : Theme.of(context).colorScheme.onSecondary.withAlpha(200);
-
-    Future<void> downloadFile() async {
-      try {
-        Uint8List bytes;
-        if (message.source.startsWith('data:') || message.source.length > 200) {
-          bytes = base64Decode(message.source);
-        } else {
-          bytes = base64Decode(message.source);
-        }
-        final file = await DownloadLocation.saveBytes(bytes, message.name);
-        if (!context.mounted) return;
-        ScaffoldMessenger.of(context).showSnackBar(
-          SnackBar(content: Text('Saved ${file.path.split('/').last}')),
-        );
-      } catch (e) {
-        if (!context.mounted) return;
-        ScaffoldMessenger.of(context).showSnackBar(
-          SnackBar(content: Text('Download failed: $e')),
-        );
-      }
-    }
-
-    return Column(
-      crossAxisAlignment:
-          isSentByMe ? CrossAxisAlignment.end : CrossAxisAlignment.start,
-      children: [
-        _senderLabel(message.authorId, isSentByMe),
-        GestureDetector(
-          onTap: downloadFile,
-          child: Container(
-            padding: const EdgeInsets.all(8),
-            decoration: BoxDecoration(
-              color: Theme.of(context).colorScheme.primary.withAlpha(225),
-              borderRadius: BorderRadius.circular(8),
-            ),
-            child: Row(
-              mainAxisSize: MainAxisSize.min,
-              children: [
-                Icon(Icons.insert_drive_file,
-                    color: Theme.of(context).colorScheme.onPrimary),
-                const SizedBox(width: 8),
-                Flexible(
-                  child: Text(
-                    message.name,
-                    style: TextStyle(color: Theme.of(context).colorScheme.onPrimary),
-                    overflow: TextOverflow.ellipsis,
-                  ),
-                ),
-              ],
-            ),
-          ),
-        ),
-        const SizedBox(height: 4),
-        Row(
-          mainAxisSize: MainAxisSize.min,
-          children: [
-            Text(timeString, style: TextStyle(fontSize: 10, color: Colors.grey[600])),
-            if (isSentByMe) ...[
-              const SizedBox(width: 4),
-              _buildStatusWidget(message, isSentByMe, tickColor),
-            ],
-          ],
-        ),
-      ],
+    return FileAttachmentBubble(
+      fileName: message.name,
+      fileSize: message.size,
+      timeString: timeString,
+      isSentByMe: isSentByMe,
+      tickWidget: _buildStatusWidget(message, isSentByMe, tickColor),
+      header: _senderLabel(message.authorId, isSentByMe),
+      resolveBytes: () => FileAttachmentResolver.resolve(message),
     );
   }
 

--- a/lib/screens/widgets/file_attachment_bubble.dart
+++ b/lib/screens/widgets/file_attachment_bubble.dart
@@ -1,0 +1,319 @@
+import 'dart:typed_data';
+
+import 'package:flutter/material.dart';
+import 'package:pdfx/pdfx.dart';
+import 'package:prysm/screens/file_preview_screen.dart';
+import 'package:prysm/screens/widgets/file_preview_content.dart';
+import 'package:prysm/services/file_preview_service.dart';
+import 'package:prysm/util/file_download_helper.dart';
+import 'package:prysm/util/readable_file_policy.dart';
+
+class FileAttachmentBubble extends StatefulWidget {
+  final String fileName;
+  final int? fileSize;
+  final String timeString;
+  final bool isSentByMe;
+  final Widget tickWidget;
+  final Future<Uint8List> Function() resolveBytes;
+  final Widget? header;
+
+  const FileAttachmentBubble({
+    required this.fileName,
+    required this.timeString,
+    required this.isSentByMe,
+    required this.tickWidget,
+    required this.resolveBytes,
+    this.fileSize,
+    this.header,
+    super.key,
+  });
+
+  @override
+  State<FileAttachmentBubble> createState() => _FileAttachmentBubbleState();
+}
+
+class _FileAttachmentBubbleState extends State<FileAttachmentBubble> {
+  late final FilePreviewCategory _category;
+  FilePreviewData? _preview;
+  Uint8List? _bytes;
+  PdfControllerPinch? _pdfController;
+  bool _loading = true;
+  bool _loadFailed = false;
+  bool _previewSkippedDueToSize = false;
+
+  @override
+  void initState() {
+    super.initState();
+    _category = ReadableFilePolicy.categorize(widget.fileName);
+    _loadPreview();
+  }
+
+  @override
+  void dispose() {
+    _pdfController?.dispose();
+    super.dispose();
+  }
+
+  Future<void> _loadPreview() async {
+    if (!ReadableFilePolicy.supportsInlinePreview(_category) &&
+        _category != FilePreviewCategory.blocked) {
+      setState(() => _loading = false);
+      return;
+    }
+
+    if (widget.fileSize != null &&
+        ReadableFilePolicy.exceedsPreviewLimit(widget.fileSize!)) {
+      setState(() {
+        _loading = false;
+        _previewSkippedDueToSize = true;
+      });
+      return;
+    }
+
+    try {
+      final bytes = await widget.resolveBytes();
+      if (!mounted) return;
+      if (bytes.isEmpty) {
+        setState(() {
+          _loading = false;
+          _loadFailed = true;
+        });
+        return;
+      }
+
+      if (ReadableFilePolicy.exceedsPreviewLimit(bytes.length)) {
+        setState(() {
+          _loading = false;
+          _previewSkippedDueToSize = true;
+        });
+        return;
+      }
+
+      final preview = await FilePreviewService.buildPreview(
+        fileName: widget.fileName,
+        bytes: bytes,
+        inline: true,
+      );
+
+      PdfControllerPinch? pdfController;
+      if (preview.category == FilePreviewCategory.pdf && preview.pdf != null) {
+        pdfController =
+            await FilePreviewService.openPdfController(preview.pdf!.documentBytes);
+      }
+
+      if (!mounted) return;
+      setState(() {
+        _bytes = bytes;
+        _preview = preview;
+        _pdfController = pdfController;
+        _loading = false;
+      });
+    } catch (_) {
+      if (!mounted) return;
+      setState(() {
+        _loading = false;
+        _loadFailed = true;
+      });
+    }
+  }
+
+  void _openFullPreview() {
+    Navigator.of(context).push(
+      MaterialPageRoute(
+        builder: (_) => FilePreviewScreen(
+          fileName: widget.fileName,
+          fileSize: widget.fileSize,
+          bytesFuture: widget.resolveBytes(),
+          category: _category,
+        ),
+      ),
+    );
+  }
+
+  Future<void> _download() async {
+    final bytes = _bytes ?? await widget.resolveBytes();
+    if (!mounted) return;
+    await FileDownloadHelper.download(
+      context,
+      fileName: widget.fileName,
+      bytes: bytes,
+      category: _category,
+    );
+  }
+
+  String get _fileSizeString {
+    if (widget.fileSize == null) return '';
+    final sizeInKB = widget.fileSize! / 1024;
+    if (sizeInKB < 1024) {
+      return '${sizeInKB.toStringAsFixed(1)} KB';
+    }
+    return '${(sizeInKB / 1024).toStringAsFixed(1)} MB';
+  }
+
+  bool get _hasTappablePreview =>
+      _preview != null && ReadableFilePolicy.supportsInlinePreview(_category);
+
+  Widget _wrapPreviewTap(Widget child) {
+    if (!_hasTappablePreview) return child;
+    return GestureDetector(
+      onTap: _openFullPreview,
+      behavior: HitTestBehavior.opaque,
+      child: child,
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final maxWidth = MediaQuery.of(context).size.width * 0.55;
+    final bubbleColor = Theme.of(context).colorScheme.primary.withAlpha(225);
+    final onPrimary = Theme.of(context).colorScheme.onPrimary;
+
+    return Column(
+      crossAxisAlignment:
+          widget.isSentByMe ? CrossAxisAlignment.end : CrossAxisAlignment.start,
+      children: [
+        if (widget.header != null) widget.header!,
+        ConstrainedBox(
+          constraints: BoxConstraints(maxWidth: maxWidth),
+          child: Container(
+            padding: const EdgeInsets.all(8),
+            decoration: BoxDecoration(
+              color: bubbleColor,
+              borderRadius: BorderRadius.circular(8),
+            ),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                if (_category == FilePreviewCategory.blocked)
+                  Padding(
+                    padding: const EdgeInsets.only(bottom: 6),
+                    child: Row(
+                      children: [
+                        Icon(Icons.warning_amber_rounded,
+                            size: 18, color: onPrimary.withValues(alpha: 0.9)),
+                        const SizedBox(width: 6),
+                        Expanded(
+                          child: Text(
+                            'Preview unavailable',
+                            style: TextStyle(
+                              fontSize: 11,
+                              color: onPrimary.withValues(alpha: 0.85),
+                            ),
+                          ),
+                        ),
+                      ],
+                    ),
+                  )
+                else if (_loading)
+                  Padding(
+                    padding: const EdgeInsets.symmetric(vertical: 12),
+                    child: Center(
+                      child: SizedBox(
+                        width: 22,
+                        height: 22,
+                        child: CircularProgressIndicator(
+                          strokeWidth: 2,
+                          color: onPrimary,
+                        ),
+                      ),
+                    ),
+                  )
+                else if (_hasTappablePreview)
+                  Padding(
+                    padding: const EdgeInsets.only(bottom: 6),
+                    child: _wrapPreviewTap(
+                      InlineFilePreview(
+                        preview: _preview!,
+                        pdfController: _pdfController,
+                      ),
+                    ),
+                  )
+                else if (_previewSkippedDueToSize)
+                  Padding(
+                    padding: const EdgeInsets.only(bottom: 6),
+                    child: Row(
+                      children: [
+                        Icon(Icons.insert_drive_file, color: onPrimary),
+                        const SizedBox(width: 6),
+                        Expanded(
+                          child: Text(
+                            'Preview unavailable (file too large)',
+                            style: TextStyle(
+                              fontSize: 11,
+                              color: onPrimary.withValues(alpha: 0.85),
+                            ),
+                          ),
+                        ),
+                      ],
+                    ),
+                  )
+                else if (_loadFailed)
+                  const SizedBox.shrink()
+                else
+                  Padding(
+                    padding: const EdgeInsets.only(bottom: 6),
+                    child: Icon(Icons.insert_drive_file, color: onPrimary),
+                  ),
+                Row(
+                  children: [
+                    IconButton(
+                      icon: Icon(
+                        Icons.download_outlined,
+                        color: onPrimary,
+                        size: 20,
+                      ),
+                      padding: EdgeInsets.zero,
+                      constraints: const BoxConstraints(
+                        minWidth: 32,
+                        minHeight: 32,
+                      ),
+                      visualDensity: VisualDensity.compact,
+                      tooltip: 'Download',
+                      onPressed: _loading ? null : _download,
+                    ),
+                    Expanded(
+                      child: Text(
+                        widget.fileName,
+                        style: TextStyle(color: onPrimary),
+                        overflow: TextOverflow.ellipsis,
+                      ),
+                    ),
+                  ],
+                ),
+                Row(
+                  mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                  children: [
+                    if (_fileSizeString.isNotEmpty)
+                      Text(
+                        _fileSizeString,
+                        style: TextStyle(
+                          fontSize: 10,
+                          color: onPrimary.withValues(alpha: 0.8),
+                        ),
+                      ),
+                    Row(
+                      mainAxisSize: MainAxisSize.min,
+                      children: [
+                        Text(
+                          widget.timeString,
+                          style: TextStyle(
+                            fontSize: 10,
+                            color: onPrimary.withValues(alpha: 0.8),
+                          ),
+                        ),
+                        if (widget.isSentByMe) ...[
+                          const SizedBox(width: 4),
+                          widget.tickWidget,
+                        ],
+                      ],
+                    ),
+                  ],
+                ),
+              ],
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+}

--- a/lib/screens/widgets/file_preview_content.dart
+++ b/lib/screens/widgets/file_preview_content.dart
@@ -1,0 +1,318 @@
+import 'dart:typed_data';
+
+import 'package:flutter/material.dart';
+import 'package:pdfx/pdfx.dart';
+import 'package:prysm/services/file_preview_service.dart';
+import 'package:prysm/util/pdf_system_open.dart';
+import 'package:prysm/util/readable_file_policy.dart';
+
+class FilePreviewContent extends StatefulWidget {
+  final FilePreviewData preview;
+  final PdfControllerPinch? pdfController;
+  final String fileName;
+  final Uint8List? bytes;
+
+  const FilePreviewContent({
+    required this.preview,
+    required this.fileName,
+    this.pdfController,
+    this.bytes,
+    super.key,
+  });
+
+  @override
+  State<FilePreviewContent> createState() => _FilePreviewContentState();
+}
+
+class _FilePreviewContentState extends State<FilePreviewContent> {
+  bool _openingPdf = false;
+
+  @override
+  Widget build(BuildContext context) {
+    return switch (widget.preview.category) {
+      FilePreviewCategory.blocked => _blockedBody(context),
+      FilePreviewCategory.binary => _binaryBody(context),
+      FilePreviewCategory.text || FilePreviewCategory.document =>
+        _textBody(widget.preview.text),
+      FilePreviewCategory.spreadsheet =>
+        _spreadsheetBody(widget.preview.spreadsheet),
+      FilePreviewCategory.pdf => _pdfBody(context),
+    };
+  }
+
+  Widget _blockedBody(BuildContext context) {
+    return Center(
+      child: Padding(
+        padding: const EdgeInsets.all(24),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Icon(Icons.warning_amber_rounded,
+                size: 48, color: Theme.of(context).colorScheme.error),
+            const SizedBox(height: 16),
+            Text(
+              'Preview unavailable',
+              style: Theme.of(context).textTheme.titleLarge,
+            ),
+            const SizedBox(height: 8),
+            Text(
+              '${widget.fileName} may be harmful. Download only if you trust the sender.',
+              textAlign: TextAlign.center,
+              style: TextStyle(color: Theme.of(context).hintColor),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _binaryBody(BuildContext context) {
+    return Center(
+      child: Padding(
+        padding: const EdgeInsets.all(24),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            const Icon(Icons.insert_drive_file, size: 48),
+            const SizedBox(height: 16),
+            Text(
+              'No preview available',
+              style: Theme.of(context).textTheme.titleLarge,
+            ),
+            const SizedBox(height: 8),
+            Text(
+              widget.fileName,
+              textAlign: TextAlign.center,
+              style: TextStyle(color: Theme.of(context).hintColor),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _textBody(TextPreviewData? data) {
+    final text = data?.fullText ?? '';
+    if (text.isEmpty) {
+      return const Center(child: Text('Empty file'));
+    }
+    return SingleChildScrollView(
+      padding: const EdgeInsets.all(16),
+      child: SelectableText(
+        text,
+        style: const TextStyle(fontFamily: 'monospace', fontSize: 14),
+      ),
+    );
+  }
+
+  Widget _spreadsheetBody(SpreadsheetPreviewData? data) {
+    final rows = data?.rows ?? [];
+    if (rows.isEmpty) {
+      return const Center(child: Text('Could not read spreadsheet'));
+    }
+    return SingleChildScrollView(
+      scrollDirection: Axis.horizontal,
+      child: SingleChildScrollView(
+        padding: const EdgeInsets.all(8),
+        child: DataTable(
+          columns: List.generate(
+            rows.first.length,
+            (i) => DataColumn(label: Text('Col ${i + 1}')),
+          ),
+          rows: rows
+              .map(
+                (row) => DataRow(
+                  cells: row
+                      .map((cell) => DataCell(Text(cell, maxLines: 3)))
+                      .toList(),
+                ),
+              )
+              .toList(),
+        ),
+      ),
+    );
+  }
+
+  Widget _pdfBody(BuildContext context) {
+    if (widget.pdfController != null) {
+      return PdfViewPinch(controller: widget.pdfController!);
+    }
+    return _pdfFallbackBody(context);
+  }
+
+  Widget _pdfFallbackBody(BuildContext context) {
+    final bytes = widget.bytes;
+    return Center(
+      child: Padding(
+        padding: const EdgeInsets.all(24),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            const Icon(Icons.picture_as_pdf, size: 48),
+            const SizedBox(height: 16),
+            Text(
+              'PDF document',
+              style: Theme.of(context).textTheme.titleLarge,
+            ),
+            const SizedBox(height: 8),
+            Text(
+              'In-app PDF preview is not available on this platform.',
+              textAlign: TextAlign.center,
+              style: TextStyle(color: Theme.of(context).hintColor),
+            ),
+            if (bytes != null && bytes.isNotEmpty) ...[
+              const SizedBox(height: 24),
+              FilledButton.icon(
+                onPressed: _openingPdf ? null : () => _openWithSystem(bytes),
+                icon: _openingPdf
+                    ? const SizedBox(
+                        width: 18,
+                        height: 18,
+                        child: CircularProgressIndicator(strokeWidth: 2),
+                      )
+                    : const Icon(Icons.open_in_new),
+                label: Text(_openingPdf ? 'Opening…' : 'Open with system viewer'),
+              ),
+            ],
+          ],
+        ),
+      ),
+    );
+  }
+
+  Future<void> _openWithSystem(Uint8List bytes) async {
+    setState(() => _openingPdf = true);
+    try {
+      final message = await PdfSystemOpen.open(bytes, widget.fileName);
+      if (!mounted) return;
+      if (message != null && message != 'done') {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(content: Text(message)),
+        );
+      }
+    } catch (e) {
+      if (!mounted) return;
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text('Could not open PDF: $e')),
+      );
+    } finally {
+      if (mounted) setState(() => _openingPdf = false);
+    }
+  }
+}
+
+class InlineFilePreview extends StatelessWidget {
+  final FilePreviewData preview;
+  final PdfControllerPinch? pdfController;
+
+  const InlineFilePreview({
+    required this.preview,
+    this.pdfController,
+    super.key,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final surface = Theme.of(context).colorScheme.surface.withValues(alpha: 0.35);
+    return Container(
+      width: double.infinity,
+      constraints: const BoxConstraints(maxHeight: 120),
+      padding: const EdgeInsets.all(8),
+      decoration: BoxDecoration(
+        color: surface,
+        borderRadius: BorderRadius.circular(6),
+      ),
+      child: switch (preview.category) {
+        FilePreviewCategory.text || FilePreviewCategory.document =>
+          _textSnippet(preview.text, context),
+        FilePreviewCategory.spreadsheet =>
+          _sheetSnippet(preview.spreadsheet, context),
+        FilePreviewCategory.pdf => _pdfSnippet(context),
+        _ => const SizedBox.shrink(),
+      },
+    );
+  }
+
+  Widget _textSnippet(TextPreviewData? data, BuildContext context) {
+    final lines = data?.lines ?? [];
+    if (lines.isEmpty) {
+      return Text('…', style: TextStyle(color: Theme.of(context).hintColor));
+    }
+    return Text(
+      lines.join('\n'),
+      maxLines: ReadableFilePolicy.textSnippetLines,
+      overflow: TextOverflow.ellipsis,
+      style: TextStyle(
+        fontFamily: 'monospace',
+        fontSize: 11,
+        color: Theme.of(context).colorScheme.onPrimary.withValues(alpha: 0.9),
+      ),
+    );
+  }
+
+  Widget _sheetSnippet(SpreadsheetPreviewData? data, BuildContext context) {
+    final rows = data?.rows ?? [];
+    if (rows.isEmpty) {
+      return Text('Spreadsheet', style: TextStyle(color: Theme.of(context).hintColor));
+    }
+    return Table(
+      defaultColumnWidth: const IntrinsicColumnWidth(),
+      children: rows
+          .map(
+            (row) => TableRow(
+              children: row
+                  .map(
+                    (cell) => Padding(
+                      padding: const EdgeInsets.only(right: 8, bottom: 2),
+                      child: Text(
+                        cell,
+                        maxLines: 1,
+                        overflow: TextOverflow.ellipsis,
+                        style: TextStyle(
+                          fontSize: 10,
+                          color: Theme.of(context)
+                              .colorScheme
+                              .onPrimary
+                              .withValues(alpha: 0.9),
+                        ),
+                      ),
+                    ),
+                  )
+                  .toList(),
+            ),
+          )
+          .toList(),
+    );
+  }
+
+  Widget _pdfSnippet(BuildContext context) {
+    if (pdfController != null) {
+      return ClipRRect(
+        borderRadius: BorderRadius.circular(4),
+        child: PdfViewPinch(
+          controller: pdfController!,
+          scrollDirection: Axis.vertical,
+        ),
+      );
+    }
+    return Row(
+      children: [
+        Icon(
+          Icons.picture_as_pdf,
+          size: 28,
+          color: Theme.of(context).colorScheme.onPrimary.withValues(alpha: 0.9),
+        ),
+        const SizedBox(width: 8),
+        Expanded(
+          child: Text(
+            'PDF document',
+            style: TextStyle(
+              fontSize: 12,
+              color: Theme.of(context).colorScheme.onPrimary.withValues(alpha: 0.9),
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+}

--- a/lib/services/file_attachment_resolver.dart
+++ b/lib/services/file_attachment_resolver.dart
@@ -1,0 +1,111 @@
+import 'dart:convert';
+
+import 'package:encrypt/encrypt.dart' as e;
+import 'package:flutter/foundation.dart';
+import 'package:flutter_chat_core/flutter_chat_core.dart';
+import 'package:prysm/util/file_encrypt.dart';
+import 'package:prysm/util/key_manager.dart';
+class FileAttachmentResolver {
+  FileAttachmentResolver._();
+
+  static const _maxCacheEntries = 20;
+  static final _cache = <String, Uint8List>{};
+  static final _cacheOrder = <String>[];
+
+  static Future<Uint8List> resolve(
+    FileMessage message, {
+    KeyManager? keyManager,
+  }) async {
+    final cached = _cache[message.id];
+    if (cached != null) return cached;
+
+    final bytes = await _resolveUncached(message, keyManager: keyManager);
+    _putCache(message.id, bytes);
+    return bytes;
+  }
+
+  static Future<Uint8List> _resolveUncached(
+    FileMessage message, {
+    KeyManager? keyManager,
+  }) async {
+    final source = message.source;
+    if (source.isEmpty) {
+      return Uint8List(0);
+    }
+
+    if (source.startsWith('audio:')) {
+      return Uint8List(0);
+    }
+
+    // Optimistic sender / group plaintext base64.
+    if (_looksLikeBase64Payload(source)) {
+      try {
+        return base64Decode(source);
+      } catch (_) {
+        // Fall through to decrypt path.
+      }
+    }
+
+    if (keyManager == null) {
+      try {
+        return base64Decode(source);
+      } catch (_) {
+        return Uint8List(0);
+      }
+    }
+
+    return decryptEncryptedSource(source, keyManager);
+  }
+
+  static bool _looksLikeBase64Payload(String source) {
+    if (source.startsWith('{')) return false;
+    if (source.startsWith('data:')) {
+      final comma = source.indexOf(',');
+      if (comma < 0) return false;
+      return _isMostlyBase64(source.substring(comma + 1));
+    }
+    return _isMostlyBase64(source);
+  }
+
+  static bool _isMostlyBase64(String value) {
+    if (value.length < 16) return false;
+    final sample = value.length > 256 ? value.substring(0, 256) : value;
+    return RegExp(r'^[A-Za-z0-9+/=\s]+$').hasMatch(sample);
+  }
+
+  static Future<Uint8List> decryptEncryptedSource(
+    String encryptedJson,
+    KeyManager keyManager,
+  ) async {
+    final hybrid = jsonDecode(encryptedJson) as Map<String, dynamic>;
+    final aesKeyBytes = keyManager.decryptMyMessageBytes(hybrid['aes_key'] as String);
+    return compute(_aesDecryptFilePayload, {
+      'aesKey': aesKeyBytes,
+      'iv': hybrid['iv'],
+      'data': hybrid['data'],
+    });
+  }
+
+  static void _putCache(String messageId, Uint8List bytes) {
+    if (_cache.containsKey(messageId)) {
+      _cacheOrder.remove(messageId);
+    } else if (_cache.length >= _maxCacheEntries && _cacheOrder.isNotEmpty) {
+      final evict = _cacheOrder.removeAt(0);
+      _cache.remove(evict);
+    }
+    _cache[messageId] = bytes;
+    _cacheOrder.add(messageId);
+  }
+
+  static void invalidate(String messageId) {
+    _cache.remove(messageId);
+    _cacheOrder.remove(messageId);
+  }
+}
+
+Uint8List _aesDecryptFilePayload(Map<String, dynamic> args) {
+  final aesKey = e.Key(Uint8List.fromList(List<int>.from(args['aesKey'] as List)));
+  final iv = e.IV.fromBase64(args['iv'] as String);
+  final encryptedData = base64Decode(args['data'] as String);
+  return AESHelper.decryptBytes(encryptedData, aesKey, iv);
+}

--- a/lib/services/file_preview_service.dart
+++ b/lib/services/file_preview_service.dart
@@ -1,0 +1,184 @@
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:docx_to_text/docx_to_text.dart';
+import 'package:excel/excel.dart';
+import 'package:pdfx/pdfx.dart';
+import 'package:prysm/util/readable_file_policy.dart';
+
+class TextPreviewData {
+  final List<String> lines;
+  final String fullText;
+
+  const TextPreviewData({required this.lines, required this.fullText});
+}
+
+class SpreadsheetPreviewData {
+  final List<List<String>> rows;
+
+  const SpreadsheetPreviewData({required this.rows});
+}
+
+class PdfPreviewData {
+  final Uint8List documentBytes;
+
+  const PdfPreviewData({required this.documentBytes});
+}
+
+class FilePreviewData {
+  final FilePreviewCategory category;
+  final TextPreviewData? text;
+  final SpreadsheetPreviewData? spreadsheet;
+  final PdfPreviewData? pdf;
+
+  const FilePreviewData._({
+    required this.category,
+    this.text,
+    this.spreadsheet,
+    this.pdf,
+  });
+
+  factory FilePreviewData.blocked() => const FilePreviewData._(
+        category: FilePreviewCategory.blocked,
+      );
+
+  factory FilePreviewData.binary() => const FilePreviewData._(
+        category: FilePreviewCategory.binary,
+      );
+
+  factory FilePreviewData.text(TextPreviewData data) => FilePreviewData._(
+        category: FilePreviewCategory.text,
+        text: data,
+      );
+
+  factory FilePreviewData.spreadsheet(SpreadsheetPreviewData data) =>
+      FilePreviewData._(
+        category: FilePreviewCategory.spreadsheet,
+        spreadsheet: data,
+      );
+
+  factory FilePreviewData.pdf(PdfPreviewData data) => FilePreviewData._(
+        category: FilePreviewCategory.pdf,
+        pdf: data,
+      );
+}
+
+class FilePreviewService {
+  FilePreviewService._();
+
+  static Future<FilePreviewData> buildPreview({
+    required String fileName,
+    required Uint8List bytes,
+    required bool inline,
+  }) async {
+    final category = ReadableFilePolicy.categorize(fileName);
+    if (category == FilePreviewCategory.blocked) {
+      return FilePreviewData.blocked();
+    }
+    if (!ReadableFilePolicy.supportsInlinePreview(category) && inline) {
+      return FilePreviewData.binary();
+    }
+    if (bytes.isEmpty) {
+      return FilePreviewData.binary();
+    }
+
+    final capped = bytes.length > ReadableFilePolicy.maxPreviewBytes
+        ? Uint8List.fromList(bytes.sublist(0, ReadableFilePolicy.maxPreviewBytes))
+        : bytes;
+
+    return switch (category) {
+      FilePreviewCategory.text => FilePreviewData.text(
+          _buildTextPreview(capped, inline: inline),
+        ),
+      FilePreviewCategory.document => FilePreviewData.text(
+          _buildDocxPreview(capped, inline: inline),
+        ),
+      FilePreviewCategory.spreadsheet => FilePreviewData.spreadsheet(
+          _buildSpreadsheetPreview(capped, inline: inline),
+        ),
+      FilePreviewCategory.pdf => FilePreviewData.pdf(
+          PdfPreviewData(documentBytes: capped),
+        ),
+      _ => FilePreviewData.binary(),
+    };
+  }
+
+  static TextPreviewData _buildTextPreview(
+    Uint8List bytes, {
+    required bool inline,
+  }) {
+    final sample = bytes.length > ReadableFilePolicy.textSnippetBytes
+        ? bytes.sublist(0, ReadableFilePolicy.textSnippetBytes)
+        : bytes;
+    final fullText = utf8.decode(sample, allowMalformed: true);
+    final allLines = const LineSplitter().convert(fullText);
+    final maxLines = inline
+        ? ReadableFilePolicy.textSnippetLines
+        : allLines.length;
+    final lines = allLines.take(maxLines).toList();
+    return TextPreviewData(lines: lines, fullText: fullText);
+  }
+
+  static TextPreviewData _buildDocxPreview(
+    Uint8List bytes, {
+    required bool inline,
+  }) {
+    try {
+      final fullText = docxToText(bytes);
+      final allLines = const LineSplitter().convert(fullText);
+      final maxLines = inline
+          ? ReadableFilePolicy.textSnippetLines
+          : allLines.length;
+      final lines = allLines.take(maxLines).toList();
+      return TextPreviewData(lines: lines, fullText: fullText);
+    } catch (_) {
+      return const TextPreviewData(lines: ['Could not read document'], fullText: '');
+    }
+  }
+
+  static SpreadsheetPreviewData _buildSpreadsheetPreview(
+    Uint8List bytes, {
+    required bool inline,
+  }) {
+    try {
+      final book = Excel.decodeBytes(bytes);
+      if (book.tables.isEmpty) {
+        return const SpreadsheetPreviewData(rows: []);
+      }
+      final sheet = book.tables.values.first;
+      final maxRows = inline
+          ? ReadableFilePolicy.spreadsheetBubbleRows
+          : ReadableFilePolicy.spreadsheetFullMaxRows;
+      final maxCols = inline
+          ? ReadableFilePolicy.spreadsheetBubbleCols
+          : sheet.maxColumns;
+
+      final rows = <List<String>>[];
+      for (var r = 0; r < maxRows && r < sheet.maxRows; r++) {
+        final row = <String>[];
+        for (var c = 0; c < maxCols; c++) {
+          final cell = sheet.cell(
+            CellIndex.indexByColumnRow(columnIndex: c, rowIndex: r),
+          );
+          row.add(cell.value?.toString() ?? '');
+        }
+        rows.add(row);
+      }
+      return SpreadsheetPreviewData(rows: rows);
+    } catch (_) {
+      return const SpreadsheetPreviewData(rows: []);
+    }
+  }
+
+  static Future<bool> isPdfRenderingSupported() => hasPdfSupport();
+
+  static Future<PdfControllerPinch?> openPdfController(Uint8List bytes) async {
+    if (!await hasPdfSupport()) return null;
+    try {
+      final doc = await PdfDocument.openData(bytes);
+      return PdfControllerPinch(document: Future.value(doc));
+    } catch (_) {
+      return null;
+    }
+  }
+}

--- a/lib/util/file_download_helper.dart
+++ b/lib/util/file_download_helper.dart
@@ -1,0 +1,66 @@
+import 'dart:io';
+import 'dart:typed_data';
+
+import 'package:flutter/material.dart';
+import 'package:prysm/util/download_location.dart';
+import 'package:prysm/util/readable_file_policy.dart';
+
+class FileDownloadHelper {
+  FileDownloadHelper._();
+
+  static Future<void> download(
+    BuildContext context, {
+    required String fileName,
+    required Uint8List bytes,
+    required FilePreviewCategory category,
+  }) async {
+    if (bytes.isEmpty) {
+      if (!context.mounted) return;
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('File not ready to download')),
+      );
+      return;
+    }
+
+    if (ReadableFilePolicy.requiresDownloadWarning(category)) {
+      final confirmed = await showDialog<bool>(
+        context: context,
+        builder: (ctx) => AlertDialog(
+          title: const Text('Download risky file?'),
+          content: Text(
+            '$fileName may be harmful to your device. '
+            'Only download if you trust the sender.',
+          ),
+          actions: [
+            TextButton(
+              onPressed: () => Navigator.pop(ctx, false),
+              child: const Text('Cancel'),
+            ),
+            FilledButton(
+              onPressed: () => Navigator.pop(ctx, true),
+              child: const Text('Download anyway'),
+            ),
+          ],
+        ),
+      );
+      if (confirmed != true || !context.mounted) return;
+    }
+
+    try {
+      final file = await DownloadLocation.saveBytes(bytes, fileName);
+      if (!context.mounted) return;
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(
+          content: Text(
+            'Saved ${file.path.split(Platform.pathSeparator).last}',
+          ),
+        ),
+      );
+    } catch (e) {
+      if (!context.mounted) return;
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text('Download failed: $e')),
+      );
+    }
+  }
+}

--- a/lib/util/pdf_system_open.dart
+++ b/lib/util/pdf_system_open.dart
@@ -1,0 +1,19 @@
+import 'dart:io';
+import 'dart:typed_data';
+
+import 'package:open_file/open_file.dart';
+import 'package:path/path.dart' as p;
+import 'package:path_provider/path_provider.dart';
+
+class PdfSystemOpen {
+  PdfSystemOpen._();
+
+  static Future<String?> open(Uint8List bytes, String fileName) async {
+    final dir = await getTemporaryDirectory();
+    final safeName = p.basename(fileName);
+    final file = File(p.join(dir.path, safeName));
+    await file.writeAsBytes(bytes, flush: true);
+    final result = await OpenFile.open(file.path);
+    return result.message;
+  }
+}

--- a/lib/util/readable_file_policy.dart
+++ b/lib/util/readable_file_policy.dart
@@ -1,0 +1,107 @@
+import 'package:mime/mime.dart';
+import 'package:path/path.dart' as p;
+
+enum FilePreviewCategory {
+  text,
+  pdf,
+  spreadsheet,
+  document,
+  blocked,
+  binary,
+}
+
+class ReadableFilePolicy {
+  ReadableFilePolicy._();
+
+  /// Files larger than this skip in-app preview to limit memory use.
+  static const maxPreviewBytes = 10 * 1024 * 1024;
+  static const textSnippetBytes = 4 * 1024;
+  static const textSnippetLines = 8;
+  static const spreadsheetBubbleRows = 4;
+  static const spreadsheetBubbleCols = 5;
+  static const spreadsheetFullMaxRows = 50;
+
+  static const _blockedExtensions = {
+    'exe', 'dll', 'so', 'dylib', 'bat', 'cmd', 'ps1', 'sh', 'bash',
+    'msi', 'dmg', 'apk', 'jar', 'deb', 'rpm', 'appimage', 'scr', 'vbs',
+    'com', 'reg', 'lnk',
+  };
+
+  static FilePreviewCategory categorize(String fileName) {
+    final ext = p.extension(fileName).toLowerCase().replaceFirst('.', '');
+    if (ext.isNotEmpty && _blockedExtensions.contains(ext)) {
+      return FilePreviewCategory.blocked;
+    }
+
+    switch (ext) {
+      case 'pdf':
+        return FilePreviewCategory.pdf;
+      case 'xlsx':
+        return FilePreviewCategory.spreadsheet;
+      case 'docx':
+        return FilePreviewCategory.document;
+      case 'txt':
+      case 'md':
+      case 'csv':
+      case 'json':
+      case 'xml':
+      case 'log':
+      case 'yaml':
+      case 'yml':
+      case 'html':
+      case 'htm':
+        return FilePreviewCategory.text;
+      case 'xls':
+        return FilePreviewCategory.binary;
+      default:
+        break;
+    }
+
+    final mime = lookupMimeType(fileName)?.toLowerCase();
+    if (mime != null) {
+      if (mime == 'application/pdf') return FilePreviewCategory.pdf;
+      if (mime ==
+              'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet' ||
+          mime == 'application/vnd.ms-excel') {
+        return ext == 'xls'
+            ? FilePreviewCategory.binary
+            : FilePreviewCategory.spreadsheet;
+      }
+      if (mime ==
+          'application/vnd.openxmlformats-officedocument.wordprocessingml.document') {
+        return FilePreviewCategory.document;
+      }
+      if (mime.startsWith('text/') ||
+          mime == 'application/json' ||
+          mime == 'application/xml') {
+        return FilePreviewCategory.text;
+      }
+      if (mime == 'application/x-msdownload' ||
+          mime == 'application/x-executable' ||
+          mime == 'application/vnd.microsoft.portable-executable') {
+        return FilePreviewCategory.blocked;
+      }
+    }
+
+    return FilePreviewCategory.binary;
+  }
+
+  static bool supportsInlinePreview(FilePreviewCategory category) {
+    return switch (category) {
+      FilePreviewCategory.text ||
+      FilePreviewCategory.pdf ||
+      FilePreviewCategory.spreadsheet ||
+      FilePreviewCategory.document =>
+        true,
+      _ => false,
+    };
+  }
+
+  static bool requiresDownloadWarning(FilePreviewCategory category) {
+    return category == FilePreviewCategory.blocked;
+  }
+
+  static bool exceedsPreviewLimit(int byteLength) {
+    return byteLength > maxPreviewBytes;
+  }
+}

--- a/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -14,6 +14,7 @@ import flutter_local_notifications
 import flutter_secure_storage_macos
 import open_file_mac
 import path_provider_foundation
+import pdfx
 import record_macos
 import screen_retriever_macos
 import shared_preferences_foundation
@@ -33,6 +34,7 @@ func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
   FlutterSecureStoragePlugin.register(with: registry.registrar(forPlugin: "FlutterSecureStoragePlugin"))
   OpenFilePlugin.register(with: registry.registrar(forPlugin: "OpenFilePlugin"))
   PathProviderPlugin.register(with: registry.registrar(forPlugin: "PathProviderPlugin"))
+  PdfxPlugin.register(with: registry.registrar(forPlugin: "PdfxPlugin"))
   RecordMacOsPlugin.register(with: registry.registrar(forPlugin: "RecordMacOsPlugin"))
   ScreenRetrieverMacosPlugin.register(with: registry.registrar(forPlugin: "ScreenRetrieverMacosPlugin"))
   SharedPreferencesPlugin.register(with: registry.registrar(forPlugin: "SharedPreferencesPlugin"))

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -5,10 +5,10 @@ packages:
     dependency: transitive
     description:
       name: archive
-      sha256: "2fde1607386ab523f7a36bb3e7edb43bd58e6edaf2ffb29d8a6d578b297fdbbd"
+      sha256: cb6a278ef2dbb298455e1a713bda08524a175630ec643a242c399c932a0a1f7d
       url: "https://pub.dev"
     source: hosted
-    version: "4.0.7"
+    version: "3.6.1"
   args:
     dependency: transitive
     description:
@@ -241,6 +241,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.1.1"
+  docx_to_text:
+    dependency: "direct main"
+    description:
+      name: docx_to_text
+      sha256: d94e199bf9f36321cbd7701f82ce4874d7b94fd362a007fd4923ba9d57794664
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.1"
   emoji_picker_flutter:
     dependency: "direct main"
     description:
@@ -257,6 +265,30 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "5.0.3"
+  equatable:
+    dependency: transitive
+    description:
+      name: equatable
+      sha256: "3e0141505477fd8ad55d6eb4e7776d3fe8430be8e497ccb1521370c3f21a3e2b"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.8"
+  excel:
+    dependency: "direct main"
+    description:
+      name: excel
+      sha256: "1a15327dcad260d5db21d1f6e04f04838109b39a2f6a84ea486ceda36e468780"
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.0.6"
+  extension:
+    dependency: transitive
+    description:
+      name: extension
+      sha256: be3a6b7f8adad2f6e2e8c63c895d19811fcf203e23466c6296267941d0ff4f24
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.6.0"
   fake_async:
     dependency: transitive
     description:
@@ -564,10 +596,10 @@ packages:
     dependency: transitive
     description:
       name: image
-      sha256: "4e973fcf4caae1a4be2fa0a13157aa38a8f9cb049db6529aa00b4d71abc4d928"
+      sha256: f31d52537dc417fdcde36088fdf11d191026fd5e4fae742491ebd40e5a8bea7d
       url: "https://pub.dev"
     source: hosted
-    version: "4.5.4"
+    version: "4.3.0"
   image_picker:
     dependency: "direct main"
     description:
@@ -872,6 +904,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.3.0"
+  pdfx:
+    dependency: "direct main"
+    description:
+      name: pdfx
+      sha256: "29db9b71d46bf2335e001f91693f2c3fbbf0760e4c2eb596bf4bafab211471c1"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.9.2"
   permission_handler:
     dependency: "direct main"
     description:
@@ -928,6 +968,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "7.0.1"
+  photo_view:
+    dependency: transitive
+    description:
+      name: photo_view
+      sha256: "1fc3d970a91295fbd1364296575f854c9863f225505c28c46e0a03e48960c75e"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.15.0"
   platform:
     dependency: transitive
     description:
@@ -952,14 +1000,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.9.1"
-  posix:
-    dependency: transitive
-    description:
-      name: posix
-      sha256: "6323a5b0fa688b6a010df4905a56b00181479e6d10534cecfecede2aa55add61"
-      url: "https://pub.dev"
-    source: hosted
-    version: "6.0.3"
   provider:
     dependency: transitive
     description:
@@ -1341,6 +1381,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.2.2"
+  universal_platform:
+    dependency: transitive
+    description:
+      name: universal_platform
+      sha256: "64e16458a0ea9b99260ceb5467a214c1f298d647c659af1bff6d3bf82536b1ec"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.1.0"
   url_launcher:
     dependency: "direct main"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -70,6 +70,9 @@ dependencies:
   audioplayers: ^6.6.0
   permission_handler: ^12.0.1
   tray_manager: ^0.5.2
+  pdfx: ^2.9.2
+  excel: ^4.0.6
+  docx_to_text: ^1.0.1
 
 flutter_launcher_icons:
   windows:

--- a/test/file_preview_service_test.dart
+++ b/test/file_preview_service_test.dart
@@ -1,0 +1,30 @@
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:prysm/services/file_preview_service.dart';
+import 'package:prysm/util/readable_file_policy.dart';
+
+void main() {
+  test('text preview truncates to snippet lines', () async {
+    final bytes = utf8.encode('line1\nline2\nline3\nline4\nline5\nline6\nline7\nline8\nline9');
+    final preview = await FilePreviewService.buildPreview(
+      fileName: 'sample.txt',
+      bytes: Uint8List.fromList(bytes),
+      inline: true,
+    );
+
+    expect(preview.category, FilePreviewCategory.text);
+    expect(preview.text!.lines.length, ReadableFilePolicy.textSnippetLines);
+    expect(preview.text!.lines.first, 'line1');
+  });
+
+  test('blocked files return blocked preview data', () async {
+    final preview = await FilePreviewService.buildPreview(
+      fileName: 'malware.exe',
+      bytes: Uint8List.fromList([1, 2, 3]),
+      inline: true,
+    );
+    expect(preview.category, FilePreviewCategory.blocked);
+  });
+}

--- a/test/readable_file_policy_test.dart
+++ b/test/readable_file_policy_test.dart
@@ -1,0 +1,49 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:prysm/util/readable_file_policy.dart';
+
+void main() {
+  test('categorizes text and pdf extensions', () {
+    expect(ReadableFilePolicy.categorize('notes.txt'), FilePreviewCategory.text);
+    expect(ReadableFilePolicy.categorize('doc.pdf'), FilePreviewCategory.pdf);
+    expect(ReadableFilePolicy.categorize('sheet.xlsx'),
+        FilePreviewCategory.spreadsheet);
+    expect(ReadableFilePolicy.categorize('report.docx'),
+        FilePreviewCategory.document);
+  });
+
+  test('blocks executable extensions', () {
+    expect(ReadableFilePolicy.categorize('setup.exe'),
+        FilePreviewCategory.blocked);
+    expect(ReadableFilePolicy.categorize('run.sh'), FilePreviewCategory.blocked);
+    expect(
+      ReadableFilePolicy.requiresDownloadWarning(
+        ReadableFilePolicy.categorize('virus.exe'),
+      ),
+      isTrue,
+    );
+  });
+
+  test('legacy xls is binary not spreadsheet preview', () {
+    expect(ReadableFilePolicy.categorize('old.xls'), FilePreviewCategory.binary);
+    expect(
+      ReadableFilePolicy.supportsInlinePreview(FilePreviewCategory.binary),
+      isFalse,
+    );
+  });
+
+  test('unknown extension is binary', () {
+    expect(ReadableFilePolicy.categorize('archive.zip'),
+        FilePreviewCategory.binary);
+  });
+
+  test('exceedsPreviewLimit above 10 MB', () {
+    expect(
+      ReadableFilePolicy.exceedsPreviewLimit(10 * 1024 * 1024),
+      isFalse,
+    );
+    expect(
+      ReadableFilePolicy.exceedsPreviewLimit(10 * 1024 * 1024 + 1),
+      isTrue,
+    );
+  });
+}

--- a/windows/flutter/generated_plugin_registrant.cc
+++ b/windows/flutter/generated_plugin_registrant.cc
@@ -10,6 +10,7 @@
 #include <emoji_picker_flutter/emoji_picker_flutter_plugin_c_api.h>
 #include <file_selector_windows/file_selector_windows.h>
 #include <flutter_secure_storage_windows/flutter_secure_storage_windows_plugin.h>
+#include <pdfx/pdfx_plugin.h>
 #include <permission_handler_windows/permission_handler_windows_plugin.h>
 #include <record_windows/record_windows_plugin_c_api.h>
 #include <screen_retriever_windows/screen_retriever_windows_plugin_c_api.h>
@@ -27,6 +28,8 @@ void RegisterPlugins(flutter::PluginRegistry* registry) {
       registry->GetRegistrarForPlugin("FileSelectorWindows"));
   FlutterSecureStorageWindowsPluginRegisterWithRegistrar(
       registry->GetRegistrarForPlugin("FlutterSecureStorageWindowsPlugin"));
+  PdfxPluginRegisterWithRegistrar(
+      registry->GetRegistrarForPlugin("PdfxPlugin"));
   PermissionHandlerWindowsPluginRegisterWithRegistrar(
       registry->GetRegistrarForPlugin("PermissionHandlerWindowsPlugin"));
   RecordWindowsPluginCApiRegisterWithRegistrar(

--- a/windows/flutter/generated_plugins.cmake
+++ b/windows/flutter/generated_plugins.cmake
@@ -7,6 +7,7 @@ list(APPEND FLUTTER_PLUGIN_LIST
   emoji_picker_flutter
   file_selector_windows
   flutter_secure_storage_windows
+  pdfx
   permission_handler_windows
   record_windows
   screen_retriever_windows


### PR DESCRIPTION
- Added inline previews for text, PDF, .xlsx, and .docx file attachments in chat.
- Introduced a full viewer for file previews with a download option.
- Implemented a warning system for risky file types before downloading.
- Refactored chat and group chat screens to utilize the new file attachment bubble for displaying file messages.
- Created a file preview service to handle file preview generation and management.
- Updated dependencies in pubspec.yaml for new file handling capabilities.