### PR TITLE
feat: add conversation preferences management

### DIFF
--- a/lib/database/conversation_preferences_db.dart
+++ b/lib/database/conversation_preferences_db.dart
@@ -1,0 +1,58 @@
+import 'package:prysm/models/conversation_preferences.dart';
+import 'package:prysm/util/db_helper.dart';
+import 'package:sqflite_common_ffi/sqflite_ffi.dart';
+
+class ConversationPreferencesDb {
+  ConversationPreferencesDb._();
+
+  static Future<void> createTable(Database db) async {
+    await db.execute('''
+      CREATE TABLE conversation_preferences (
+        conversationId TEXT PRIMARY KEY,
+        isPinned INTEGER NOT NULL DEFAULT 0,
+        pinnedAt INTEGER,
+        isArchived INTEGER NOT NULL DEFAULT 0,
+        archivedAt INTEGER
+      )
+    ''');
+  }
+
+  static Future<ConversationPreferences?> get(String conversationId) async {
+    final db = await DBHelper.database;
+    final rows = await db.query(
+      'conversation_preferences',
+      where: 'conversationId = ?',
+      whereArgs: [conversationId],
+      limit: 1,
+    );
+    if (rows.isEmpty) return null;
+    return ConversationPreferences.fromMap(rows.first);
+  }
+
+  static Future<Map<String, ConversationPreferences>> getAll() async {
+    final db = await DBHelper.database;
+    final rows = await db.query('conversation_preferences');
+    return {
+      for (final row in rows)
+        row['conversationId'] as String: ConversationPreferences.fromMap(row),
+    };
+  }
+
+  static Future<void> upsert(ConversationPreferences prefs) async {
+    final db = await DBHelper.database;
+    await db.insert(
+      'conversation_preferences',
+      prefs.toMap(),
+      conflictAlgorithm: ConflictAlgorithm.replace,
+    );
+  }
+
+  static Future<void> delete(String conversationId) async {
+    final db = await DBHelper.database;
+    await db.delete(
+      'conversation_preferences',
+      where: 'conversationId = ?',
+      whereArgs: [conversationId],
+    );
+  }
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -21,7 +21,10 @@ import 'package:prysm/screens/chat.dart';
 import 'package:prysm/screens/create_group_screen.dart';
 import 'package:prysm/screens/group_chat.dart';
 import 'package:prysm/models/conversation.dart';
+import 'package:prysm/models/conversation_preferences.dart';
 import 'package:prysm/models/group.dart';
+import 'package:prysm/services/conversation_preferences_service.dart';
+import 'package:prysm/screens/widgets/conversation_actions_sheet.dart';
 import 'package:prysm/services/group_service.dart';
 import 'package:prysm/util/db_helper.dart';
 import 'package:prysm/client/TorHttpClient.dart';
@@ -511,6 +514,8 @@ class _HomeScreenState extends State<HomeScreen> with WidgetsBindingObserver {
   String _searchQuery = '';
   Map<String, String> _lastMessagePreviews = {};
   Map<String, int> _unreadCounts = {};
+  Map<String, ConversationPreferences> _conversationPrefs = {};
+  bool _viewingArchived = false;
 
   Timer? _refreshTimer;
   Timer? _loadUsersDebounce;
@@ -521,11 +526,66 @@ class _HomeScreenState extends State<HomeScreen> with WidgetsBindingObserver {
   bool _loadUsersQueued = false;
   bool _loadUsersQueuedLight = false;
 
+  int get _archivedCount =>
+      conversations.where((c) => _conversationPrefs[c.id]?.isArchived ?? false).length;
+
   List<Conversation> get _filteredConversations {
-    if (_searchQuery.isEmpty) return conversations;
-    return conversations
-        .where((c) => c.displayName.toLowerCase().contains(_searchQuery))
-        .toList();
+    return conversations.where((c) {
+      final archived = _conversationPrefs[c.id]?.isArchived ?? false;
+      if (_searchQuery.isNotEmpty) {
+        if (!c.displayName.toLowerCase().contains(_searchQuery)) return false;
+        return _viewingArchived ? archived : true;
+      }
+      return _viewingArchived ? archived : !archived;
+    }).toList();
+  }
+
+  Future<void> _reloadConversationPreferences() async {
+    final prefs = await ConversationPreferencesService.instance.getAll();
+    if (!mounted) return;
+    setState(() {
+      _conversationPrefs = prefs;
+      ConversationPreferencesService.sortConversations(conversations, prefs);
+    });
+  }
+
+  Future<void> _pinConversation(String id) async {
+    await ConversationPreferencesService.instance.pin(id);
+    await _reloadConversationPreferences();
+  }
+
+  Future<void> _unpinConversation(String id) async {
+    await ConversationPreferencesService.instance.unpin(id);
+    await _reloadConversationPreferences();
+  }
+
+  Future<void> _archiveConversation(String id) async {
+    await ConversationPreferencesService.instance.archive(id);
+    if (selectedConversation?.id == id) {
+      clearChat();
+    }
+    if (mounted) {
+      setState(() => _viewingArchived = false);
+    }
+    await _reloadConversationPreferences();
+  }
+
+  Future<void> _unarchiveConversation(String id) async {
+    await ConversationPreferencesService.instance.unarchive(id);
+    await _reloadConversationPreferences();
+  }
+
+  void _showConversationActions(Conversation conv) {
+    showConversationActionsSheet(
+      context: context,
+      conversation: conv,
+      preferences: _conversationPrefs[conv.id],
+      viewingArchived: _viewingArchived,
+      onPin: () => _pinConversation(conv.id),
+      onUnpin: () => _unpinConversation(conv.id),
+      onArchive: () => _archiveConversation(conv.id),
+      onUnarchive: () => _unarchiveConversation(conv.id),
+    );
   }
 
   @override
@@ -666,6 +726,7 @@ class _HomeScreenState extends State<HomeScreen> with WidgetsBindingObserver {
     late final List<Map<String, dynamic>> userMaps;
     late final Map<String, int> timestamps;
     late final List<Group> newGroups;
+    late final Map<String, ConversationPreferences> prefs;
     Map<String, String> previews = _lastMessagePreviews;
     Map<String, int> unread = _unreadCounts;
 
@@ -676,6 +737,7 @@ class _HomeScreenState extends State<HomeScreen> with WidgetsBindingObserver {
         groupService.getGroups(),
         MessagesDb.getLastMessagePreviews(widget.onionAddress),
         MessagesDb.getUnreadCounts(widget.onionAddress),
+        ConversationPreferencesService.instance.getAll(),
       ]);
       if (!mounted) return;
       userMaps = results[0] as List<Map<String, dynamic>>;
@@ -683,16 +745,19 @@ class _HomeScreenState extends State<HomeScreen> with WidgetsBindingObserver {
       newGroups = results[2] as List<Group>;
       previews = results[3] as Map<String, String>;
       unread = results[4] as Map<String, int>;
+      prefs = results[5] as Map<String, ConversationPreferences>;
     } else {
       final fastResults = await Future.wait([
         DBHelper.getUsers(),
         MessagesDb.getLastMessageTimestampsForAllUsers(),
         groupService.getGroups(),
+        ConversationPreferencesService.instance.getAll(),
       ]);
       if (!mounted) return;
       userMaps = fastResults[0] as List<Map<String, dynamic>>;
       timestamps = fastResults[1] as Map<String, int>;
       newGroups = fastResults[2] as List<Group>;
+      prefs = fastResults[3] as Map<String, ConversationPreferences>;
 
       if (isLoading) {
         _applyLoadedUsers(
@@ -701,6 +766,7 @@ class _HomeScreenState extends State<HomeScreen> with WidgetsBindingObserver {
           newGroups: newGroups,
           previews: previews,
           unread: unread,
+          prefs: prefs,
         );
       }
 
@@ -719,6 +785,7 @@ class _HomeScreenState extends State<HomeScreen> with WidgetsBindingObserver {
       newGroups: newGroups,
       previews: previews,
       unread: unread,
+      prefs: prefs,
     );
     } finally {
       _loadUsersInProgress = false;
@@ -737,6 +804,7 @@ class _HomeScreenState extends State<HomeScreen> with WidgetsBindingObserver {
     required List<Group> newGroups,
     required Map<String, String> previews,
     required Map<String, int> unread,
+    required Map<String, ConversationPreferences> prefs,
   }) {
     if (!mounted) return;
 
@@ -779,16 +847,13 @@ class _HomeScreenState extends State<HomeScreen> with WidgetsBindingObserver {
           .map((c) => DirectConversation(c)),
       ...newGroups.map((g) => GroupConversation(g)),
     ];
-    newConversations.sort((a, b) {
-      final aTs = a.lastMessageTimestamp ?? 0;
-      final bTs = b.lastMessageTimestamp ?? 0;
-      return bTs.compareTo(aTs);
-    });
+    ConversationPreferencesService.sortConversations(newConversations, prefs);
 
     final changed = newContacts.length != contacts.length ||
         newGroups.length != groups.length ||
         !_mapsEqual(previews, _lastMessagePreviews) ||
         !_mapsEqual(unread, _unreadCounts) ||
+        !_conversationPrefsEqual(prefs, _conversationPrefs) ||
         !newConversations.every((c) {
           final old = conversations.cast<Conversation?>().firstWhere(
                 (o) => o!.id == c.id,
@@ -804,6 +869,7 @@ class _HomeScreenState extends State<HomeScreen> with WidgetsBindingObserver {
       setState(() {
         _lastMessagePreviews = previews;
         _unreadCounts = unread;
+        _conversationPrefs = prefs;
         contacts = newContacts;
         groups = newGroups;
         conversations = newConversations;
@@ -841,6 +907,18 @@ class _HomeScreenState extends State<HomeScreen> with WidgetsBindingObserver {
     if (a.length != b.length) return false;
     for (final entry in a.entries) {
       if (b[entry.key] != entry.value) return false;
+    }
+    return true;
+  }
+
+  bool _conversationPrefsEqual(
+    Map<String, ConversationPreferences> a,
+    Map<String, ConversationPreferences> b,
+  ) {
+    if (a.length != b.length) return false;
+    for (final entry in a.entries) {
+      final other = b[entry.key];
+      if (other == null || other != entry.value) return false;
     }
     return true;
   }
@@ -1178,6 +1256,31 @@ class _HomeScreenState extends State<HomeScreen> with WidgetsBindingObserver {
               ],
             ),
           ),
+          if (_viewingArchived)
+            Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+              child: Row(
+                children: [
+                  IconButton(
+                    icon: const Icon(Icons.arrow_back),
+                    tooltip: 'Back to chats',
+                    onPressed: () => setState(() {
+                      _viewingArchived = false;
+                      _searchQuery = '';
+                    }),
+                  ),
+                  const Expanded(
+                    child: Text(
+                      'Archived',
+                      style: TextStyle(
+                        fontWeight: FontWeight.w600,
+                        fontSize: 16,
+                      ),
+                    ),
+                  ),
+                ],
+              ),
+            ),
           const SizedBox(height: 8),
           // Search bar
           Padding(
@@ -1197,12 +1300,14 @@ class _HomeScreenState extends State<HomeScreen> with WidgetsBindingObserver {
                 onChanged: (value) {
                   setState(() => _searchQuery = value.trim().toLowerCase());
                 },
-                decoration: const InputDecoration(
-                  hintText: 'Search chats...',
-                  hintStyle: TextStyle(fontSize: 14),
-                  prefixIcon: Icon(Icons.search, size: 20),
+                decoration: InputDecoration(
+                  hintText: _viewingArchived
+                      ? 'Search archived...'
+                      : 'Search chats...',
+                  hintStyle: const TextStyle(fontSize: 14),
+                  prefixIcon: const Icon(Icons.search, size: 20),
                   border: InputBorder.none,
-                  contentPadding: EdgeInsets.symmetric(
+                  contentPadding: const EdgeInsets.symmetric(
                     horizontal: 16,
                     vertical: 12
                   ),
@@ -1215,10 +1320,37 @@ class _HomeScreenState extends State<HomeScreen> with WidgetsBindingObserver {
           Expanded(
             child: ListView.builder(
               padding: const EdgeInsets.symmetric(vertical: 8),
-              itemCount: _filteredConversations.length,
+              itemCount: _filteredConversations.length +
+                  (!_viewingArchived && _searchQuery.isEmpty && _archivedCount > 0
+                      ? 1
+                      : 0),
               itemBuilder: (_, index) {
+                final showArchivedEntry = !_viewingArchived &&
+                    _searchQuery.isEmpty &&
+                    _archivedCount > 0;
+                if (showArchivedEntry && index == _filteredConversations.length) {
+                  return Padding(
+                    padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 2),
+                    child: ListTile(
+                      leading: Icon(
+                        Icons.archive_outlined,
+                        color: Theme.of(context).colorScheme.primary,
+                      ),
+                      title: const Text('Archived'),
+                      subtitle: Text('$_archivedCount'),
+                      shape: RoundedRectangleBorder(
+                        borderRadius: BorderRadius.circular(12),
+                      ),
+                      onTap: () => setState(() => _viewingArchived = true),
+                    ),
+                  );
+                }
+
                 final conv = _filteredConversations[index];
                 final isSelected = selectedConversation?.id == conv.id;
+                final prefs = _conversationPrefs[conv.id];
+                final isPinned = prefs?.isPinned ?? false;
+                final isArchived = prefs?.isArchived ?? false;
                 final Widget leading;
                 final String subtitle;
 
@@ -1241,37 +1373,62 @@ class _HomeScreenState extends State<HomeScreen> with WidgetsBindingObserver {
                       : 'Group · $timeLabel';
                 }
 
+                Widget? trailing;
+                if (unreadCount > 0) {
+                  trailing = CircleAvatar(
+                    radius: 11,
+                    backgroundColor: Theme.of(context).colorScheme.primary,
+                    child: Text(
+                      unreadCount > 9 ? '9+' : '$unreadCount',
+                      style: TextStyle(
+                        fontSize: 10,
+                        color: Theme.of(context).colorScheme.onPrimary,
+                      ),
+                    ),
+                  );
+                } else if (isPinned && !_viewingArchived) {
+                  trailing = Icon(
+                    Icons.push_pin,
+                    size: 18,
+                    color: Theme.of(context).hintColor,
+                  );
+                }
+
                 return Padding(
                   key: ValueKey('${conv.id}_${conv.lastMessageTimestamp ?? 0}_$unreadCount'),
                   padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 2),
                   child: ListTile(
                     leading: leading,
-                    title: Text(
-                      conv.displayName,
-                      style: TextStyle(
-                        fontWeight: unreadCount > 0 || isSelected
-                            ? FontWeight.bold
-                            : FontWeight.normal,
-                      ),
+                    title: Row(
+                      children: [
+                        Expanded(
+                          child: Text(
+                            conv.displayName,
+                            style: TextStyle(
+                              fontWeight: unreadCount > 0 || isSelected
+                                  ? FontWeight.bold
+                                  : FontWeight.normal,
+                            ),
+                            overflow: TextOverflow.ellipsis,
+                          ),
+                        ),
+                        if (isArchived && !_viewingArchived && _searchQuery.isNotEmpty)
+                          Padding(
+                            padding: const EdgeInsets.only(left: 4),
+                            child: Icon(
+                              Icons.archive_outlined,
+                              size: 14,
+                              color: Theme.of(context).hintColor,
+                            ),
+                          ),
+                      ],
                     ),
                     subtitle: Text(
                       subtitle,
                       maxLines: 1,
                       overflow: TextOverflow.ellipsis,
                     ),
-                    trailing: unreadCount > 0
-                        ? CircleAvatar(
-                            radius: 11,
-                            backgroundColor: Theme.of(context).colorScheme.primary,
-                            child: Text(
-                              unreadCount > 9 ? '9+' : '$unreadCount',
-                              style: TextStyle(
-                                fontSize: 10,
-                                color: Theme.of(context).colorScheme.onPrimary,
-                              ),
-                            ),
-                          )
-                        : null,
+                    trailing: trailing,
                     selected: isSelected,
                     selectedTileColor: Theme.of(context).primaryColor.withValues(alpha: 0.1),
                     shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
@@ -1282,6 +1439,7 @@ class _HomeScreenState extends State<HomeScreen> with WidgetsBindingObserver {
                         onSelectGroup(conv.group);
                       }
                     },
+                    onLongPress: () => _showConversationActions(conv),
                   ),
                 );
               },

--- a/lib/models/conversation_preferences.dart
+++ b/lib/models/conversation_preferences.dart
@@ -1,0 +1,53 @@
+class ConversationPreferences {
+  final String conversationId;
+  final bool isPinned;
+  final int? pinnedAt;
+  final bool isArchived;
+  final int? archivedAt;
+
+  const ConversationPreferences({
+    required this.conversationId,
+    this.isPinned = false,
+    this.pinnedAt,
+    this.isArchived = false,
+    this.archivedAt,
+  });
+
+  factory ConversationPreferences.fromMap(Map<String, dynamic> map) {
+    return ConversationPreferences(
+      conversationId: map['conversationId'] as String,
+      isPinned: (map['isPinned'] as int? ?? 0) == 1,
+      pinnedAt: map['pinnedAt'] as int?,
+      isArchived: (map['isArchived'] as int? ?? 0) == 1,
+      archivedAt: map['archivedAt'] as int?,
+    );
+  }
+
+  Map<String, dynamic> toMap() => {
+        'conversationId': conversationId,
+        'isPinned': isPinned ? 1 : 0,
+        'pinnedAt': pinnedAt,
+        'isArchived': isArchived ? 1 : 0,
+        'archivedAt': archivedAt,
+      };
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        other is ConversationPreferences &&
+            other.conversationId == conversationId &&
+            other.isPinned == isPinned &&
+            other.pinnedAt == pinnedAt &&
+            other.isArchived == isArchived &&
+            other.archivedAt == archivedAt;
+  }
+
+  @override
+  int get hashCode => Object.hash(
+        conversationId,
+        isPinned,
+        pinnedAt,
+        isArchived,
+        archivedAt,
+      );
+}

--- a/lib/screens/chat.dart
+++ b/lib/screens/chat.dart
@@ -30,6 +30,7 @@ import 'package:prysm/util/message_modify_refresh_notifier.dart';
 import 'package:prysm/util/reaction_refresh_notifier.dart';
 import 'package:prysm/util/waveform_extractor.dart';
 import 'package:prysm/services/chat_service.dart'; // ✅ ADD THIS
+import 'package:prysm/services/conversation_preferences_service.dart';
 import 'package:prysm/util/db_helper.dart';
 import 'package:prysm/util/file_encrypt.dart';
 import 'package:prysm/util/tor_service.dart';
@@ -1064,6 +1065,7 @@ class _ChatScreenState extends State<ChatScreen> {
             _loadInitialMessages();
           },
           onDeleteContact: () async {
+            await ConversationPreferencesService.instance.delete(widget.peerId);
             await DBHelper.deleteUser(widget.peerId);
             resetChatState();
             setState(() {
@@ -1071,6 +1073,11 @@ class _ChatScreenState extends State<ChatScreen> {
               _chatKey = UniqueKey();
               _replyToMessage = null;
             });
+            widget.clearChat();
+          },
+          onPreferencesChanged: widget.reloadUsers,
+          onArchived: () {
+            Navigator.of(context).pop();
             widget.clearChat();
           },
         ),

--- a/lib/screens/chat_profile_screen.dart
+++ b/lib/screens/chat_profile_screen.dart
@@ -6,6 +6,7 @@ import 'package:prysm/services/notification_mute_service.dart';
 import '../models/contact.dart';
 import '../util/db_helper.dart';
 import 'widgets/contact_avatar.dart';
+import 'widgets/conversation_prefs_tiles.dart';
 import 'widgets/notification_mute_tile.dart';
 
 class ChatProfileScreen extends StatefulWidget {
@@ -16,6 +17,8 @@ class ChatProfileScreen extends StatefulWidget {
   final Function(Contact) onUpdateName;
   final Function() onDeleteChat;
   final Function() onDeleteContact;
+  final VoidCallback onPreferencesChanged;
+  final VoidCallback? onArchived;
 
   const ChatProfileScreen({
     required this.peer,
@@ -25,6 +28,8 @@ class ChatProfileScreen extends StatefulWidget {
     required this.onUpdateName,
     required this.onDeleteChat,
     required this.onDeleteContact,
+    required this.onPreferencesChanged,
+    this.onArchived,
     super.key,
   });
 
@@ -272,6 +277,25 @@ class _ChatProfileScreenState extends State<ChatProfileScreen> {
                       },
                     ),
                   ],
+                ),
+              ),
+              const SizedBox(height: 20),
+              Container(
+                decoration: BoxDecoration(
+                  color: Theme.of(context).cardColor,
+                  borderRadius: BorderRadius.circular(20),
+                  boxShadow: [
+                    BoxShadow(
+                      color: Colors.black.withValues(alpha: 0.05),
+                      blurRadius: 10,
+                      offset: const Offset(0, 4),
+                    ),
+                  ],
+                ),
+                child: ConversationPrefsTiles(
+                  conversationId: widget.peer.id,
+                  onChanged: widget.onPreferencesChanged,
+                  onArchived: widget.onArchived,
                 ),
               ),
               const SizedBox(height: 20),

--- a/lib/screens/group_chat.dart
+++ b/lib/screens/group_chat.dart
@@ -1069,6 +1069,11 @@ class _GroupChatScreenState extends State<GroupChatScreen> {
             widget.onCloseChat?.call();
             widget.reloadConversations();
           },
+          onArchived: () {
+            Navigator.of(context).pop();
+            widget.onCloseChat?.call();
+            widget.reloadConversations();
+          },
         ),
       ),
     );

--- a/lib/screens/group_settings_screen.dart
+++ b/lib/screens/group_settings_screen.dart
@@ -10,6 +10,7 @@ import 'package:prysm/models/group.dart';
 import 'package:prysm/services/group_service.dart';
 import 'package:prysm/screens/widgets/contact_avatar.dart';
 import 'package:prysm/util/db_helper.dart';
+import 'package:prysm/screens/widgets/conversation_prefs_tiles.dart';
 import 'package:prysm/screens/widgets/notification_mute_tile.dart';
 import 'package:prysm/services/notification_mute_service.dart';
 import 'package:prysm/util/key_manager.dart';
@@ -21,6 +22,7 @@ class GroupSettingsScreen extends StatefulWidget {
   final KeyManager keyManager;
   final VoidCallback onChanged;
   final VoidCallback onLeftOrDeleted;
+  final VoidCallback? onArchived;
 
   const GroupSettingsScreen({
     required this.group,
@@ -29,6 +31,7 @@ class GroupSettingsScreen extends StatefulWidget {
     required this.keyManager,
     required this.onChanged,
     required this.onLeftOrDeleted,
+    this.onArchived,
     super.key,
   });
 
@@ -386,6 +389,12 @@ class _GroupSettingsScreenState extends State<GroupSettingsScreen> {
                         : null,
                   );
                 }),
+                const Divider(),
+                ConversationPrefsTiles(
+                  conversationId: widget.group.id,
+                  onChanged: widget.onChanged,
+                  onArchived: widget.onArchived,
+                ),
                 const Divider(),
                 NotificationMuteTile(
                   target: MuteTarget.group,

--- a/lib/screens/widgets/conversation_actions_sheet.dart
+++ b/lib/screens/widgets/conversation_actions_sheet.dart
@@ -1,0 +1,66 @@
+import 'package:flutter/material.dart';
+import 'package:prysm/models/conversation.dart';
+import 'package:prysm/models/conversation_preferences.dart';
+
+Future<void> showConversationActionsSheet({
+  required BuildContext context,
+  required Conversation conversation,
+  required ConversationPreferences? preferences,
+  required bool viewingArchived,
+  required Future<void> Function() onPin,
+  required Future<void> Function() onUnpin,
+  required Future<void> Function() onArchive,
+  required Future<void> Function() onUnarchive,
+}) {
+  final isPinned = preferences?.isPinned ?? false;
+  final isArchived = preferences?.isArchived ?? false;
+
+  return showModalBottomSheet<void>(
+    context: context,
+    builder: (ctx) => SafeArea(
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Padding(
+            padding: const EdgeInsets.fromLTRB(20, 16, 20, 8),
+            child: Text(
+              conversation.displayName,
+              style: Theme.of(ctx).textTheme.titleMedium,
+              maxLines: 1,
+              overflow: TextOverflow.ellipsis,
+            ),
+          ),
+          if (!viewingArchived && !isArchived)
+            ListTile(
+              leading: Icon(
+                isPinned ? Icons.push_pin_outlined : Icons.push_pin,
+              ),
+              title: Text(isPinned ? 'Unpin chat' : 'Pin chat'),
+              onTap: () async {
+                Navigator.pop(ctx);
+                if (isPinned) {
+                  await onUnpin();
+                } else {
+                  await onPin();
+                }
+              },
+            ),
+          ListTile(
+            leading: const Icon(Icons.archive_outlined),
+            title: Text(
+              viewingArchived || isArchived ? 'Unarchive chat' : 'Archive chat',
+            ),
+            onTap: () async {
+              Navigator.pop(ctx);
+              if (viewingArchived || isArchived) {
+                await onUnarchive();
+              } else {
+                await onArchive();
+              }
+            },
+          ),
+        ],
+      ),
+    ),
+  );
+}

--- a/lib/screens/widgets/conversation_prefs_tiles.dart
+++ b/lib/screens/widgets/conversation_prefs_tiles.dart
@@ -1,0 +1,89 @@
+import 'package:flutter/material.dart';
+import 'package:prysm/models/conversation_preferences.dart';
+import 'package:prysm/services/conversation_preferences_service.dart';
+
+class ConversationPrefsTiles extends StatefulWidget {
+  final String conversationId;
+  final VoidCallback onChanged;
+  final VoidCallback? onArchived;
+
+  const ConversationPrefsTiles({
+    required this.conversationId,
+    required this.onChanged,
+    this.onArchived,
+    super.key,
+  });
+
+  @override
+  State<ConversationPrefsTiles> createState() => _ConversationPrefsTilesState();
+}
+
+class _ConversationPrefsTilesState extends State<ConversationPrefsTiles> {
+  ConversationPreferences? _prefs;
+  bool _loading = true;
+
+  @override
+  void initState() {
+    super.initState();
+    _load();
+  }
+
+  Future<void> _load() async {
+    final all = await ConversationPreferencesService.instance.getAll();
+    if (!mounted) return;
+    setState(() {
+      _prefs = all[widget.conversationId];
+      _loading = false;
+    });
+  }
+
+  Future<void> _togglePin() async {
+    if (_prefs?.isPinned == true) {
+      await ConversationPreferencesService.instance.unpin(widget.conversationId);
+    } else {
+      await ConversationPreferencesService.instance.pin(widget.conversationId);
+    }
+    await _load();
+    widget.onChanged();
+  }
+
+  Future<void> _toggleArchive() async {
+    if (_prefs?.isArchived == true) {
+      await ConversationPreferencesService.instance.unarchive(widget.conversationId);
+      await _load();
+      widget.onChanged();
+      return;
+    }
+    await ConversationPreferencesService.instance.archive(widget.conversationId);
+    widget.onArchived?.call();
+    widget.onChanged();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    if (_loading) {
+      return const SizedBox(
+        height: 96,
+        child: Center(child: CircularProgressIndicator()),
+      );
+    }
+
+    final isPinned = _prefs?.isPinned ?? false;
+    final isArchived = _prefs?.isArchived ?? false;
+
+    return Column(
+      children: [
+        ListTile(
+          leading: Icon(isPinned ? Icons.push_pin_outlined : Icons.push_pin),
+          title: Text(isPinned ? 'Unpin chat' : 'Pin chat'),
+          onTap: _togglePin,
+        ),
+        ListTile(
+          leading: const Icon(Icons.archive_outlined),
+          title: Text(isArchived ? 'Unarchive chat' : 'Archive chat'),
+          onTap: _toggleArchive,
+        ),
+      ],
+    );
+  }
+}

--- a/lib/server/PrysmServer.dart
+++ b/lib/server/PrysmServer.dart
@@ -16,6 +16,7 @@ import 'package:prysm/services/message_modify_service.dart';
 import 'package:prysm/services/reaction_service.dart';
 import 'package:prysm/services/notification_mute_service.dart';
 import 'package:prysm/services/settings_service.dart';
+import 'package:prysm/services/conversation_preferences_service.dart';
 import 'package:prysm/util/conversation_refresh_notifier.dart';
 import 'package:prysm/util/peer_profile_cache.dart';
 
@@ -311,6 +312,10 @@ class PrysmServer {
         if (data['replyTo'] != null) 'replyTo': data['replyTo'],
         'viewOnce': (data['viewOnce'] == true || data['viewOnce'] == 1) ? 1 : 0,
       }, localId);
+
+      final conversationId = inboundGroupId ?? senderId;
+      await ConversationPreferencesService.instance
+          .unarchiveIfArchived(conversationId);
 
       ConversationRefreshNotifier.instance.notifyInboundMessage();
 

--- a/lib/server/PrysmServer.dart
+++ b/lib/server/PrysmServer.dart
@@ -344,7 +344,7 @@ class PrysmServer {
               notificationId: Random().nextInt(99999999),
               payload: jsonEncode({
                 'senderId': senderId,
-                if (groupId != null) 'groupId': groupId,
+                'groupId': ?groupId,
               }),
             );
           }

--- a/lib/services/conversation_preferences_service.dart
+++ b/lib/services/conversation_preferences_service.dart
@@ -1,0 +1,97 @@
+import 'package:prysm/database/conversation_preferences_db.dart';
+import 'package:prysm/models/conversation.dart';
+import 'package:prysm/models/conversation_preferences.dart';
+
+class ConversationPreferencesService {
+  ConversationPreferencesService._();
+  static final ConversationPreferencesService instance =
+      ConversationPreferencesService._();
+
+  Future<Map<String, ConversationPreferences>> getAll() =>
+      ConversationPreferencesDb.getAll();
+
+  Future<void> pin(String conversationId) async {
+    final existing = await ConversationPreferencesDb.get(conversationId);
+    final now = DateTime.now().millisecondsSinceEpoch;
+    await ConversationPreferencesDb.upsert(
+      ConversationPreferences(
+        conversationId: conversationId,
+        isPinned: true,
+        pinnedAt: now,
+        isArchived: existing?.isArchived ?? false,
+        archivedAt: existing?.archivedAt,
+      ),
+    );
+  }
+
+  Future<void> unpin(String conversationId) async {
+    final existing = await ConversationPreferencesDb.get(conversationId);
+    await ConversationPreferencesDb.upsert(
+      ConversationPreferences(
+        conversationId: conversationId,
+        isPinned: false,
+        isArchived: existing?.isArchived ?? false,
+        archivedAt: existing?.archivedAt,
+      ),
+    );
+  }
+
+  Future<void> archive(String conversationId) async {
+    final existing = await ConversationPreferencesDb.get(conversationId);
+    final now = DateTime.now().millisecondsSinceEpoch;
+    await ConversationPreferencesDb.upsert(
+      ConversationPreferences(
+        conversationId: conversationId,
+        isPinned: existing?.isPinned ?? false,
+        pinnedAt: existing?.pinnedAt,
+        isArchived: true,
+        archivedAt: now,
+      ),
+    );
+  }
+
+  Future<void> unarchive(String conversationId) async {
+    final existing = await ConversationPreferencesDb.get(conversationId);
+    if (existing == null || !existing.isArchived) return;
+    await ConversationPreferencesDb.upsert(
+      ConversationPreferences(
+        conversationId: conversationId,
+        isPinned: existing.isPinned,
+        pinnedAt: existing.pinnedAt,
+        isArchived: false,
+      ),
+    );
+  }
+
+  Future<bool> unarchiveIfArchived(String conversationId) async {
+    final existing = await ConversationPreferencesDb.get(conversationId);
+    if (existing == null || !existing.isArchived) return false;
+    await unarchive(conversationId);
+    return true;
+  }
+
+  Future<void> delete(String conversationId) =>
+      ConversationPreferencesDb.delete(conversationId);
+
+  static void sortConversations(
+    List<Conversation> conversations,
+    Map<String, ConversationPreferences> prefs,
+  ) {
+    conversations.sort((a, b) {
+      final ap = prefs[a.id];
+      final bp = prefs[b.id];
+      final aPinned = ap?.isPinned ?? false;
+      final bPinned = bp?.isPinned ?? false;
+      if (aPinned != bPinned) return aPinned ? -1 : 1;
+      if (aPinned && bPinned) {
+        final aPinAt = ap?.pinnedAt ?? 0;
+        final bPinAt = bp?.pinnedAt ?? 0;
+        final pinCmp = bPinAt.compareTo(aPinAt);
+        if (pinCmp != 0) return pinCmp;
+      }
+      final aTs = a.lastMessageTimestamp ?? 0;
+      final bTs = b.lastMessageTimestamp ?? 0;
+      return bTs.compareTo(aTs);
+    });
+  }
+}

--- a/lib/services/group_chat_service.dart
+++ b/lib/services/group_chat_service.dart
@@ -424,8 +424,8 @@ class GroupChatService {
         'type': type,
         'replyTo': replyToId,
         'timestamp': timestamp,
-        if (fileName != null) 'fileName': fileName,
-        if (fileSize != null) 'fileSize': fileSize,
+        'fileName': ?fileName,
+        'fileSize': ?fileSize,
         if (viewOnce) 'viewOnce': true,
       });
       final response = await torClient
@@ -471,8 +471,8 @@ class GroupChatService {
       'replyTo': replyToId,
       'groupId': groupId,
       'targetMemberId': targetMemberId,
-      if (fileName != null) 'fileName': fileName,
-      if (fileSize != null) 'fileSize': fileSize,
+      'fileName': ?fileName,
+      'fileSize': ?fileSize,
       'viewOnce': viewOnce ? 1 : 0,
     });
   }

--- a/lib/services/group_service.dart
+++ b/lib/services/group_service.dart
@@ -755,7 +755,7 @@ class GroupService {
           'createdBy': userId,
           'members': members,
           'keyVersion': keyVersion,
-          if (avatarBase64 != null) 'avatarBase64': avatarBase64,
+          'avatarBase64': ?avatarBase64,
         },
       );
       return;
@@ -774,7 +774,7 @@ class GroupService {
       'members': members,
       'encryptedGroupKey': encryptedGroupKey,
       'keyVersion': keyVersion,
-      if (avatarBase64 != null) 'avatarBase64': avatarBase64,
+      'avatarBase64': ?avatarBase64,
     });
 
     await _sendControlMessage(
@@ -837,7 +837,7 @@ class GroupService {
     final payload = jsonEncode({
       'groupId': groupId,
       'name': name,
-      if (avatarBase64 != null) 'avatarBase64': avatarBase64,
+      'avatarBase64': ?avatarBase64,
     });
 
     await _sendControlMessage(

--- a/lib/services/group_service.dart
+++ b/lib/services/group_service.dart
@@ -6,6 +6,7 @@ import 'package:prysm/client/TorHttpClient.dart';
 import 'package:prysm/constants/group_constants.dart';
 import 'package:prysm/database/messages.dart';
 import 'package:prysm/models/group.dart';
+import 'package:prysm/services/conversation_preferences_service.dart';
 import 'package:prysm/util/db_helper.dart';
 import 'package:prysm/util/group_crypto.dart';
 import 'package:prysm/util/key_manager.dart';
@@ -555,6 +556,7 @@ class GroupService {
 
   Future<void> deleteGroupLocal(String groupId, {bool notify = true}) async {
     await MessagesDb.deleteMessagesForGroup(groupId);
+    await ConversationPreferencesService.instance.delete(groupId);
     await DBHelper.deleteGroup(groupId);
     invalidateGroupKeyCache(groupId);
     if (notify) {

--- a/lib/util/db_helper.dart
+++ b/lib/util/db_helper.dart
@@ -1,4 +1,5 @@
 
+import 'package:prysm/database/conversation_preferences_db.dart';
 import 'package:sqflite_common_ffi/sqflite_ffi.dart';
 import 'package:path/path.dart';
 import 'package:path_provider/path_provider.dart';
@@ -23,7 +24,7 @@ class DBHelper {
   static Future<Database> _initDB() async {
     final docDir = await getApplicationDocumentsDirectory();
     final path = join(docDir.path, 'prysm', 'chat_app.db');
-    return await openDatabase(path, version: 4, onCreate: _createDB, onUpgrade: _onUpgrade);
+    return await openDatabase(path, version: 5, onCreate: _createDB, onUpgrade: _onUpgrade);
   }
 
   static Future _createDB(Database db, int version) async {
@@ -39,6 +40,7 @@ class DBHelper {
     ''');
     await db.execute('CREATE INDEX idx_users_name ON users(name)');
     await _createGroupTables(db);
+    await ConversationPreferencesDb.createTable(db);
   }
 
   static Future<void> _createGroupTables(Database db) async {
@@ -88,6 +90,9 @@ class DBHelper {
     }
     if (oldVersion < 4) {
       await _createGroupTables(db);
+    }
+    if (oldVersion < 5) {
+      await ConversationPreferencesDb.createTable(db);
     }
   }
 

--- a/test/conversation_preferences_test.dart
+++ b/test/conversation_preferences_test.dart
@@ -1,0 +1,79 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:prysm/models/contact.dart';
+import 'package:prysm/models/conversation.dart';
+import 'package:prysm/models/conversation_preferences.dart';
+import 'package:prysm/models/group.dart';
+import 'package:prysm/services/conversation_preferences_service.dart';
+
+void main() {
+  test('pinned conversations sort above unpinned by recency', () {
+    final a = DirectConversation(Contact(
+      id: 'a.onion',
+      name: 'A',
+      avatarUrl: '',
+      publicKeyPem: '',
+      lastMessageTimestamp: 1000,
+    ));
+    final b = DirectConversation(Contact(
+      id: 'b.onion',
+      name: 'B',
+      avatarUrl: '',
+      publicKeyPem: '',
+      lastMessageTimestamp: 2000,
+    ));
+    final c = DirectConversation(Contact(
+      id: 'c.onion',
+      name: 'C',
+      avatarUrl: '',
+      publicKeyPem: '',
+      lastMessageTimestamp: 500,
+    ));
+
+    final list = [a, b, c];
+    final prefs = {
+      'c.onion': const ConversationPreferences(
+        conversationId: 'c.onion',
+        isPinned: true,
+        pinnedAt: 10,
+      ),
+      'b.onion': const ConversationPreferences(
+        conversationId: 'b.onion',
+        isPinned: true,
+        pinnedAt: 20,
+      ),
+    };
+
+    ConversationPreferencesService.sortConversations(list, prefs);
+
+    expect(list.map((c) => c.id).toList(), ['b.onion', 'c.onion', 'a.onion']);
+  });
+
+  test('group conversations participate in pin ordering', () {
+    final group = GroupConversation(Group(
+      id: 'g1',
+      name: 'Team',
+      createdBy: 'x',
+      createdAt: 1,
+      lastMessageTimestamp: 100,
+    ));
+    final direct = DirectConversation(Contact(
+      id: 'd.onion',
+      name: 'D',
+      avatarUrl: '',
+      publicKeyPem: '',
+      lastMessageTimestamp: 9999,
+    ));
+
+    final list = [direct, group];
+    final prefs = {
+      'g1': const ConversationPreferences(
+        conversationId: 'g1',
+        isPinned: true,
+        pinnedAt: 1,
+      ),
+    };
+
+    ConversationPreferencesService.sortConversations(list, prefs);
+    expect(list.first.id, 'g1');
+  });
+}


### PR DESCRIPTION
- Introduced ConversationPreferences model and service for managing chat preferences.
- Implemented database support for conversation preferences, including pinning and archiving.
- Enhanced chat and group chat screens to allow users to pin and archive conversations.
- Added UI components for managing conversation preferences in chat profile and group settings.
- Updated conversation sorting logic to prioritize pinned conversations.
- Included tests for conversation preferences functionality.