### PR TITLE
feat: implement notification mute functionality

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -12,6 +12,7 @@ import 'package:prysm/database/messages.dart';
 import 'package:prysm/screens/pin_entry.dart';
 import 'package:prysm/screens/settings_screen.dart';
 import 'package:prysm/server/PrysmServer.dart';
+import 'package:prysm/services/notification_mute_service.dart';
 import 'package:prysm/services/settings_service.dart';
 import 'package:prysm/services/tray_service.dart';
 import 'package:prysm/util/key_manager.dart';
@@ -109,6 +110,7 @@ void main() async {
   }
 
   await SettingsService().init();
+  await NotificationMuteService.instance.init();
 
   final keyManager = KeyManager();
 

--- a/lib/screens/chat_profile_screen.dart
+++ b/lib/screens/chat_profile_screen.dart
@@ -2,9 +2,11 @@ import 'dart:convert';
 import 'package:bs58/bs58.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
+import 'package:prysm/services/notification_mute_service.dart';
 import '../models/contact.dart';
 import '../util/db_helper.dart';
 import 'widgets/contact_avatar.dart';
+import 'widgets/notification_mute_tile.dart';
 
 class ChatProfileScreen extends StatefulWidget {
   final Contact peer;
@@ -273,7 +275,25 @@ class _ChatProfileScreenState extends State<ChatProfileScreen> {
                 ),
               ),
               const SizedBox(height: 20),
-              // Action buttons
+              Container(
+                decoration: BoxDecoration(
+                  color: Theme.of(context).cardColor,
+                  borderRadius: BorderRadius.circular(20),
+                  boxShadow: [
+                    BoxShadow(
+                      color: Colors.black.withValues(alpha: 0.05),
+                      blurRadius: 10,
+                      offset: const Offset(0, 4),
+                    ),
+                  ],
+                ),
+                child: NotificationMuteTile(
+                  target: MuteTarget.user,
+                  id: widget.peer.id,
+                  label: widget.peer.displayName,
+                ),
+              ),
+              const SizedBox(height: 20),
               Container(
                 decoration: BoxDecoration(
                   color: Theme.of(context).cardColor,

--- a/lib/screens/group_settings_screen.dart
+++ b/lib/screens/group_settings_screen.dart
@@ -10,6 +10,8 @@ import 'package:prysm/models/group.dart';
 import 'package:prysm/services/group_service.dart';
 import 'package:prysm/screens/widgets/contact_avatar.dart';
 import 'package:prysm/util/db_helper.dart';
+import 'package:prysm/screens/widgets/notification_mute_tile.dart';
+import 'package:prysm/services/notification_mute_service.dart';
 import 'package:prysm/util/key_manager.dart';
 
 class GroupSettingsScreen extends StatefulWidget {
@@ -384,6 +386,12 @@ class _GroupSettingsScreenState extends State<GroupSettingsScreen> {
                         : null,
                   );
                 }),
+                const Divider(),
+                NotificationMuteTile(
+                  target: MuteTarget.group,
+                  id: widget.group.id,
+                  label: _groupName,
+                ),
                 const Divider(),
                 if (_isAdmin && _members.length < maxGroupMembers)
                   ListTile(

--- a/lib/screens/widgets/notification_mute_sheet.dart
+++ b/lib/screens/widgets/notification_mute_sheet.dart
@@ -1,0 +1,118 @@
+import 'package:flutter/material.dart';
+import 'package:prysm/services/notification_mute_service.dart';
+
+String _formatClock(DateTime dt) {
+  final hour = dt.hour % 12 == 0 ? 12 : dt.hour % 12;
+  final minute = dt.minute.toString().padLeft(2, '0');
+  final period = dt.hour >= 12 ? 'PM' : 'AM';
+  return '$hour:$minute $period';
+}
+
+String _formatDate(DateTime dt) {
+  const months = [
+    'Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun',
+    'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec',
+  ];
+  return '${months[dt.month - 1]} ${dt.day}';
+}
+
+String formatMuteSubtitle(MuteInfo? info) {
+  if (info == null) {
+    return 'Silence message alerts';
+  }
+  if (info.isForever) {
+    return 'Muted until you turn notifications back on';
+  }
+  final expiresAt = info.expiresAt!;
+  final time = _formatClock(expiresAt);
+  final today = DateTime.now();
+  final isToday = expiresAt.year == today.year &&
+      expiresAt.month == today.month &&
+      expiresAt.day == today.day;
+  if (isToday) {
+    return 'Muted until $time';
+  }
+  return 'Muted until ${_formatDate(expiresAt)}, $time';
+}
+
+Future<void> showNotificationMuteSheet({
+  required BuildContext context,
+  required MuteTarget target,
+  required String id,
+  required String label,
+  VoidCallback? onChanged,
+}) async {
+  final service = NotificationMuteService.instance;
+  final info = service.muteInfo(target, id);
+  final isMuted = info != null;
+
+  await showModalBottomSheet<void>(
+    context: context,
+    builder: (ctx) => SafeArea(
+      child: Padding(
+        padding: const EdgeInsets.symmetric(vertical: 8),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Padding(
+              padding: const EdgeInsets.fromLTRB(20, 12, 20, 4),
+              child: Text(
+                isMuted ? 'Notifications muted' : 'Mute notifications',
+                style: Theme.of(ctx).textTheme.titleMedium,
+              ),
+            ),
+            if (isMuted)
+              Padding(
+                padding: const EdgeInsets.fromLTRB(20, 0, 20, 8),
+                child: Text(
+                  formatMuteSubtitle(info),
+                  style: Theme.of(ctx).textTheme.bodySmall,
+                ),
+              ),
+            if (isMuted)
+              ListTile(
+                leading: const Icon(Icons.notifications_active_outlined),
+                title: const Text('Turn notifications back on'),
+                onTap: () async {
+                  await service.unmute(target, id);
+                  if (ctx.mounted) Navigator.pop(ctx);
+                  onChanged?.call();
+                  if (context.mounted) {
+                    ScaffoldMessenger.of(context).showSnackBar(
+                      SnackBar(content: Text('Notifications enabled for $label')),
+                    );
+                  }
+                },
+              ),
+            if (isMuted) const Divider(height: 1),
+            ...MuteDuration.values.map((duration) {
+              return ListTile(
+                leading: Icon(
+                  duration == MuteDuration.forever
+                      ? Icons.notifications_off_outlined
+                      : Icons.schedule_outlined,
+                ),
+                title: Text(duration.label),
+                onTap: () async {
+                  await service.mute(target, id, duration);
+                  if (ctx.mounted) Navigator.pop(ctx);
+                  onChanged?.call();
+                  if (context.mounted) {
+                    final mutedUntil = duration == MuteDuration.forever
+                        ? 'until you turn them back on'
+                        : 'for ${duration.label}';
+                    ScaffoldMessenger.of(context).showSnackBar(
+                      SnackBar(
+                        content: Text('Notifications muted $mutedUntil for $label'),
+                      ),
+                    );
+                  }
+                },
+              );
+            }),
+          ],
+        ),
+      ),
+    ),
+  );
+}

