### PR TITLE
feat: implement link unfurling feature

### DIFF
--- a/lib/models/link_preview.dart
+++ b/lib/models/link_preview.dart
@@ -1,0 +1,25 @@
+class LinkPreview {
+  final String url;
+  final String? title;
+  final String? description;
+  final String? imageUrl;
+  final String? siteName;
+
+  const LinkPreview({
+    required this.url,
+    this.title,
+    this.description,
+    this.imageUrl,
+    this.siteName,
+  });
+
+  bool get hasContent =>
+      (title != null && title!.isNotEmpty) ||
+      (description != null && description!.isNotEmpty) ||
+      (imageUrl != null && imageUrl!.isNotEmpty);
+
+  String get displayHost {
+    final uri = Uri.tryParse(url);
+    return uri?.host ?? url;
+  }
+}

--- a/lib/models/settings.dart
+++ b/lib/models/settings.dart
@@ -25,6 +25,7 @@ class Settings {
 
   // Files
   final bool enableFilePreview;
+  final bool enableLinkUnfurling;
   final String? customDownloadPath;
 
   Settings({
@@ -42,6 +43,7 @@ class Settings {
     this.avatar,
     this.username,
     this.enableFilePreview = false,
+    this.enableLinkUnfurling = false,
     this.customDownloadPath,
   });
 
@@ -61,6 +63,7 @@ class Settings {
     'avatar': avatar,
     'username': username,
     'enableFilePreview': enableFilePreview,
+    'enableLinkUnfurling': enableLinkUnfurling,
     'customDownloadPath': customDownloadPath,
   };
 
@@ -80,6 +83,7 @@ class Settings {
     avatar: json['avatar'],
     username: json['username'],
     enableFilePreview: json['enableFilePreview'] ?? false,
+    enableLinkUnfurling: json['enableLinkUnfurling'] ?? false,
     customDownloadPath: json['customDownloadPath'],
   );
 
@@ -99,6 +103,7 @@ class Settings {
     String? avatar,
     String? username,
     bool? enableFilePreview,
+    bool? enableLinkUnfurling,
     String? customDownloadPath,
     bool clearCustomDownloadPath = false,
   }) => Settings(
@@ -117,6 +122,7 @@ class Settings {
     avatar: avatar ?? this.avatar,
     username: username ?? this.username,
     enableFilePreview: enableFilePreview ?? this.enableFilePreview,
+    enableLinkUnfurling: enableLinkUnfurling ?? this.enableLinkUnfurling,
     customDownloadPath: clearCustomDownloadPath
         ? null
         : (customDownloadPath ?? this.customDownloadPath),
@@ -152,6 +158,7 @@ class Settings {
         other.avatar == avatar &&
         other.username == username &&
         other.enableFilePreview == enableFilePreview &&
+        other.enableLinkUnfurling == enableLinkUnfurling &&
         other.customDownloadPath == customDownloadPath;
   }
 
@@ -171,6 +178,7 @@ class Settings {
         (avatar?.hashCode ?? 0) ^
         (username?.hashCode ?? 0) ^
         enableFilePreview.hashCode ^
+        enableLinkUnfurling.hashCode ^
         (customDownloadPath?.hashCode ?? 0);
   }
 }

--- a/lib/screens/chat.dart
+++ b/lib/screens/chat.dart
@@ -20,6 +20,7 @@ import 'package:prysm/screens/widgets/contact_avatar.dart';
 import 'package:prysm/screens/widgets/message_reaction_bar.dart';
 import 'package:prysm/screens/widgets/message_reaction_picker.dart';
 import 'package:prysm/screens/widgets/file_attachment_bubble.dart';
+import 'package:prysm/screens/widgets/linked_message_text.dart';
 import 'package:prysm/screens/widgets/voice_message_bubble.dart';
 import 'package:prysm/services/file_attachment_resolver.dart';
 import 'package:prysm/screens/widgets/deleted_message_bubble.dart';
@@ -1145,63 +1146,6 @@ class _ChatScreenState extends State<ChatScreen> {
     return '';
   }
 
-  static final _urlRegex = RegExp(
-    r'https?://[^\s<>\[\]{}|\\^`]+',
-    caseSensitive: false,
-  );
-
-  Widget _buildLinkedText(String text, Color textColor, double fontSize) {
-    final matches = _urlRegex.allMatches(text).toList();
-    if (matches.isEmpty) {
-      return Text(text, style: TextStyle(color: textColor, fontSize: fontSize));
-    }
-
-    final spans = <InlineSpan>[];
-    int lastEnd = 0;
-
-    for (final match in matches) {
-      if (match.start > lastEnd) {
-        spans.add(TextSpan(
-          text: text.substring(lastEnd, match.start),
-          style: TextStyle(color: textColor, fontSize: fontSize),
-        ));
-      }
-      final url = match.group(0)!;
-      spans.add(WidgetSpan(
-        alignment: PlaceholderAlignment.baseline,
-        baseline: TextBaseline.alphabetic,
-        child: GestureDetector(
-          onTap: () => _openUrl(url),
-          onLongPress: () {
-            Clipboard.setData(ClipboardData(text: url));
-            ScaffoldMessenger.of(context).showSnackBar(
-              const SnackBar(content: Text('Link copied'), duration: Duration(seconds: 1)),
-            );
-          },
-          child: Text(
-            url,
-            style: TextStyle(
-              color: textColor,
-              fontSize: fontSize,
-              decoration: TextDecoration.underline,
-              decorationColor: textColor.withAlpha(180),
-            ),
-          ),
-        ),
-      ));
-      lastEnd = match.end;
-    }
-
-    if (lastEnd < text.length) {
-      spans.add(TextSpan(
-        text: text.substring(lastEnd),
-        style: TextStyle(color: textColor, fontSize: fontSize),
-      ));
-    }
-
-    return RichText(text: TextSpan(children: spans));
-  }
-
   Future<void> _openUrl(String url) async {
     final uri = Uri.tryParse(url);
     if (uri != null && await canLaunchUrl(uri)) {
@@ -2040,13 +1984,13 @@ class _ChatScreenState extends State<ChatScreen> {
           crossAxisAlignment: CrossAxisAlignment.start,
           mainAxisSize: MainAxisSize.min,
           children: [
-            // ✅ Text with clickable links
-            _buildLinkedText(
-              message.text,
-              isSentByMe
+            LinkedMessageText(
+              text: message.text,
+              textColor: isSentByMe
                   ? Theme.of(context).colorScheme.onPrimary
                   : Theme.of(context).colorScheme.onSecondary,
-              14,
+              fontSize: 14,
+              onOpenUrl: _openUrl,
             ),
             const SizedBox(height: 4),
             // ✅ Time and ticks aligned to the right

--- a/lib/screens/group_chat.dart
+++ b/lib/screens/group_chat.dart
@@ -23,6 +23,7 @@ import 'package:prysm/screens/widgets/contact_avatar.dart';
 import 'package:prysm/screens/widgets/message_reaction_bar.dart';
 import 'package:prysm/screens/widgets/message_reaction_picker.dart';
 import 'package:prysm/screens/widgets/file_attachment_bubble.dart';
+import 'package:prysm/screens/widgets/linked_message_text.dart';
 import 'package:prysm/screens/widgets/voice_message_bubble.dart';
 import 'package:prysm/services/file_attachment_resolver.dart';
 import 'package:prysm/screens/widgets/deleted_message_bubble.dart';
@@ -90,11 +91,6 @@ class _GroupChatScreenState extends State<GroupChatScreen> {
   Message? _replyToMessage;
   final Set<String> selectedMessageIds = {};
   final Map<String, double> _dragOffsets = {};
-
-  static final _urlRegex = RegExp(
-    r'https?://[^\s<>\[\]{}|\\^`]+',
-    caseSensitive: false,
-  );
 
   @override
   void initState() {
@@ -248,55 +244,6 @@ class _GroupChatScreenState extends State<GroupChatScreen> {
         ],
       ),
     );
-  }
-
-  Widget _buildLinkedText(String text, Color textColor, double fontSize) {
-    final matches = _urlRegex.allMatches(text).toList();
-    if (matches.isEmpty) {
-      return Text(text, style: TextStyle(color: textColor, fontSize: fontSize));
-    }
-
-    final spans = <InlineSpan>[];
-    var lastEnd = 0;
-    for (final match in matches) {
-      if (match.start > lastEnd) {
-        spans.add(TextSpan(
-          text: text.substring(lastEnd, match.start),
-          style: TextStyle(color: textColor, fontSize: fontSize),
-        ));
-      }
-      final url = match.group(0)!;
-      spans.add(WidgetSpan(
-        alignment: PlaceholderAlignment.baseline,
-        baseline: TextBaseline.alphabetic,
-        child: GestureDetector(
-          onTap: () => _openUrl(url),
-          onLongPress: () {
-            Clipboard.setData(ClipboardData(text: url));
-            ScaffoldMessenger.of(context).showSnackBar(
-              const SnackBar(content: Text('Link copied'), duration: Duration(seconds: 1)),
-            );
-          },
-          child: Text(
-            url,
-            style: TextStyle(
-              color: textColor,
-              fontSize: fontSize,
-              decoration: TextDecoration.underline,
-              decorationColor: textColor.withAlpha(180),
-            ),
-          ),
-        ),
-      ));
-      lastEnd = match.end;
-    }
-    if (lastEnd < text.length) {
-      spans.add(TextSpan(
-        text: text.substring(lastEnd),
-        style: TextStyle(color: textColor, fontSize: fontSize),
-      ));
-    }
-    return RichText(text: TextSpan(children: spans));
   }
 
   Future<void> _openUrl(String url) async {
@@ -1147,12 +1094,13 @@ class _GroupChatScreenState extends State<GroupChatScreen> {
               mainAxisSize: MainAxisSize.min,
               children: [
                 _replyPreviewWidget(message, isSentByMe),
-                _buildLinkedText(
-                  message.text,
-                  isSentByMe
+                LinkedMessageText(
+                  text: message.text,
+                  textColor: isSentByMe
                       ? Theme.of(context).colorScheme.onPrimary
                       : Theme.of(context).colorScheme.onSecondary,
-                  16,
+                  fontSize: 16,
+                  onOpenUrl: _openUrl,
                 ),
                 const SizedBox(height: 4),
                 Row(

--- a/lib/screens/settings_screen.dart
+++ b/lib/screens/settings_screen.dart
@@ -39,6 +39,7 @@ class _SettingsScreenState extends State<SettingsScreen> {
   bool _minimizeOnMinimizeButton = false;
   bool _enableRelay = false;
   bool _enableFilePreview = false;
+  bool _enableLinkUnfurling = false;
   String _downloadLocationDisplay = 'Loading...';
   StreamSubscription<void>? _batterySaverSub;
 
@@ -66,6 +67,7 @@ class _SettingsScreenState extends State<SettingsScreen> {
       _minimizeOnMinimizeButton = settings.minimizeOnMinimizeButton;
       _enableRelay = settings.enableRelay;
       _enableFilePreview = settings.enableFilePreview;
+      _enableLinkUnfurling = settings.enableLinkUnfurling;
     });
   }
 
@@ -175,6 +177,11 @@ class _SettingsScreenState extends State<SettingsScreen> {
   void _onFilePreviewToggle(bool value) async {
     await settings.setEnableFilePreview(value);
     setState(() => _enableFilePreview = value);
+  }
+
+  void _onLinkUnfurlingToggle(bool value) async {
+    await settings.setEnableLinkUnfurling(value);
+    setState(() => _enableLinkUnfurling = value);
   }
 
   void _onBatterySavingToggle(bool value) async {
@@ -639,6 +646,14 @@ class _SettingsScreenState extends State<SettingsScreen> {
                   Icons.preview_outlined,
                   _enableFilePreview,
                   _onFilePreviewToggle,
+                ),
+                const Divider(height: 1),
+                _buildSwitchTile(
+                  'Link previews',
+                  'Fetch titles and images for URLs in messages via Tor',
+                  Icons.link_outlined,
+                  _enableLinkUnfurling,
+                  _onLinkUnfurlingToggle,
                 ),
                 const Divider(height: 1),
                 _buildNavigationTile(

--- a/lib/screens/widgets/link_unfurl_preview.dart
+++ b/lib/screens/widgets/link_unfurl_preview.dart
@@ -1,0 +1,148 @@
+import 'dart:typed_data';
+
+import 'package:flutter/material.dart';
+import 'package:prysm/models/link_preview.dart';
+import 'package:prysm/services/link_unfurl_service.dart';
+import 'package:prysm/services/settings_service.dart';
+
+class LinkUnfurlPreview extends StatefulWidget {
+  final String url;
+  final Color textColor;
+  final VoidCallback onOpen;
+
+  const LinkUnfurlPreview({
+    required this.url,
+    required this.textColor,
+    required this.onOpen,
+    super.key,
+  });
+
+  @override
+  State<LinkUnfurlPreview> createState() => _LinkUnfurlPreviewState();
+}
+
+class _LinkUnfurlPreviewState extends State<LinkUnfurlPreview> {
+  LinkPreview? _preview;
+  Uint8List? _imageBytes;
+  bool _loading = true;
+
+  @override
+  void initState() {
+    super.initState();
+    if (SettingsService().enableLinkUnfurling) {
+      _load();
+    } else {
+      _loading = false;
+    }
+  }
+
+  Future<void> _load() async {
+    final preview = await LinkUnfurlService.instance.fetch(widget.url);
+    Uint8List? imageBytes;
+    final imageUrl = preview?.imageUrl;
+    if (imageUrl != null && imageUrl.isNotEmpty) {
+      imageBytes = await LinkUnfurlService.instance.fetchImage(imageUrl);
+    }
+    if (!mounted) return;
+    setState(() {
+      _preview = preview;
+      _imageBytes = imageBytes;
+      _loading = false;
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    if (!SettingsService().enableLinkUnfurling) {
+      return const SizedBox.shrink();
+    }
+    if (_loading) {
+      return Padding(
+        padding: const EdgeInsets.only(top: 8),
+        child: SizedBox(
+          height: 4,
+          child: LinearProgressIndicator(
+            color: widget.textColor.withValues(alpha: 0.5),
+            backgroundColor: widget.textColor.withValues(alpha: 0.15),
+          ),
+        ),
+      );
+    }
+    final preview = _preview;
+    if (preview == null || !preview.hasContent) {
+      return const SizedBox.shrink();
+    }
+
+    return Padding(
+      padding: const EdgeInsets.only(top: 8),
+      child: Material(
+        color: widget.textColor.withValues(alpha: 0.08),
+        borderRadius: BorderRadius.circular(8),
+        child: InkWell(
+          onTap: widget.onOpen,
+          borderRadius: BorderRadius.circular(8),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            children: [
+              if (_imageBytes != null && _imageBytes!.isNotEmpty)
+                ClipRRect(
+                  borderRadius: const BorderRadius.vertical(top: Radius.circular(8)),
+                  child: Image.memory(
+                    _imageBytes!,
+                    height: 120,
+                    width: double.infinity,
+                    fit: BoxFit.cover,
+                    errorBuilder: (_, _, _) => const SizedBox.shrink(),
+                  ),
+                ),
+              Padding(
+                padding: const EdgeInsets.all(10),
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    if (preview.siteName != null && preview.siteName!.isNotEmpty)
+                      Text(
+                        preview.siteName!,
+                        style: TextStyle(
+                          fontSize: 11,
+                          color: widget.textColor.withValues(alpha: 0.7),
+                        ),
+                        maxLines: 1,
+                        overflow: TextOverflow.ellipsis,
+                      ),
+                    if (preview.title != null && preview.title!.isNotEmpty) ...[
+                      if (preview.siteName != null) const SizedBox(height: 2),
+                      Text(
+                        preview.title!,
+                        style: TextStyle(
+                          fontSize: 13,
+                          fontWeight: FontWeight.w600,
+                          color: widget.textColor,
+                        ),
+                        maxLines: 2,
+                        overflow: TextOverflow.ellipsis,
+                      ),
+                    ],
+                    if (preview.description != null &&
+                        preview.description!.isNotEmpty) ...[
+                      const SizedBox(height: 4),
+                      Text(
+                        preview.description!,
+                        style: TextStyle(
+                          fontSize: 12,
+                          color: widget.textColor.withValues(alpha: 0.85),
+                        ),
+                        maxLines: 3,
+                        overflow: TextOverflow.ellipsis,
+                      ),
+                    ],
+                  ],
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/screens/widgets/linked_message_text.dart
+++ b/lib/screens/widgets/linked_message_text.dart
@@ -1,0 +1,94 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:prysm/screens/widgets/link_unfurl_preview.dart';
+import 'package:prysm/services/settings_service.dart';
+import 'package:prysm/util/url_detector.dart';
+
+class LinkedMessageText extends StatelessWidget {
+  final String text;
+  final Color textColor;
+  final double fontSize;
+  final Future<void> Function(String url) onOpenUrl;
+
+  const LinkedMessageText({
+    required this.text,
+    required this.textColor,
+    required this.fontSize,
+    required this.onOpenUrl,
+    super.key,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final firstUrl = UrlDetector.firstUrl(text);
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        _buildLinkedText(context),
+        if (firstUrl != null && SettingsService().enableLinkUnfurling)
+          LinkUnfurlPreview(
+            url: firstUrl,
+            textColor: textColor,
+            onOpen: () => onOpenUrl(firstUrl),
+          ),
+      ],
+    );
+  }
+
+  Widget _buildLinkedText(BuildContext context) {
+    final matches = UrlDetector.urlRegex.allMatches(text).toList();
+    if (matches.isEmpty) {
+      return Text(text, style: TextStyle(color: textColor, fontSize: fontSize));
+    }
+
+    final spans = <InlineSpan>[];
+    var lastEnd = 0;
+
+    for (final match in matches) {
+      if (match.start > lastEnd) {
+        spans.add(TextSpan(
+          text: text.substring(lastEnd, match.start),
+          style: TextStyle(color: textColor, fontSize: fontSize),
+        ));
+      }
+      final url = match.group(0)!;
+      spans.add(WidgetSpan(
+        alignment: PlaceholderAlignment.baseline,
+        baseline: TextBaseline.alphabetic,
+        child: GestureDetector(
+          onTap: () => onOpenUrl(url),
+          onLongPress: () {
+            Clipboard.setData(ClipboardData(text: url));
+            ScaffoldMessenger.of(context).showSnackBar(
+              const SnackBar(
+                content: Text('Link copied'),
+                duration: Duration(seconds: 1),
+              ),
+            );
+          },
+          child: Text(
+            url,
+            style: TextStyle(
+              color: textColor,
+              fontSize: fontSize,
+              decoration: TextDecoration.underline,
+              decorationColor: textColor.withAlpha(180),
+            ),
+          ),
+        ),
+      ));
+      lastEnd = match.end;
+    }
+
+    if (lastEnd < text.length) {
+      spans.add(TextSpan(
+        text: text.substring(lastEnd),
+        style: TextStyle(color: textColor, fontSize: fontSize),
+      ));
+    }
+
+    return RichText(text: TextSpan(children: spans));
+  }
+}

--- a/lib/services/link_unfurl_service.dart
+++ b/lib/services/link_unfurl_service.dart
@@ -1,0 +1,152 @@
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:prysm/client/TorHttpClient.dart';
+import 'package:prysm/models/link_preview.dart';
+import 'package:prysm/util/link_unfurl_parser.dart';
+import 'package:prysm/util/link_unfurl_policy.dart';
+
+class LinkUnfurlService {
+  LinkUnfurlService._();
+  static final LinkUnfurlService instance = LinkUnfurlService._();
+
+  static const _torProxyHost = '127.0.0.1';
+  static const _torProxyPort = 9050;
+
+  final _cache = <String, LinkPreview?>{};
+  final _imageCache = <String, Uint8List?>{};
+  final _inFlight = <String, Future<LinkPreview?>>{};
+  final _imageInFlight = <String, Future<Uint8List?>>{};
+
+  Future<LinkPreview?> fetch(String url) async {
+    final uri = Uri.tryParse(url);
+    if (uri == null || !LinkUnfurlPolicy.isSafeToUnfurl(uri)) return null;
+
+    if (_cache.containsKey(url)) return _cache[url];
+
+    final pending = _inFlight[url];
+    if (pending != null) return pending;
+
+    final future = _fetchUncached(uri, url);
+    _inFlight[url] = future;
+    try {
+      final preview = await future;
+      _remember(url, preview);
+      return preview;
+    } finally {
+      _inFlight.remove(url);
+    }
+  }
+
+  Future<Uint8List?> fetchImage(String imageUrl) async {
+    final uri = Uri.tryParse(imageUrl);
+    if (uri == null || !LinkUnfurlPolicy.isSafeToUnfurl(uri)) return null;
+
+    if (_imageCache.containsKey(imageUrl)) return _imageCache[imageUrl];
+
+    final pending = _imageInFlight[imageUrl];
+    if (pending != null) return pending;
+
+    final future = _fetchImageUncached(uri);
+    _imageInFlight[imageUrl] = future;
+    try {
+      final bytes = await future;
+      _rememberImage(imageUrl, bytes);
+      return bytes;
+    } finally {
+      _imageInFlight.remove(imageUrl);
+    }
+  }
+
+  Future<LinkPreview?> _fetchUncached(Uri uri, String originalUrl) async {
+    final torClient = TorHttpClient(
+      proxyHost: _torProxyHost,
+      proxyPort: _torProxyPort,
+    );
+    try {
+      final response = await torClient
+          .get(uri, const {
+            'User-Agent': 'Prysm/1.0 (link preview)',
+            'Accept': 'text/html,application/xhtml+xml',
+          })
+          .timeout(LinkUnfurlPolicy.fetchTimeout);
+
+      if (response.statusCode < 200 || response.statusCode >= 400) {
+        return null;
+      }
+
+      final body = await _readLimited(response, LinkUnfurlPolicy.maxHtmlBytes);
+      final html = utf8.decode(body, allowMalformed: true);
+      final headEnd = html.indexOf('</head>');
+      final snippet = headEnd > 0 ? html.substring(0, headEnd) : html;
+      final parsed = LinkUnfurlParser.parse(originalUrl, snippet);
+      if (parsed == null) return null;
+
+      final imageUrl = LinkUnfurlPolicy.resolveUrl(uri, parsed.imageUrl);
+      return LinkPreview(
+        url: parsed.url,
+        title: parsed.title,
+        description: parsed.description,
+        imageUrl: imageUrl,
+        siteName: parsed.siteName,
+      );
+    } catch (_) {
+      return null;
+    } finally {
+      torClient.close();
+    }
+  }
+
+  Future<Uint8List?> _fetchImageUncached(Uri uri) async {
+    final torClient = TorHttpClient(
+      proxyHost: _torProxyHost,
+      proxyPort: _torProxyPort,
+    );
+    try {
+      final response = await torClient
+          .get(uri, const {'Accept': 'image/*'})
+          .timeout(LinkUnfurlPolicy.fetchTimeout);
+
+      if (response.statusCode < 200 || response.statusCode >= 400) {
+        return null;
+      }
+
+      final bytes = await _readLimited(response, LinkUnfurlPolicy.maxImageBytes);
+      return Uint8List.fromList(bytes);
+    } catch (_) {
+      return null;
+    } finally {
+      torClient.close();
+    }
+  }
+
+  Future<List<int>> _readLimited(Stream<List<int>> stream, int maxBytes) async {
+    final buffer = <int>[];
+    await for (final chunk in stream) {
+      buffer.addAll(chunk);
+      if (buffer.length >= maxBytes) {
+        return buffer.sublist(0, maxBytes);
+      }
+    }
+    return buffer;
+  }
+
+  void _remember(String url, LinkPreview? preview) {
+    if (_cache.length >= LinkUnfurlPolicy.maxCacheEntries) {
+      _cache.remove(_cache.keys.first);
+    }
+    _cache[url] = preview;
+  }
+
+  void _rememberImage(String url, Uint8List? bytes) {
+    if (_imageCache.length >= LinkUnfurlPolicy.maxCacheEntries) {
+      _imageCache.remove(_imageCache.keys.first);
+    }
+    _imageCache[url] = bytes;
+  }
+
+  void clearCache() {
+    _cache.clear();
+    _imageCache.clear();
+  }
+}

--- a/lib/services/settings_service.dart
+++ b/lib/services/settings_service.dart
@@ -2,6 +2,7 @@
 import 'dart:convert';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:prysm/models/settings.dart';
+import 'package:prysm/services/link_unfurl_service.dart';
 
 class SettingsService {
   static const String appVersion = 'v0.2.0';
@@ -50,6 +51,7 @@ class SettingsService {
 
   // Files
   bool get enableFilePreview => _settings.enableFilePreview;
+  bool get enableLinkUnfurling => _settings.enableLinkUnfurling;
   String? get customDownloadPath => _settings.customDownloadPath;
 
   // Initialize (call at app startup)
@@ -157,6 +159,14 @@ class SettingsService {
 
   Future<void> setEnableFilePreview(bool value) async {
     _settings = _settings.copyWith(enableFilePreview: value);
+    await save();
+  }
+
+  Future<void> setEnableLinkUnfurling(bool value) async {
+    _settings = _settings.copyWith(enableLinkUnfurling: value);
+    if (!value) {
+      LinkUnfurlService.instance.clearCache();
+    }
     await save();
   }
 

--- a/lib/util/link_unfurl_parser.dart
+++ b/lib/util/link_unfurl_parser.dart
@@ -1,0 +1,84 @@
+import 'package:prysm/models/link_preview.dart';
+import 'package:prysm/util/link_unfurl_policy.dart';
+
+class LinkUnfurlParser {
+  LinkUnfurlParser._();
+
+  static LinkPreview? parse(String url, String html) {
+    final title = _truncate(
+      _metaContent(html, 'og:title') ??
+          _metaContent(html, 'twitter:title') ??
+          _titleTag(html),
+      LinkUnfurlPolicy.maxTitleLength,
+    );
+    final description = _truncate(
+      _metaContent(html, 'og:description') ??
+          _metaContent(html, 'twitter:description') ??
+          _metaContent(html, 'description'),
+      LinkUnfurlPolicy.maxDescriptionLength,
+    );
+    final imageUrl = _metaContent(html, 'og:image') ??
+        _metaContent(html, 'twitter:image');
+    final siteName =
+        _metaContent(html, 'og:site_name') ?? Uri.tryParse(url)?.host;
+
+    if ((title == null || title.isEmpty) &&
+        (description == null || description.isEmpty) &&
+        (imageUrl == null || imageUrl.isEmpty)) {
+      return null;
+    }
+
+    return LinkPreview(
+      url: url,
+      title: title,
+      description: description,
+      imageUrl: imageUrl,
+      siteName: siteName,
+    );
+  }
+
+  static String? _metaContent(String html, String key) {
+    final patterns = [
+      RegExp(
+        '<meta[^>]+(?:property|name)=["\']$key["\'][^>]+content=["\']([^"\']*)["\']',
+        caseSensitive: false,
+      ),
+      RegExp(
+        '<meta[^>]+content=["\']([^"\']*)["\'][^>]+(?:property|name)=["\']$key["\']',
+        caseSensitive: false,
+      ),
+    ];
+    for (final pattern in patterns) {
+      final match = pattern.firstMatch(html);
+      final value = match?.group(1)?.trim();
+      if (value != null && value.isNotEmpty) return _decodeEntities(value);
+    }
+    return null;
+  }
+
+  static String? _titleTag(String html) {
+    final match = RegExp(
+      '<title[^>]*>([^<]*)</title>',
+      caseSensitive: false,
+    ).firstMatch(html);
+    final value = match?.group(1)?.trim();
+    if (value == null || value.isEmpty) return null;
+    return _decodeEntities(value);
+  }
+
+  static String? _truncate(String? value, int maxLength) {
+    if (value == null || value.isEmpty) return null;
+    if (value.length <= maxLength) return value;
+    return '${value.substring(0, maxLength - 1)}…';
+  }
+
+  static String _decodeEntities(String value) {
+    return value
+        .replaceAll('&amp;', '&')
+        .replaceAll('&lt;', '<')
+        .replaceAll('&gt;', '>')
+        .replaceAll('&quot;', '"')
+        .replaceAll('&#39;', "'")
+        .replaceAll('&apos;', "'");
+  }
+}

--- a/lib/util/link_unfurl_policy.dart
+++ b/lib/util/link_unfurl_policy.dart
@@ -1,0 +1,41 @@
+class LinkUnfurlPolicy {
+  LinkUnfurlPolicy._();
+
+  static const int maxHtmlBytes = 512 * 1024;
+  static const int maxImageBytes = 2 * 1024 * 1024;
+  static const Duration fetchTimeout = Duration(seconds: 8);
+  static const int maxCacheEntries = 64;
+  static const int maxTitleLength = 200;
+  static const int maxDescriptionLength = 300;
+
+  static bool isSafeToUnfurl(Uri uri) {
+    if (!uri.hasScheme) return false;
+    final scheme = uri.scheme.toLowerCase();
+    if (scheme != 'http' && scheme != 'https') return false;
+
+    final host = uri.host.toLowerCase();
+    if (host.isEmpty) return false;
+    if (host == 'localhost' || host.endsWith('.localhost')) return false;
+
+    if (host == '::1' || host.startsWith('127.')) return false;
+    if (host.startsWith('10.')) return false;
+    if (host.startsWith('192.168.')) return false;
+
+    final parts = host.split('.');
+    if (parts.length == 4 && parts[0] == '172') {
+      final second = int.tryParse(parts[1]);
+      if (second != null && second >= 16 && second <= 31) return false;
+    }
+
+    if (host == '0.0.0.0') return false;
+    return true;
+  }
+
+  static String? resolveUrl(Uri base, String? value) {
+    if (value == null || value.isEmpty) return null;
+    final parsed = Uri.tryParse(value);
+    if (parsed == null) return null;
+    if (parsed.hasScheme) return value;
+    return base.resolve(value).toString();
+  }
+}

--- a/lib/util/url_detector.dart
+++ b/lib/util/url_detector.dart
@@ -1,0 +1,13 @@
+class UrlDetector {
+  UrlDetector._();
+
+  static final RegExp urlRegex = RegExp(
+    r'https?://[^\s<>\[\]{}|\\^`]+',
+    caseSensitive: false,
+  );
+
+  static String? firstUrl(String text) {
+    final match = urlRegex.firstMatch(text);
+    return match?.group(0);
+  }
+}

--- a/test/link_unfurl_parser_test.dart
+++ b/test/link_unfurl_parser_test.dart
@@ -1,0 +1,46 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:prysm/util/link_unfurl_parser.dart';
+import 'package:prysm/util/link_unfurl_policy.dart';
+
+void main() {
+  test('parses open graph metadata from html head', () {
+    const html = '''
+      <html><head>
+        <meta property="og:title" content="Example Site" />
+        <meta property="og:description" content="A short summary." />
+        <meta property="og:image" content="https://example.com/preview.png" />
+        <meta property="og:site_name" content="Example" />
+      </head></html>
+    ''';
+
+    final preview = LinkUnfurlParser.parse('https://example.com/page', html);
+    expect(preview, isNotNull);
+    expect(preview!.title, 'Example Site');
+    expect(preview.description, 'A short summary.');
+    expect(preview.imageUrl, 'https://example.com/preview.png');
+    expect(preview.siteName, 'Example');
+  });
+
+  test('allows onion and blocks local hosts', () {
+    expect(
+      LinkUnfurlPolicy.isSafeToUnfurl(Uri.parse('http://abc123.onion/page')),
+      isTrue,
+    );
+    expect(
+      LinkUnfurlPolicy.isSafeToUnfurl(Uri.parse('http://127.0.0.1/page')),
+      isFalse,
+    );
+    expect(
+      LinkUnfurlPolicy.isSafeToUnfurl(Uri.parse('https://example.com/page')),
+      isTrue,
+    );
+  });
+
+  test('resolves relative preview image urls', () {
+    final base = Uri.parse('https://example.com/blog/post');
+    expect(
+      LinkUnfurlPolicy.resolveUrl(base, '/assets/preview.png'),
+      'https://example.com/assets/preview.png',
+    );
+  });
+}


### PR DESCRIPTION
- Added LinkPreview model to represent link metadata.
- Introduced LinkUnfurlService for fetching and caching link previews.
- Created LinkUnfurlPreview widget to display link previews in chat.
- Implemented LinkedMessageText widget for clickable links with previews.
- Updated Settings to include an option for enabling link unfurling.
- Enhanced chat and group chat screens to utilize the new link unfurling feature.
- Added tests for link unfurling functionality and parsing logic.