--- a/lib/screens/widgets/notification_mute_tile.dart
+++ b/lib/screens/widgets/notification_mute_tile.dart
@@ -1,0 +1,45 @@
+import 'package:flutter/material.dart';
+import 'package:prysm/screens/widgets/notification_mute_sheet.dart';
+import 'package:prysm/services/notification_mute_service.dart';
+
+class NotificationMuteTile extends StatefulWidget {
+  final MuteTarget target;
+  final String id;
+  final String label;
+
+  const NotificationMuteTile({
+    required this.target,
+    required this.id,
+    required this.label,
+    super.key,
+  });
+
+  @override
+  State<NotificationMuteTile> createState() => _NotificationMuteTileState();
+}
+
+class _NotificationMuteTileState extends State<NotificationMuteTile> {
+  void _refresh() => setState(() {});
+
+  @override
+  Widget build(BuildContext context) {
+    final info = NotificationMuteService.instance.muteInfo(widget.target, widget.id);
+    final isMuted = info != null;
+
+    return ListTile(
+      leading: Icon(
+        isMuted ? Icons.notifications_off_outlined : Icons.notifications_outlined,
+      ),
+      title: Text(isMuted ? 'Notifications muted' : 'Mute notifications'),
+      subtitle: Text(formatMuteSubtitle(info)),
+      trailing: const Icon(Icons.chevron_right),
+      onTap: () => showNotificationMuteSheet(
+        context: context,
+        target: widget.target,
+        id: widget.id,
+        label: widget.label,
+        onChanged: _refresh,
+      ),
+    );
+  }
+}

--- a/lib/server/PrysmServer.dart
+++ b/lib/server/PrysmServer.dart
@@ -13,6 +13,7 @@ import '../database/messages.dart';
 import 'package:prysm/constants/group_constants.dart';
 import 'package:prysm/services/group_service.dart';
 import 'package:prysm/services/reaction_service.dart';
+import 'package:prysm/services/notification_mute_service.dart';
 import 'package:prysm/services/settings_service.dart';
 import 'package:prysm/util/conversation_refresh_notifier.dart';
 import 'package:prysm/util/peer_profile_cache.dart';
@@ -251,22 +252,29 @@ class PrysmServer {
         if (appState == AppLifecycleState.paused ||
             appState == AppLifecycleState.inactive ||
             appState == AppLifecycleState.detached) {
-          final contact = await DBHelper.getUserById(
-            data['senderId'] as String,
-          );
-          final senderName = contact?['name'] ?? 'Unknown contact';
-          final body = isGroupMessageType(type)
-              ? 'New group message from $senderName'
-              : 'Open to view the message';
-          NotificationService().showNewMessageNotification(
-            senderName: isGroupMessageType(type) ? 'Group chat' : senderName,
-            message: body,
-            notificationId: Random().nextInt(99999999),
-            payload: jsonEncode({
-              'senderId': senderId,
-              if (data['groupId'] != null) 'groupId': data['groupId'],
-            }),
-          );
+          final groupId = data['groupId'] as String?;
+          final muteService = NotificationMuteService.instance;
+          final muted = groupId != null
+              ? muteService.isMuted(MuteTarget.group, groupId)
+              : muteService.isMuted(MuteTarget.user, senderId);
+          if (!muted) {
+            final contact = await DBHelper.getUserById(
+              data['senderId'] as String,
+            );
+            final senderName = contact?['name'] ?? 'Unknown contact';
+            final body = isGroupMessageType(type)
+                ? 'New group message from $senderName'
+                : 'Open to view the message';
+            NotificationService().showNewMessageNotification(
+              senderName: isGroupMessageType(type) ? 'Group chat' : senderName,
+              message: body,
+              notificationId: Random().nextInt(99999999),
+              payload: jsonEncode({
+                'senderId': senderId,
+                if (groupId != null) 'groupId': groupId,
+              }),
+            );
+          }
         }
       }
 

--- a/lib/services/notification_mute_service.dart
+++ b/lib/services/notification_mute_service.dart
@@ -1,0 +1,150 @@
+import 'dart:async' show unawaited;
+import 'dart:convert';
+
+import 'package:shared_preferences/shared_preferences.dart';
+
+enum MuteTarget { user, group }
+
+enum MuteDuration {
+  oneHour,
+  twoHours,
+  fourHours,
+  eightHours,
+  forever,
+}
+
+extension MuteDurationX on MuteDuration {
+  Duration? get duration {
+    switch (this) {
+      case MuteDuration.oneHour:
+        return const Duration(hours: 1);
+      case MuteDuration.twoHours:
+        return const Duration(hours: 2);
+      case MuteDuration.fourHours:
+        return const Duration(hours: 4);
+      case MuteDuration.eightHours:
+        return const Duration(hours: 8);
+      case MuteDuration.forever:
+        return null;
+    }
+  }
+
+  String get label {
+    switch (this) {
+      case MuteDuration.oneHour:
+        return '1 hour';
+      case MuteDuration.twoHours:
+        return '2 hours';
+      case MuteDuration.fourHours:
+        return '4 hours';
+      case MuteDuration.eightHours:
+        return '8 hours';
+      case MuteDuration.forever:
+        return 'Until I turn it back on';
+    }
+  }
+}
+
+class MuteInfo {
+  final bool isForever;
+  final DateTime? expiresAt;
+
+  const MuteInfo({required this.isForever, this.expiresAt});
+}
+
+class NotificationMuteService {
+  NotificationMuteService._();
+  static final NotificationMuteService instance = NotificationMuteService._();
+
+  static const _storageKey = 'notification_mutes';
+  static const int _forever = -1;
+
+  SharedPreferences? _prefs;
+  final Map<String, int> _mutes = {};
+
+  Future<void> init() async {
+    _prefs = await SharedPreferences.getInstance();
+    await _load();
+    _pruneExpired();
+  }
+
+  Future<void> mute(MuteTarget target, String id, MuteDuration duration) async {
+    final key = _keyFor(target, id);
+    final expiry = duration == MuteDuration.forever
+        ? _forever
+        : DateTime.now().add(duration.duration!).millisecondsSinceEpoch;
+    _mutes[key] = expiry;
+    await _save();
+  }
+
+  Future<void> unmute(MuteTarget target, String id) async {
+    _mutes.remove(_keyFor(target, id));
+    await _save();
+  }
+
+  bool isMuted(MuteTarget target, String id) {
+    _pruneExpired();
+    final expiry = _mutes[_keyFor(target, id)];
+    if (expiry == null) return false;
+    if (expiry == _forever) return true;
+    return DateTime.now().millisecondsSinceEpoch < expiry;
+  }
+
+  MuteInfo? muteInfo(MuteTarget target, String id) {
+    _pruneExpired();
+    final expiry = _mutes[_keyFor(target, id)];
+    if (expiry == null) return null;
+    if (expiry == _forever) {
+      return const MuteInfo(isForever: true);
+    }
+    return MuteInfo(
+      isForever: false,
+      expiresAt: DateTime.fromMillisecondsSinceEpoch(expiry),
+    );
+  }
+
+  String _keyFor(MuteTarget target, String id) {
+    final prefix = target == MuteTarget.user ? 'u' : 'g';
+    return '$prefix:$id';
+  }
+
+  Future<void> _load() async {
+    _mutes.clear();
+    final raw = _prefs?.getString(_storageKey);
+    if (raw == null) return;
+    try {
+      final decoded = jsonDecode(raw) as Map<String, dynamic>;
+      for (final entry in decoded.entries) {
+        final value = entry.value;
+        if (value is int) {
+          _mutes[entry.key] = value;
+        }
+      }
+    } catch (e) {
+      print('Error loading notification mutes: $e');
+    }
+  }
+
+  Future<void> _save() async {
+    try {
+      await _prefs?.setString(_storageKey, jsonEncode(_mutes));
+    } catch (e) {
+      print('Error saving notification mutes: $e');
+    }
+  }
+
+  void _pruneExpired() {
+    final now = DateTime.now().millisecondsSinceEpoch;
+    final expiredKeys = <String>[];
+    for (final entry in _mutes.entries) {
+      if (entry.value != _forever && entry.value <= now) {
+        expiredKeys.add(entry.key);
+      }
+    }
+    if (expiredKeys.isEmpty) return;
+    for (final key in expiredKeys) {
+      _mutes.remove(key);
+    }
+    unawaited(_save());
+  }
+}

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -820,10 +820,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: "1741988757a65eb6b36abe716829688cf01910bbf91c34354ff7ec1c3de2b349"
+      sha256: "23f08335362185a5ea2ad3a4e597f1375e78bce8a040df5c600c8d3552ef2394"
       url: "https://pub.dev"
     source: hosted
-    version: "1.18.0"
+    version: "1.17.0"
   mime:
     dependency: "direct main"
     description:
@@ -1497,10 +1497,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "949a932224383300f01be9221c39180316445ecb8e7547f70a41a35bf421fb9e"
+      sha256: "8161c84903fd860b26bfdefb7963b3f0b68fee7adea0f59ef805ecca346f0c7a"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.11"
+    version: "0.7.10"
   timezone:
     dependency: transitive
     description:

--- a/test/notification_mute_service_test.dart
+++ b/test/notification_mute_service_test.dart
@@ -1,0 +1,43 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:prysm/services/notification_mute_service.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+void main() {
+  setUp(() async {
+    SharedPreferences.setMockInitialValues({});
+    await NotificationMuteService.instance.init();
+  });
+
+  test('user mute expires after duration', () async {
+    final service = NotificationMuteService.instance;
+    await service.mute(MuteTarget.user, 'alice.onion', MuteDuration.oneHour);
+    expect(service.isMuted(MuteTarget.user, 'alice.onion'), isTrue);
+
+    await service.unmute(MuteTarget.user, 'alice.onion');
+    expect(service.isMuted(MuteTarget.user, 'alice.onion'), isFalse);
+  });
+
+  test('group forever mute persists until removed', () async {
+    final service = NotificationMuteService.instance;
+    await service.mute(MuteTarget.group, 'group-1', MuteDuration.forever);
+
+    final info = service.muteInfo(MuteTarget.group, 'group-1');
+    expect(info, isNotNull);
+    expect(info!.isForever, isTrue);
+    expect(service.isMuted(MuteTarget.group, 'group-1'), isTrue);
+
+    await service.unmute(MuteTarget.group, 'group-1');
+    expect(service.muteInfo(MuteTarget.group, 'group-1'), isNull);
+  });
+
+  test('user and group mutes are independent', () async {
+    final service = NotificationMuteService.instance;
+    await service.mute(MuteTarget.user, 'bob.onion', MuteDuration.twoHours);
+    await service.mute(MuteTarget.group, 'group-2', MuteDuration.fourHours);
+
+    expect(service.isMuted(MuteTarget.user, 'bob.onion'), isTrue);
+    expect(service.isMuted(MuteTarget.group, 'group-2'), isTrue);
+    expect(service.isMuted(MuteTarget.user, 'group-2'), isFalse);
+    expect(service.isMuted(MuteTarget.group, 'bob.onion'), isFalse);
+  });
+}


### PR DESCRIPTION
- Added NotificationMuteService to manage user and group notification mutes.
- Introduced NotificationMuteTile and notification_mute_sheet for UI integration.
- Updated chat and group settings screens to include mute options.
- Ensured notifications respect mute settings in PrysmServer.
- Added tests for notification mute service functionality.