### PR TITLE
feat: implement read receipt functionality

### DIFF
--- a/lib/constants/group_constants.dart
+++ b/lib/constants/group_constants.dart
@@ -21,6 +21,9 @@ const String groupReactionType = 'group_reaction';
 const String messageModifyType = 'message_modify';
 const String groupMessageModifyType = 'group_message_modify';
 
+const String readReceiptType = 'read_receipt';
+const String groupReadReceiptType = 'group_read_receipt';
+
 const Set<String> groupControlTypes = {
   groupInviteType,
   groupKeyRotateType,
@@ -42,10 +45,13 @@ const Set<String> messageModifyTypes = {
   groupMessageModifyType,
 };
 
+const Set<String> readReceiptTypes = {readReceiptType, groupReadReceiptType};
+
 bool isGroupControlType(String type) => groupControlTypes.contains(type);
 bool isGroupMessageType(String type) => groupMessageTypes.contains(type);
 bool isReactionType(String type) => reactionTypes.contains(type);
 bool isMessageModifyType(String type) => messageModifyTypes.contains(type);
+bool isReadReceiptType(String type) => readReceiptTypes.contains(type);
 
 /// Deterministic wire id for a reaction event (dedupe / pending queue).
 String reactionEventId({
@@ -53,3 +59,10 @@ String reactionEventId({
   required String reactorId,
 }) =>
     '$targetMessageId::$reactorId';
+
+/// Deterministic wire id for a read receipt event (dedupe / pending queue).
+String readReceiptEventId({
+  required String targetMessageId,
+  required String readerId,
+}) =>
+    '$targetMessageId::$readerId';

--- a/lib/database/message_read_receipts.dart
+++ b/lib/database/message_read_receipts.dart
@@ -1,0 +1,82 @@
+import 'package:prysm/database/messages.dart';
+import 'package:sqflite/sqflite.dart';
+
+class MessageReadReceiptsDb {
+  static Future<void> createTable(Database db) async {
+    await db.execute('''
+      CREATE TABLE IF NOT EXISTS message_read_receipts (
+        messageId TEXT NOT NULL,
+        groupId TEXT,
+        readerId TEXT NOT NULL,
+        readAt INTEGER NOT NULL,
+        PRIMARY KEY (messageId, readerId)
+      )
+    ''');
+    await db.execute(
+      'CREATE INDEX IF NOT EXISTS idx_read_receipts_group ON message_read_receipts(groupId)',
+    );
+  }
+
+  static String _storageId(String wireMessageId, {String? groupId}) =>
+      MessagesDb.scopedId(wireId: wireMessageId, groupId: groupId);
+
+  static Future<void> upsertReceipt({
+    required String wireMessageId,
+    required String readerId,
+    required int readAt,
+    String? groupId,
+  }) async {
+    final db = await MessagesDb.database;
+    final messageId = _storageId(wireMessageId, groupId: groupId);
+    await db.insert(
+      'message_read_receipts',
+      {
+        'messageId': messageId,
+        'groupId': groupId,
+        'readerId': readerId,
+        'readAt': readAt,
+      },
+      conflictAlgorithm: ConflictAlgorithm.replace,
+    );
+  }
+
+  static Future<List<Map<String, dynamic>>> getReceiptsForMessage({
+    required String wireMessageId,
+    String? groupId,
+  }) async {
+    final db = await MessagesDb.database;
+    final messageId = _storageId(wireMessageId, groupId: groupId);
+    return db.query(
+      'message_read_receipts',
+      where: 'messageId = ?',
+      whereArgs: [messageId],
+      orderBy: 'readAt ASC',
+    );
+  }
+
+  static Future<Map<String, List<Map<String, dynamic>>>> getReceiptsForMessages(
+    List<String> wireIds, {
+    String? groupId,
+  }) async {
+    if (wireIds.isEmpty) return {};
+    final db = await MessagesDb.database;
+    final storageIds = wireIds
+        .map((id) => _storageId(id, groupId: groupId))
+        .toList();
+    final placeholders = List.filled(storageIds.length, '?').join(',');
+    final rows = await db.query(
+      'message_read_receipts',
+      where: 'messageId IN ($placeholders)',
+      whereArgs: storageIds,
+      orderBy: 'readAt ASC',
+    );
+
+    final result = <String, List<Map<String, dynamic>>>{};
+    for (final row in rows) {
+      final storageMessageId = row['messageId'] as String;
+      final wireId = MessagesDb.wireIdFromStorage(storageMessageId);
+      result.putIfAbsent(wireId, () => []).add(row);
+    }
+    return result;
+  }
+}

--- a/lib/database/messages.dart
+++ b/lib/database/messages.dart
@@ -1,4 +1,5 @@
 import 'package:prysm/database/message_reactions.dart';
+import 'package:prysm/database/message_read_receipts.dart';
 import 'package:prysm/util/db_helper.dart';
 import 'package:path_provider/path_provider.dart';
 import 'package:sqflite/sqflite.dart';
@@ -11,7 +12,7 @@ class MessagesDb {
 	static final _openCompleter = Completer<Database>();
 	static final _dbMutex = Mutex();
 
-    static const _dbVersion = 8;
+    static const _dbVersion = 9;
 
 	static const String _directChatTypeFilter =
 		"(type IS NULL OR type IN ('text', 'file', 'image', 'audio'))";
@@ -50,6 +51,7 @@ class MessagesDb {
 					if (oldVersion < 6) await _upgradeToV6(db);
 					if (oldVersion < 7) await _upgradeToV7(db);
 					if (oldVersion < 8) await _upgradeToV8(db);
+					if (oldVersion < 9) await _upgradeToV9(db);
 				},
 				onDowngrade: (db, oldVersion, newVersion) async {
 					throw Exception('Database downgrade not supported: $oldVersion -> $newVersion');
@@ -107,6 +109,7 @@ class MessagesDb {
             'CREATE INDEX IF NOT EXISTS idx_read_status ON messages(readAt, status)'
         );
         await MessageReactionsDb.createTable(db);
+        await MessageReadReceiptsDb.createTable(db);
     }
 
 
@@ -190,6 +193,18 @@ class MessagesDb {
 		if (!columns.any((col) => col['name'] == 'editedAt')) {
 			await db.execute('ALTER TABLE messages ADD COLUMN editedAt INTEGER');
 		}
+	}
+
+	static Future<void> _upgradeToV9(Database db) async {
+		print('UPGRADING DB TO v9');
+		await MessageReadReceiptsDb.createTable(db);
+		// Outbound rows had readAt set on delivery — not peer read confirmations.
+		await db.execute('''
+			UPDATE messages
+			SET readAt = NULL
+			WHERE COALESCE(status, '') = 'sent'
+			  AND COALESCE(status, '') != 'received'
+		''');
 	}
 
 	/// Storage primary key: group messages are scoped per group to avoid cross-group REPLACE.
@@ -501,6 +516,68 @@ class MessagesDb {
             );
         });
     }
+
+	/// Mark inbound direct messages as read locally. Returns wire IDs newly marked.
+	static Future<List<String>> markInboundConversationRead(
+		String localUserId,
+		String peerId,
+	) async {
+		return await _dbMutex.protect(() async {
+			final db = await database;
+			final now = DateTime.now().millisecondsSinceEpoch;
+			final rows = await db.query(
+				'messages',
+				columns: ['id'],
+				where:
+					'groupId IS NULL AND senderId = ? AND receiverId = ? AND status = ? AND readAt IS NULL',
+				whereArgs: [peerId, localUserId, 'received'],
+			);
+			if (rows.isEmpty) return <String>[];
+
+			await db.update(
+				'messages',
+				{'readAt': now},
+				where:
+					'groupId IS NULL AND senderId = ? AND receiverId = ? AND status = ? AND readAt IS NULL',
+				whereArgs: [peerId, localUserId, 'received'],
+			);
+
+			return rows
+				.map((r) => wireIdFromStorage(r['id'] as String))
+				.toList();
+		});
+	}
+
+	/// Mark inbound group messages as read locally. Returns wire IDs newly marked.
+	static Future<List<String>> markInboundGroupRead(
+		String localUserId,
+		String groupId,
+	) async {
+		return await _dbMutex.protect(() async {
+			final db = await database;
+			final now = DateTime.now().millisecondsSinceEpoch;
+			final rows = await db.query(
+				'messages',
+				columns: ['id'],
+				where:
+					'groupId = ? AND senderId != ? AND status = ? AND readAt IS NULL',
+				whereArgs: [groupId, localUserId, 'received'],
+			);
+			if (rows.isEmpty) return <String>[];
+
+			await db.update(
+				'messages',
+				{'readAt': now},
+				where:
+					'groupId = ? AND senderId != ? AND status = ? AND readAt IS NULL',
+				whereArgs: [groupId, localUserId, 'received'],
+			);
+
+			return rows
+				.map((r) => wireIdFromStorage(r['id'] as String))
+				.toList();
+		});
+	}
 
     static Future<void> updateMessageStatus(
 		String messageId,

--- a/lib/screens/chat.dart
+++ b/lib/screens/chat.dart
@@ -26,6 +26,13 @@ import 'package:prysm/services/file_attachment_resolver.dart';
 import 'package:prysm/screens/widgets/deleted_message_bubble.dart';
 import 'package:prysm/services/message_modify_service.dart';
 import 'package:prysm/services/reaction_service.dart';
+import 'package:prysm/services/read_receipt_service.dart';
+import 'package:prysm/services/settings_service.dart';
+import 'package:prysm/database/message_read_receipts.dart';
+import 'package:prysm/screens/widgets/message_status_icon.dart';
+import 'package:prysm/screens/widgets/read_receipt_details_sheet.dart';
+import 'package:prysm/util/message_status_mapper.dart';
+import 'package:prysm/util/read_receipt_refresh_notifier.dart';
 import 'package:prysm/util/message_modify_policy.dart';
 import 'package:prysm/util/message_modify_refresh_notifier.dart';
 import 'package:prysm/util/reaction_refresh_notifier.dart';
@@ -86,6 +93,8 @@ class _ChatScreenState extends State<ChatScreen> {
   // ✅ ADD ChatService
   late ChatService _chatService;
   late ReactionService _reactionService;
+  late ReadReceiptService _readReceiptService;
+  final _settings = SettingsService();
 
   var _messages = InMemoryChatController();
   final Map<String, Message> _messageCache = {};
@@ -120,6 +129,8 @@ class _ChatScreenState extends State<ChatScreen> {
   StreamSubscription? _reactionSub;
   StreamSubscription? _reactionRefreshSub;
   StreamSubscription? _modifyRefreshSub;
+  StreamSubscription? _readReceiptRefreshSub;
+  Timer? _readReceiptDebounce;
   late MessageModifyService _modifyService;
 
   void _scrollListener() {
@@ -146,6 +157,11 @@ class _ChatScreenState extends State<ChatScreen> {
       keyManager: widget.keyManager,
     );
     _reactionService = ReactionService.direct(
+      userId: widget.userId,
+      keyManager: widget.keyManager,
+      peerId: widget.peerId,
+    );
+    _readReceiptService = ReadReceiptService.direct(
       userId: widget.userId,
       keyManager: widget.keyManager,
       peerId: widget.peerId,
@@ -204,8 +220,12 @@ class _ChatScreenState extends State<ChatScreen> {
         ReactionRefreshNotifier.instance.onReactionChanged.listen(_applyReactionUpdate);
     _modifyRefreshSub = MessageModifyRefreshNotifier.instance.onModifyChanged
         .listen(_applyModifyUpdate);
+    _readReceiptRefreshSub =
+        ReadReceiptRefreshNotifier.instance.onReadReceiptChanged
+            .listen(_applyReadReceiptUpdate);
 
     await _loadInitialMessages();
+    await _markInboundAsRead();
 
     if (mounted && _messages.messages.isNotEmpty) {
       WidgetsBinding.instance.addPostFrameCallback((_) {
@@ -241,6 +261,7 @@ class _ChatScreenState extends State<ChatScreen> {
           }
         }
       });
+      await _markInboundAsRead();
     } catch (e) {
       debugPrint('Error handling new messages: $e');
     }
@@ -254,21 +275,52 @@ class _ChatScreenState extends State<ChatScreen> {
     if (idx != -1) {
       setState(() {
         final msg = _messages.messages[idx];
-
-        if (update.status == 'read') {
-          _messages.updateMessage(msg, msg.copyWith(seenAt: DateTime.now()));
-        } else if (update.status == 'failed') {
-          _messages.updateMessage(msg, msg.copyWith(
-            metadata: {...?msg.metadata, 'failed': true},
-          ));
-        } else if (update.status == 'pending') {
-          // Resend in progress — clear failed flag
-          _messages.updateMessage(msg, msg.copyWith(
-            metadata: {...?msg.metadata, 'failed': false},
-          ));
-        }
+        final updated = messageWithDeliveryUpdate(
+          msg,
+          status: update.status,
+          readReceiptsEnabled: _settings.sendReadReceipts,
+        );
+        _messages.updateMessage(msg, updated);
+        _messageCache[msg.id] = updated;
       });
     }
+  }
+
+  Future<void> _markInboundAsRead() async {
+    final wireIds = await MessagesDb.markInboundConversationRead(
+      widget.userId,
+      widget.peerId,
+    );
+    if (wireIds.isEmpty) return;
+
+    _readReceiptDebounce?.cancel();
+    _readReceiptDebounce = Timer(const Duration(milliseconds: 300), () async {
+      if (_settings.sendReadReceipts) {
+        await _readReceiptService.sendReceiptsForMessages(wireIds);
+      }
+    });
+  }
+
+  void _applyReadReceiptUpdate(ReadReceiptUpdate update) {
+    if (!mounted || !_settings.sendReadReceipts) return;
+    if (update.groupId != null) return;
+
+    try {
+      final msg = _messages.messages.firstWhere((m) => m.id == update.targetMessageId);
+      if (msg.authorId != widget.userId) return;
+      if (!update.allRead) return;
+
+      final latest = update.readByMemberId.values.reduce(max);
+      final updated = msg.copyWith(
+        sentAt: msg.sentAt ?? DateTime.now(),
+        seenAt: DateTime.fromMillisecondsSinceEpoch(latest),
+        metadata: {...?msg.metadata, 'deliveryStatus': 'read'},
+      );
+      setState(() {
+        _messages.updateMessage(msg, updated);
+        _messageCache[msg.id] = updated;
+      });
+    } catch (_) {}
   }
 
   @override
@@ -282,6 +334,8 @@ class _ChatScreenState extends State<ChatScreen> {
     _reactionSub?.cancel();
     _reactionRefreshSub?.cancel();
     _modifyRefreshSub?.cancel();
+    _readReceiptRefreshSub?.cancel();
+    _readReceiptDebounce?.cancel();
     _pingTimer?.cancel();
     _batterySaverSub?.cancel();
 
@@ -480,9 +534,6 @@ class _ChatScreenState extends State<ChatScreen> {
               createdAt: DateTime.fromMillisecondsSinceEpoch(msg['timestamp']),
               id: msg['id'],
               replyToMessageId: msg['replyTo'],
-              seenAt: msg['readAt'] != null
-                  ? DateTime.fromMillisecondsSinceEpoch(msg['readAt'])
-                  : null,
               text: _decryptDirectTextMessage(msg, keyManager),
               metadata: meta.isEmpty ? null : meta,
             ),
@@ -498,9 +549,6 @@ class _ChatScreenState extends State<ChatScreen> {
               replyToMessageId: msg['replyTo'],
               name: fileName,
               size: msg['fileSize'] ?? 0,
-              seenAt: msg['readAt'] != null
-                  ? DateTime.fromMillisecondsSinceEpoch(msg['readAt'] as int)
-                  : null,
               source: msg['message'],
             ),
           );
@@ -513,9 +561,6 @@ class _ChatScreenState extends State<ChatScreen> {
               replyToMessageId: msg['replyTo'],
               name: msg['fileName'] ?? 'voice_message.wav',
               size: msg['fileSize'] ?? 0,
-              seenAt: msg['readAt'] != null
-                  ? DateTime.fromMillisecondsSinceEpoch(msg['readAt'] as int)
-                  : null,
               source: msg['message'],
             ),
           );
@@ -532,9 +577,6 @@ class _ChatScreenState extends State<ChatScreen> {
                 createdAt: DateTime.fromMillisecondsSinceEpoch(msg['timestamp']),
                 replyToMessageId: msg['replyTo'],
                 size: 0,
-                seenAt: msg['readAt'] != null
-                    ? DateTime.fromMillisecondsSinceEpoch(msg['readAt'] as int)
-                    : null,
                 source: "",
                 metadata: {'viewOnce': true, 'viewed': true},
               ),
@@ -547,9 +589,6 @@ class _ChatScreenState extends State<ChatScreen> {
                 createdAt: DateTime.fromMillisecondsSinceEpoch(msg['timestamp']),
                 replyToMessageId: msg['replyTo'],
                 size: msg['fileSize'] ?? 0,
-                seenAt: msg['readAt'] != null
-                    ? DateTime.fromMillisecondsSinceEpoch(msg['readAt'] as int)
-                    : null,
                 source:
                     "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==",
                 metadata: isViewOnce ? {'viewOnce': true, 'viewed': false} : null,
@@ -566,9 +605,6 @@ class _ChatScreenState extends State<ChatScreen> {
                   createdAt: DateTime.fromMillisecondsSinceEpoch(msg['timestamp']),
                   replyToMessageId: msg['replyTo'],
                   size: decryptedBytes.length,
-                  seenAt: msg['readAt'] != null
-                      ? DateTime.fromMillisecondsSinceEpoch(msg['readAt'] as int)
-                      : null,
                   source:
                       "data:image/png;base64,${base64Encode(decryptedBytes)}",
                 );
@@ -595,7 +631,8 @@ class _ChatScreenState extends State<ChatScreen> {
         );
       }
     }
-    return _attachReactions(messages);
+    final withReactions = await _attachReactions(messages);
+    return _attachOutboundStatus(withReactions, rawMessages);
   }
 
   Future<List<Message>> _attachReactions(List<Message> messages) async {
@@ -607,6 +644,41 @@ class _ChatScreenState extends State<ChatScreen> {
         .toList();
   }
 
+  Future<List<Message>> _attachOutboundStatus(
+    List<Message> messages,
+    List<Map<String, dynamic>> rawRows,
+  ) async {
+    final readReceiptsEnabled = _settings.sendReadReceipts;
+    final outboundWireIds = <String>[];
+    final rowByWireId = <String, Map<String, dynamic>>{};
+
+    for (final row in rawRows) {
+      final wireId = MessagesDb.wireIdFromStorage(row['id'] as String);
+      if (row['senderId'] == widget.userId) {
+        outboundWireIds.add(wireId);
+        rowByWireId[wireId] = row;
+      }
+    }
+
+    if (outboundWireIds.isEmpty) return messages;
+
+    final receipts =
+        await MessageReadReceiptsDb.getReceiptsForMessages(outboundWireIds);
+
+    return messages.map((m) {
+      final row = rowByWireId[m.id];
+      if (row == null) return m;
+      final status = outboundStatusFromDbRow(
+        row: row,
+        localUserId: widget.userId,
+        readReceiptsEnabled: readReceiptsEnabled,
+        receipts: receipts[m.id] ?? const [],
+        requiredReadCount: 1,
+      );
+      return applyOutboundStatus(m, status: status);
+    }).toList();
+  }
+
   Message _deletedMessageFromRow(
     Map<String, dynamic> msg,
     Map<String, Object?> meta,
@@ -616,9 +688,6 @@ class _ChatScreenState extends State<ChatScreen> {
       createdAt: DateTime.fromMillisecondsSinceEpoch(msg['timestamp'] as int),
       id: msg['id'] as String,
       replyToMessageId: msg['replyTo'] as String?,
-      seenAt: msg['readAt'] != null
-          ? DateTime.fromMillisecondsSinceEpoch(msg['readAt'] as int)
-          : null,
       text: '',
       metadata: meta,
     );
@@ -835,13 +904,14 @@ class _ChatScreenState extends State<ChatScreen> {
 
     setState(() {
       _messages.insertMessage(
-        TextMessage(
-          authorId: _user.id,
-          createdAt: DateTime.now(),
-          id: messageId,
-          text: text,
-          sentAt: DateTime.now(), // Optimistic: show single tick
-          replyToMessageId: replyToId,
+        messageWithPendingStatus(
+          TextMessage(
+            authorId: _user.id,
+            createdAt: DateTime.now(),
+            id: messageId,
+            text: text,
+            replyToMessageId: replyToId,
+          ),
         ),
         index: _messages.messages.length,
       );
@@ -875,29 +945,31 @@ class _ChatScreenState extends State<ChatScreen> {
     setState(() {
       if (type == "file") {
         _messages.insertMessage(
-          FileMessage(
-            authorId: _user.id,
-            createdAt: DateTime.now(),
-            id: messageId,
-            name: fileName,
-            size: bytes.length,
-            replyToMessageId: replyToId,
-            source: base64Encode(bytes),
-            sentAt: DateTime.now(),
+          messageWithPendingStatus(
+            FileMessage(
+              authorId: _user.id,
+              createdAt: DateTime.now(),
+              id: messageId,
+              name: fileName,
+              size: bytes.length,
+              replyToMessageId: replyToId,
+              source: base64Encode(bytes),
+            ),
           ),
           index: _messages.messages.length,
         );
       } else if (type == "image") {
         _messages.insertMessage(
-          ImageMessage(
-            authorId: _user.id,
-            createdAt: DateTime.now(),
-            id: messageId,
-            size: bytes.length,
-            replyToMessageId: replyToId,
-            source: "data:image/png;base64,${base64Encode(bytes.toList())}",
-            sentAt: DateTime.now(),
-            metadata: viewOnce ? {'viewOnce': true, 'viewed': false} : null,
+          messageWithPendingStatus(
+            ImageMessage(
+              authorId: _user.id,
+              createdAt: DateTime.now(),
+              id: messageId,
+              size: bytes.length,
+              replyToMessageId: replyToId,
+              source: "data:image/png;base64,${base64Encode(bytes.toList())}",
+              metadata: viewOnce ? {'viewOnce': true, 'viewed': false} : null,
+            ),
           ),
           index: _messages.messages.length,
         );
@@ -1017,15 +1089,16 @@ class _ChatScreenState extends State<ChatScreen> {
 
     setState(() {
       _messages.insertMessage(
-        FileMessage(
-          authorId: _user.id,
-          createdAt: DateTime.now(),
-          id: messageId,
-          name: 'voice_message.wav',
-          size: bytes.length,
-          source: 'audio:$durationMs:$cachePath',
-          sentAt: DateTime.now(),
-          metadata: {'waveform': waveformMeta},
+        messageWithPendingStatus(
+          FileMessage(
+            authorId: _user.id,
+            createdAt: DateTime.now(),
+            id: messageId,
+            name: 'voice_message.wav',
+            size: bytes.length,
+            source: 'audio:$durationMs:$cachePath',
+            metadata: {'waveform': waveformMeta},
+          ),
         ),
         index: _messages.messages.length,
       );
@@ -1182,6 +1255,15 @@ class _ChatScreenState extends State<ChatScreen> {
             _editMessage(message);
           },
         ),
+      if (isSentByMe)
+        ListTile(
+          leading: const Icon(Icons.info_outline),
+          title: const Text('Info'),
+          onTap: () {
+            Navigator.pop(context);
+            _openMessageInfo(message);
+          },
+        ),
       ListTile(
         leading: const Icon(Icons.reply),
         title: const Text('Reply'),
@@ -1242,31 +1324,34 @@ class _ChatScreenState extends State<ChatScreen> {
     _chatService.resendMessage(message.id);
   }
 
-  /// Build tick/status widget for sent messages. Shows ⚠ for failed.
+  String _deliveryStatusLabel(Message message) {
+    if (message.metadata?['failed'] == true) return 'Failed';
+    if (isOutboundPending(message)) return 'Pending';
+    if (_settings.sendReadReceipts && message.seenAt != null) return 'Read';
+    if (message.sentAt != null) return 'Delivered';
+    return 'Pending';
+  }
+
+  void _openMessageInfo(Message message) {
+    ReadReceiptDetailsSheet.show(
+      context,
+      messageId: message.id,
+      localUserId: widget.userId,
+      messageAuthorId: message.authorId,
+      directPeerId: widget.peerId,
+      deliveryStatusLabel: _deliveryStatusLabel(message),
+      showReadSection: _settings.sendReadReceipts,
+    );
+  }
+
   Widget _buildStatusWidget(Message message, bool isSentByMe, Color tickColor) {
-    if (!isSentByMe) return const SizedBox.shrink();
-
-    final isFailed = message.metadata?['failed'] == true;
-    if (isFailed) {
-      return GestureDetector(
-        onTap: () => _resendMessage(message),
-        child: Row(
-          mainAxisSize: MainAxisSize.min,
-          children: [
-            Icon(Icons.warning_amber_rounded, size: 14, color: Colors.red[400]),
-            const SizedBox(width: 2),
-            Text('Tap to retry', style: TextStyle(fontSize: 9, color: Colors.red[400])),
-          ],
-        ),
-      );
-    }
-
-    if (message.seenAt != null) {
-      return Icon(Icons.done_all, size: 14, color: tickColor);
-    } else if (message.sentAt != null) {
-      return Icon(Icons.done, size: 14, color: tickColor.withAlpha(140));
-    }
-    return const SizedBox.shrink();
+    return MessageStatusIcon(
+      message: message,
+      isSentByMe: isSentByMe,
+      tickColor: tickColor,
+      readReceiptsEnabled: _settings.sendReadReceipts,
+      onRetry: () => _resendMessage(message),
+    );
   }
 
   Future<void> deleteSelectedMessages() async {

--- a/lib/screens/group_chat.dart
+++ b/lib/screens/group_chat.dart
@@ -29,6 +29,13 @@ import 'package:prysm/services/file_attachment_resolver.dart';
 import 'package:prysm/screens/widgets/deleted_message_bubble.dart';
 import 'package:prysm/services/message_modify_service.dart';
 import 'package:prysm/services/reaction_service.dart';
+import 'package:prysm/services/read_receipt_service.dart';
+import 'package:prysm/services/settings_service.dart';
+import 'package:prysm/database/message_read_receipts.dart';
+import 'package:prysm/screens/widgets/message_status_icon.dart';
+import 'package:prysm/screens/widgets/read_receipt_details_sheet.dart';
+import 'package:prysm/util/message_status_mapper.dart';
+import 'package:prysm/util/read_receipt_refresh_notifier.dart';
 import 'package:prysm/util/message_modify_policy.dart';
 import 'package:prysm/util/message_modify_refresh_notifier.dart';
 import 'package:prysm/util/reaction_refresh_notifier.dart';
@@ -68,8 +75,10 @@ class _GroupChatScreenState extends State<GroupChatScreen> {
   late GroupService _groupService;
   late GroupChatService _chatService;
   late ReactionService _reactionService;
+  late ReadReceiptService _readReceiptService;
   late MessageModifyService _modifyService;
   late User _user;
+  final _settings = SettingsService();
 
   var _messages = InMemoryChatController();
   final Map<String, String> _senderNames = {};
@@ -87,6 +96,9 @@ class _GroupChatScreenState extends State<GroupChatScreen> {
   StreamSubscription? _reactionRefreshSub;
   StreamSubscription? _modifyRefreshSub;
   StreamSubscription? _membershipSub;
+  StreamSubscription? _readReceiptRefreshSub;
+  Timer? _readReceiptDebounce;
+  List<String> _groupMemberIds = [];
 
   Message? _replyToMessage;
   final Set<String> selectedMessageIds = {};
@@ -108,6 +120,12 @@ class _GroupChatScreenState extends State<GroupChatScreen> {
       groupService: _groupService,
     );
     _reactionService = ReactionService.group(
+      userId: widget.userId,
+      keyManager: widget.keyManager,
+      groupId: widget.group.id,
+      groupService: _groupService,
+    );
+    _readReceiptService = ReadReceiptService.group(
       userId: widget.userId,
       keyManager: widget.keyManager,
       groupId: widget.group.id,
@@ -145,6 +163,8 @@ class _GroupChatScreenState extends State<GroupChatScreen> {
     _reactionRefreshSub?.cancel();
     _modifyRefreshSub?.cancel();
     _membershipSub?.cancel();
+    _readReceiptRefreshSub?.cancel();
+    _readReceiptDebounce?.cancel();
     _chatService.dispose();
     _reactionService.dispose();
   }
@@ -179,7 +199,8 @@ class _GroupChatScreenState extends State<GroupChatScreen> {
 
     final members = await _groupService.getMembers(widget.group.id);
     _memberCount = members.length;
-    await _resolveSenderNames(members.map((m) => m.memberId).toList());
+    _groupMemberIds = members.map((m) => m.memberId).toList();
+    await _resolveSenderNames(_groupMemberIds);
 
     final ok = await _chatService.initialize();
     if (!ok && mounted) {
@@ -196,8 +217,12 @@ class _GroupChatScreenState extends State<GroupChatScreen> {
         ReactionRefreshNotifier.instance.onReactionChanged.listen(_applyReactionUpdate);
     _modifyRefreshSub = MessageModifyRefreshNotifier.instance.onModifyChanged
         .listen(_applyModifyUpdate);
+    _readReceiptRefreshSub =
+        ReadReceiptRefreshNotifier.instance.onReadReceiptChanged
+            .listen(_applyReadReceiptUpdate);
 
     await _loadMoreMessages();
+    await _markInboundAsRead();
     _chatService.startPolling();
     _chatService.startSendQueue();
 
@@ -267,6 +292,15 @@ class _GroupChatScreenState extends State<GroupChatScreen> {
             onTap: () {
               Navigator.pop(context);
               _editMessage(message);
+            },
+          ),
+        if (isSentByMe)
+          ListTile(
+            leading: const Icon(Icons.info_outline),
+            title: const Text('Info'),
+            onTap: () {
+              Navigator.pop(context);
+              _openMessageInfo(message);
             },
           ),
         ListTile(
@@ -565,6 +599,7 @@ class _GroupChatScreenState extends State<GroupChatScreen> {
         }
       }
     });
+    await _markInboundAsRead();
   }
 
   void _handleStatusUpdate(GroupMessageStatusUpdate update) {
@@ -573,41 +608,49 @@ class _GroupChatScreenState extends State<GroupChatScreen> {
     if (idx == -1) return;
     final msg = _messages.messages[idx];
     setState(() {
-      if (msg is TextMessage) {
-        _messages.updateMessage(
-          msg,
-          msg.copyWith(
-            seenAt: update.status == 'read' ? DateTime.now() : msg.seenAt,
-            metadata: {
-              ...?msg.metadata,
-              'failed': update.status == 'failed',
-            },
-          ),
-        );
-      } else if (msg is ImageMessage) {
-        _messages.updateMessage(
-          msg,
-          msg.copyWith(
-            seenAt: update.status == 'read' ? DateTime.now() : msg.seenAt,
-            metadata: {
-              ...?msg.metadata,
-              'failed': update.status == 'failed',
-            },
-          ),
-        );
-      } else if (msg is FileMessage) {
-        _messages.updateMessage(
-          msg,
-          msg.copyWith(
-            seenAt: update.status == 'read' ? DateTime.now() : msg.seenAt,
-            metadata: {
-              ...?msg.metadata,
-              'failed': update.status == 'failed',
-            },
-          ),
-        );
+      final updated = messageWithDeliveryUpdate(
+        msg,
+        status: update.status,
+        readReceiptsEnabled: _settings.sendReadReceipts,
+      );
+      _messages.updateMessage(msg, updated);
+    });
+  }
+
+  Future<void> _markInboundAsRead() async {
+    final wireIds = await MessagesDb.markInboundGroupRead(
+      widget.userId,
+      widget.group.id,
+    );
+    if (wireIds.isEmpty) return;
+
+    _readReceiptDebounce?.cancel();
+    _readReceiptDebounce = Timer(const Duration(milliseconds: 300), () async {
+      if (_settings.sendReadReceipts) {
+        await _readReceiptService.sendReceiptsForMessages(wireIds);
       }
     });
+  }
+
+  void _applyReadReceiptUpdate(ReadReceiptUpdate update) {
+    if (!mounted || !_settings.sendReadReceipts) return;
+    if (update.groupId != widget.group.id) return;
+
+    try {
+      final msg = _messages.messages.firstWhere((m) => m.id == update.targetMessageId);
+      if (msg.authorId != widget.userId) return;
+      if (!update.allRead) return;
+
+      final latest = update.readByMemberId.values.reduce(max);
+      final updated = msg.copyWith(
+        sentAt: msg.sentAt ?? DateTime.now(),
+        seenAt: DateTime.fromMillisecondsSinceEpoch(latest),
+        metadata: {...?msg.metadata, 'deliveryStatus': 'read'},
+      );
+      setState(() {
+        _messages.updateMessage(msg, updated);
+      });
+    } catch (_) {}
   }
 
   void _resendMessage(Message message) {
@@ -658,9 +701,6 @@ class _GroupChatScreenState extends State<GroupChatScreen> {
         final createdAt = DateTime.fromMillisecondsSinceEpoch(msg['timestamp'] as int);
         final id = MessagesDb.wireIdFromStorage(msg['id'] as String);
         final replyTo = msg['replyTo'] as String?;
-        final seenAt = msg['readAt'] != null
-            ? DateTime.fromMillisecondsSinceEpoch(msg['readAt'] as int)
-            : null;
         final meta = metadataFromDbRow(msg);
 
         if (meta['deleted'] == true) {
@@ -669,7 +709,6 @@ class _GroupChatScreenState extends State<GroupChatScreen> {
             createdAt: createdAt,
             id: id,
             replyToMessageId: replyTo,
-            seenAt: seenAt,
             text: '',
             metadata: meta,
           ));
@@ -684,7 +723,6 @@ class _GroupChatScreenState extends State<GroupChatScreen> {
             id: id,
             text: text,
             replyToMessageId: replyTo,
-            seenAt: seenAt,
             metadata: meta.isEmpty ? null : meta,
           ));
         } else if (type == groupImageType) {
@@ -697,7 +735,6 @@ class _GroupChatScreenState extends State<GroupChatScreen> {
               createdAt: createdAt,
               replyToMessageId: replyTo,
               size: 0,
-              seenAt: seenAt,
               source: '',
               metadata: const {'viewOnce': true, 'viewed': true},
             ));
@@ -708,7 +745,6 @@ class _GroupChatScreenState extends State<GroupChatScreen> {
               createdAt: createdAt,
               replyToMessageId: replyTo,
               size: msg['fileSize'] as int? ?? 0,
-              seenAt: seenAt,
               source: '',
               metadata: const {'viewOnce': true, 'viewed': false},
             ));
@@ -720,7 +756,6 @@ class _GroupChatScreenState extends State<GroupChatScreen> {
               createdAt: createdAt,
               replyToMessageId: replyTo,
               size: bytes.length,
-              seenAt: seenAt,
               source: 'data:image/png;base64,${base64Encode(bytes)}',
             ));
           }
@@ -739,7 +774,6 @@ class _GroupChatScreenState extends State<GroupChatScreen> {
               replyToMessageId: replyTo,
               name: msg['fileName'] as String? ?? 'voice_message.wav',
               size: bytes.length,
-              seenAt: seenAt,
               source: 'audio:$durationMs:$cachePath',
               metadata: {'waveform': WaveformExtractor.encodePeaks(peaks)},
             ));
@@ -752,7 +786,6 @@ class _GroupChatScreenState extends State<GroupChatScreen> {
               replyToMessageId: replyTo,
               name: fileName,
               size: bytes.length,
-              seenAt: seenAt,
               source: base64Encode(bytes),
             ));
           }
@@ -779,7 +812,47 @@ class _GroupChatScreenState extends State<GroupChatScreen> {
       }
     }
 
-    return _attachReactions(result);
+    final withReactions = await _attachReactions(result);
+    return _attachOutboundStatus(withReactions, raw);
+  }
+
+  Future<List<Message>> _attachOutboundStatus(
+    List<Message> messages,
+    List<Map<String, dynamic>> rawRows,
+  ) async {
+    final readReceiptsEnabled = _settings.sendReadReceipts;
+    final outboundWireIds = <String>[];
+    final rowByWireId = <String, Map<String, dynamic>>{};
+
+    for (final row in rawRows) {
+      final wireId = MessagesDb.wireIdFromStorage(row['id'] as String);
+      if (row['senderId'] == widget.userId) {
+        outboundWireIds.add(wireId);
+        rowByWireId[wireId] = row;
+      }
+    }
+
+    if (outboundWireIds.isEmpty) return messages;
+
+    final receipts = await MessageReadReceiptsDb.getReceiptsForMessages(
+      outboundWireIds,
+      groupId: widget.group.id,
+    );
+
+    final requiredReadCount = _memberCount > 1 ? _memberCount - 1 : 1;
+
+    return messages.map((m) {
+      final row = rowByWireId[m.id];
+      if (row == null) return m;
+      final status = outboundStatusFromDbRow(
+        row: row,
+        localUserId: widget.userId,
+        readReceiptsEnabled: readReceiptsEnabled,
+        receipts: receipts[m.id] ?? const [],
+        requiredReadCount: requiredReadCount,
+      );
+      return applyOutboundStatus(m, status: status);
+    }).toList();
   }
 
   Future<void> _loadMoreMessages() async {
@@ -827,13 +900,14 @@ class _GroupChatScreenState extends State<GroupChatScreen> {
     final replyToId = _replyToMessage?.id;
     setState(() {
       _messages.insertMessage(
-        TextMessage(
-          authorId: _user.id,
-          createdAt: DateTime.now(),
-          id: messageId,
-          text: text,
-          sentAt: DateTime.now(),
-          replyToMessageId: replyToId,
+        messageWithPendingStatus(
+          TextMessage(
+            authorId: _user.id,
+            createdAt: DateTime.now(),
+            id: messageId,
+            text: text,
+            replyToMessageId: replyToId,
+          ),
         ),
         index: _messages.messages.length,
       );
@@ -857,27 +931,29 @@ class _GroupChatScreenState extends State<GroupChatScreen> {
     setState(() {
       if (type == 'file') {
         _messages.insertMessage(
-          FileMessage(
-            authorId: _user.id,
-            createdAt: DateTime.now(),
-            id: messageId,
-            name: fileName,
-            size: bytes.length,
-            source: base64Encode(bytes),
-            sentAt: DateTime.now(),
+          messageWithPendingStatus(
+            FileMessage(
+              authorId: _user.id,
+              createdAt: DateTime.now(),
+              id: messageId,
+              name: fileName,
+              size: bytes.length,
+              source: base64Encode(bytes),
+            ),
           ),
           index: _messages.messages.length,
         );
       } else if (type == 'image') {
         _messages.insertMessage(
-          ImageMessage(
-            authorId: _user.id,
-            createdAt: DateTime.now(),
-            id: messageId,
-            size: bytes.length,
-            source: 'data:image/png;base64,${base64Encode(bytes)}',
-            sentAt: DateTime.now(),
-            metadata: viewOnce ? const {'viewOnce': true, 'viewed': false} : null,
+          messageWithPendingStatus(
+            ImageMessage(
+              authorId: _user.id,
+              createdAt: DateTime.now(),
+              id: messageId,
+              size: bytes.length,
+              source: 'data:image/png;base64,${base64Encode(bytes)}',
+              metadata: viewOnce ? const {'viewOnce': true, 'viewed': false} : null,
+            ),
           ),
           index: _messages.messages.length,
         );
@@ -962,15 +1038,16 @@ class _GroupChatScreenState extends State<GroupChatScreen> {
 
     setState(() {
       _messages.insertMessage(
-        FileMessage(
-          authorId: _user.id,
-          createdAt: DateTime.now(),
-          id: messageId,
-          name: 'voice_message.wav',
-          size: bytes.length,
-          source: 'audio:$durationMs:$cachePath',
-          sentAt: DateTime.now(),
-          metadata: {'waveform': WaveformExtractor.encodePeaks(peaks)},
+        messageWithPendingStatus(
+          FileMessage(
+            authorId: _user.id,
+            createdAt: DateTime.now(),
+            id: messageId,
+            name: 'voice_message.wav',
+            size: bytes.length,
+            source: 'audio:$durationMs:$cachePath',
+            metadata: {'waveform': WaveformExtractor.encodePeaks(peaks)},
+          ),
         ),
         index: _messages.messages.length,
       );
@@ -1007,8 +1084,11 @@ class _GroupChatScreenState extends State<GroupChatScreen> {
           onChanged: () async {
             final members = await _groupService.getMembers(widget.group.id);
             if (mounted) {
-              setState(() => _memberCount = members.length);
-              await _resolveSenderNames(members.map((m) => m.memberId).toList());
+              setState(() {
+                _memberCount = members.length;
+                _groupMemberIds = members.map((m) => m.memberId).toList();
+              });
+              await _resolveSenderNames(_groupMemberIds);
             }
             widget.reloadConversations();
           },
@@ -1032,30 +1112,35 @@ class _GroupChatScreenState extends State<GroupChatScreen> {
     super.dispose();
   }
 
+  String _deliveryStatusLabel(Message message) {
+    if (message.metadata?['failed'] == true) return 'Failed';
+    if (isOutboundPending(message)) return 'Pending';
+    if (_settings.sendReadReceipts && message.seenAt != null) return 'Read';
+    if (message.sentAt != null) return 'Delivered';
+    return 'Pending';
+  }
+
+  void _openMessageInfo(Message message) {
+    ReadReceiptDetailsSheet.show(
+      context,
+      messageId: message.id,
+      localUserId: widget.userId,
+      groupId: widget.group.id,
+      messageAuthorId: message.authorId,
+      groupMemberIds: _groupMemberIds,
+      deliveryStatusLabel: _deliveryStatusLabel(message),
+      showReadSection: _settings.sendReadReceipts,
+    );
+  }
+
   Widget _buildStatusWidget(Message message, bool isSentByMe, Color tickColor) {
-    if (!isSentByMe) return const SizedBox.shrink();
-
-    final isFailed = message.metadata?['failed'] == true;
-    if (isFailed) {
-      return GestureDetector(
-        onTap: () => _resendMessage(message),
-        child: Row(
-          mainAxisSize: MainAxisSize.min,
-          children: [
-            Icon(Icons.warning_amber_rounded, size: 14, color: Colors.red[400]),
-            const SizedBox(width: 2),
-            Text('Tap to retry', style: TextStyle(fontSize: 9, color: Colors.red[400])),
-          ],
-        ),
-      );
-    }
-
-    if (message.seenAt != null) {
-      return Icon(Icons.done_all, size: 14, color: tickColor);
-    } else if (message.sentAt != null) {
-      return Icon(Icons.done, size: 14, color: tickColor.withAlpha(140));
-    }
-    return const SizedBox.shrink();
+    return MessageStatusIcon(
+      message: message,
+      isSentByMe: isSentByMe,
+      tickColor: tickColor,
+      readReceiptsEnabled: _settings.sendReadReceipts,
+      onRetry: () => _resendMessage(message),
+    );
   }
 
   Widget _groupTextMessageBuilder(

--- a/lib/screens/privacy_settings_screen.dart
+++ b/lib/screens/privacy_settings_screen.dart
@@ -37,7 +37,7 @@ class _PrivacySettingsScreenState extends State<PrivacySettingsScreen> {
     final prefs = await SharedPreferences.getInstance();
     setState(() {
       _showOnlineStatus = prefs.getBool('show_online_status') ?? true;
-      _readReceipts = prefs.getBool('read_receipts') ?? true;
+      _readReceipts = settings.sendReadReceipts;
       _lastSeen = prefs.getBool('last_seen') ?? true;
       _profilePhoto = prefs.getBool('profile_photo') ?? true;
     });
@@ -55,11 +55,11 @@ class _PrivacySettingsScreenState extends State<PrivacySettingsScreen> {
     _savePrivacySetting('show_online_status', value);
   }
 
-  void _onReadReceiptsToggle(bool value) {
+  Future<void> _onReadReceiptsToggle(bool value) async {
     setState(() {
       _readReceipts = value;
     });
-    _savePrivacySetting('read_receipts', value);
+    await settings.setSendReadReceipts(value);
   }
 
   void _onLastSeenToggle(bool value) {

--- a/lib/screens/widgets/message_status_icon.dart
+++ b/lib/screens/widgets/message_status_icon.dart
@@ -1,0 +1,59 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_chat_core/flutter_chat_core.dart';
+import 'package:prysm/util/message_status_mapper.dart';
+
+/// Tick / clock / failed status for outgoing messages.
+class MessageStatusIcon extends StatelessWidget {
+  final Message message;
+  final bool isSentByMe;
+  final Color tickColor;
+  final bool readReceiptsEnabled;
+  final VoidCallback? onRetry;
+
+  const MessageStatusIcon({
+    required this.message,
+    required this.isSentByMe,
+    required this.tickColor,
+    required this.readReceiptsEnabled,
+    this.onRetry,
+    super.key,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    if (!isSentByMe) return const SizedBox.shrink();
+
+    final isFailed = message.metadata?['failed'] == true;
+    if (isFailed) {
+      return GestureDetector(
+        onTap: onRetry,
+        child: Row(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Icon(Icons.warning_amber_rounded, size: 14, color: Colors.red[400]),
+            const SizedBox(width: 2),
+            Text(
+              'Tap to retry',
+              style: TextStyle(fontSize: 9, color: Colors.red[400]),
+            ),
+          ],
+        ),
+      );
+    }
+
+    final isRead = readReceiptsEnabled && message.seenAt != null;
+    if (isRead) {
+      return Icon(Icons.done_all, size: 14, color: tickColor);
+    }
+
+    if (message.sentAt != null) {
+      return Icon(Icons.done, size: 14, color: tickColor.withAlpha(140));
+    }
+
+    if (isOutboundPending(message)) {
+      return Icon(Icons.schedule, size: 14, color: tickColor.withAlpha(120));
+    }
+
+    return const SizedBox.shrink();
+  }
+}

--- a/lib/screens/widgets/read_receipt_details_sheet.dart
+++ b/lib/screens/widgets/read_receipt_details_sheet.dart
@@ -1,0 +1,223 @@
+import 'package:flutter/material.dart';
+import 'package:prysm/database/message_read_receipts.dart';
+import 'package:prysm/util/db_helper.dart';
+
+class ReadReceiptMember {
+  final String memberId;
+  final String displayName;
+  final int? readAt;
+  final bool isPending;
+
+  const ReadReceiptMember({
+    required this.memberId,
+    required this.displayName,
+    this.readAt,
+    this.isPending = false,
+  });
+}
+
+class ReadReceiptDetailsSheet extends StatelessWidget {
+  final String messageId;
+  final String? groupId;
+  final String localUserId;
+  final String? messageAuthorId;
+  final List<String>? groupMemberIds;
+  final String? directPeerId;
+  final String deliveryStatusLabel;
+  final bool showReadSection;
+
+  const ReadReceiptDetailsSheet({
+    required this.messageId,
+    required this.localUserId,
+    required this.deliveryStatusLabel,
+    this.groupId,
+    this.messageAuthorId,
+    this.groupMemberIds,
+    this.directPeerId,
+    this.showReadSection = true,
+    super.key,
+  });
+
+  static Future<void> show(
+    BuildContext context, {
+    required String messageId,
+    required String localUserId,
+    required String deliveryStatusLabel,
+    String? groupId,
+    String? messageAuthorId,
+    List<String>? groupMemberIds,
+    String? directPeerId,
+    bool showReadSection = true,
+  }) {
+    return showModalBottomSheet<void>(
+      context: context,
+      showDragHandle: true,
+      builder: (ctx) => ReadReceiptDetailsSheet(
+        messageId: messageId,
+        localUserId: localUserId,
+        deliveryStatusLabel: deliveryStatusLabel,
+        groupId: groupId,
+        messageAuthorId: messageAuthorId,
+        groupMemberIds: groupMemberIds,
+        directPeerId: directPeerId,
+        showReadSection: showReadSection,
+      ),
+    );
+  }
+
+  Future<List<ReadReceiptMember>> _loadMembers() async {
+    final receipts = await MessageReadReceiptsDb.getReceiptsForMessage(
+      wireMessageId: messageId,
+      groupId: groupId,
+    );
+    final readBy = <String, int>{
+      for (final row in receipts)
+        row['readerId'] as String: row['readAt'] as int,
+    };
+
+    if (groupId == null) {
+      final peerId = directPeerId ??
+          readBy.keys.firstWhere(
+            (id) => id != localUserId,
+            orElse: () => readBy.keys.isNotEmpty ? readBy.keys.first : '',
+          );
+      if (peerId.isEmpty) return [];
+      final user = await DBHelper.getUserById(peerId);
+      final name = user?['customName'] as String? ??
+          user?['name'] as String? ??
+          peerId;
+      return [
+        ReadReceiptMember(
+          memberId: peerId,
+          displayName: name,
+          readAt: readBy[peerId],
+          isPending: !readBy.containsKey(peerId),
+        ),
+      ];
+    }
+
+    final memberIds = groupMemberIds ??
+        (await DBHelper.getGroupMembers(groupId!))
+            .map((m) => m['memberId'] as String)
+            .toList();
+
+    final expected = memberIds
+        .where((id) => id != messageAuthorId && id != localUserId)
+        .toList();
+
+    final members = <ReadReceiptMember>[];
+    for (final id in expected) {
+      final user = await DBHelper.getUserById(id);
+      final name =
+          user?['customName'] as String? ?? user?['name'] as String? ?? id;
+      final readAt = readBy[id];
+      members.add(
+        ReadReceiptMember(
+          memberId: id,
+          displayName: name,
+          readAt: readAt,
+          isPending: readAt == null,
+        ),
+      );
+    }
+
+    members.sort((a, b) {
+      if (a.readAt == null && b.readAt == null) return 0;
+      if (a.readAt == null) return 1;
+      if (b.readAt == null) return -1;
+      return a.readAt!.compareTo(b.readAt!);
+    });
+    return members;
+  }
+
+  String _formatTime(int? millis) {
+    if (millis == null) return 'Pending';
+    final dt = DateTime.fromMillisecondsSinceEpoch(millis);
+    final hour = dt.hour.toString().padLeft(2, '0');
+    final minute = dt.minute.toString().padLeft(2, '0');
+    return '${dt.month}/${dt.day} $hour:$minute';
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return SafeArea(
+      child: Padding(
+        padding: const EdgeInsets.fromLTRB(16, 0, 16, 24),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(
+              'Message info',
+              style: Theme.of(context).textTheme.titleMedium,
+            ),
+            const SizedBox(height: 12),
+            ListTile(
+              contentPadding: EdgeInsets.zero,
+              leading: const Icon(Icons.local_shipping_outlined, size: 20),
+              title: const Text('Delivery'),
+              trailing: Text(
+                deliveryStatusLabel,
+                style: TextStyle(
+                  color: Theme.of(context).colorScheme.onSurfaceVariant,
+                ),
+              ),
+            ),
+            if (showReadSection) ...[
+              const Divider(height: 1),
+              Padding(
+                padding: const EdgeInsets.only(top: 8, bottom: 4),
+                child: Text(
+                  'Read by',
+                  style: Theme.of(context).textTheme.titleSmall,
+                ),
+              ),
+            ],
+            if (showReadSection)
+            FutureBuilder<List<ReadReceiptMember>>(
+              future: _loadMembers(),
+              builder: (context, snapshot) {
+                if (snapshot.connectionState == ConnectionState.waiting) {
+                  return const Padding(
+                    padding: EdgeInsets.all(24),
+                    child: Center(child: CircularProgressIndicator()),
+                  );
+                }
+                final members = snapshot.data ?? [];
+                if (members.isEmpty) {
+                  return const Padding(
+                    padding: EdgeInsets.all(16),
+                    child: Text('No read information available.'),
+                  );
+                }
+                return Flexible(
+                  child: ListView.separated(
+                    shrinkWrap: true,
+                    itemCount: members.length,
+                    separatorBuilder: (_, index) => const Divider(height: 1),
+                    itemBuilder: (context, index) {
+                      final member = members[index];
+                      return ListTile(
+                        contentPadding: EdgeInsets.zero,
+                        title: Text(member.displayName),
+                        trailing: Text(
+                          _formatTime(member.readAt),
+                          style: TextStyle(
+                            color: member.isPending
+                                ? Theme.of(context).colorScheme.outline
+                                : null,
+                            fontSize: 13,
+                          ),
+                        ),
+                      );
+                    },
+                  ),
+                );
+              },
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/server/PrysmServer.dart
+++ b/lib/server/PrysmServer.dart
@@ -14,6 +14,7 @@ import 'package:prysm/constants/group_constants.dart';
 import 'package:prysm/services/group_service.dart';
 import 'package:prysm/services/message_modify_service.dart';
 import 'package:prysm/services/reaction_service.dart';
+import 'package:prysm/services/read_receipt_service.dart';
 import 'package:prysm/services/notification_mute_service.dart';
 import 'package:prysm/services/settings_service.dart';
 import 'package:prysm/util/conversation_refresh_notifier.dart';
@@ -188,6 +189,59 @@ class PrysmServer {
         );
       }
 
+      // Read receipt side-channel — never stored in messages table
+      if (isReadReceiptType(type)) {
+        final receiverId = data['receiverId'] as String;
+        final senderId = data['senderId'] as String;
+
+        if (localOnionAddress != null) {
+          if (senderId == localOnionAddress) {
+            return Response.ok(
+              jsonEncode({'status': 'received', 'id': data['id']}),
+              headers: {'Content-Type': 'application/json'},
+            );
+          }
+          if (receiverId != localOnionAddress) {
+            return Response.forbidden(
+              jsonEncode({'error': 'Message not addressed to this node'}),
+              headers: {'Content-Type': 'application/json'},
+            );
+          }
+        }
+
+        if (type == groupReadReceiptType && data['groupId'] == null) {
+          return _badRequest('groupId required for group read receipts');
+        }
+
+        await DBHelper.ensureUserExist(senderId);
+
+        final localId = localOnionAddress ?? receiverId;
+        final groupService =
+            GroupService(userId: localId, keyManager: keyManager);
+
+        try {
+          await ReadReceiptService.applyInbound(
+            keyManager: keyManager,
+            encrypted: data['message'] as String,
+            senderId: senderId,
+            type: type,
+            groupId: data['groupId'] as String?,
+            groupService: groupService,
+          );
+        } catch (e) {
+          print('PrysmServer: read receipt handling failed: $e');
+          return Response.internalServerError(
+            body: jsonEncode({'error': 'Read receipt processing failed'}),
+            headers: {'Content-Type': 'application/json'},
+          );
+        }
+
+        return Response.ok(
+          jsonEncode({'status': 'received', 'id': data['id']}),
+          headers: {'Content-Type': 'application/json'},
+        );
+      }
+
       // Reaction side-channel — never stored in messages table
       if (isReactionType(type)) {
         final receiverId = data['receiverId'] as String;
@@ -306,7 +360,6 @@ class PrysmServer {
         if (data['fileName'] != null) 'fileName': data['fileName'] as String,
         if (data['fileSize'] != null) 'fileSize': data['fileSize'],
         'timestamp': messageTimestamp,
-        'readAt': timeReceived,
         'status': (data['status'] ?? 'received') as String,
         if (data['replyTo'] != null) 'replyTo': data['replyTo'],
         'viewOnce': (data['viewOnce'] == true || data['viewOnce'] == 1) ? 1 : 0,

--- a/lib/services/chat_service.dart
+++ b/lib/services/chat_service.dart
@@ -542,11 +542,8 @@ class ChatService {
 
   Future<void> _markAsSent(String messageId) async {
     await MessagesDb.updateMessageStatus(messageId, 'sent');
-    await MessagesDb.setAsRead(messageId);
-
-    // ✅ Only emit 'read' - UI already shows 'sent' optimistically
     if (!_disposed) {
-      _messageStatusController.add(MessageStatusUpdate(messageId, 'read'));
+      _messageStatusController.add(MessageStatusUpdate(messageId, 'sent'));
     }
   }
 

--- a/lib/services/group_chat_service.dart
+++ b/lib/services/group_chat_service.dart
@@ -638,9 +638,8 @@ class GroupChatService {
 
   Future<void> _markAsSent(String messageId) async {
     await MessagesDb.updateMessageStatus(messageId, 'sent', groupId: groupId);
-    await MessagesDb.setAsRead(messageId, groupId: groupId);
     if (!_disposed) {
-      _messageStatusController.add(GroupMessageStatusUpdate(messageId, 'read'));
+      _messageStatusController.add(GroupMessageStatusUpdate(messageId, 'sent'));
     }
   }
 }

--- a/lib/services/read_receipt_service.dart
+++ b/lib/services/read_receipt_service.dart
@@ -1,0 +1,401 @@
+import 'dart:async';
+import 'dart:convert';
+
+import 'package:prysm/client/TorHttpClient.dart';
+import 'package:prysm/constants/group_constants.dart';
+import 'package:prysm/database/message_read_receipts.dart';
+import 'package:prysm/database/messages.dart';
+import 'package:prysm/services/group_service.dart';
+import 'package:prysm/services/settings_service.dart';
+import 'package:prysm/util/db_helper.dart';
+import 'package:prysm/util/group_crypto.dart';
+import 'package:prysm/util/key_manager.dart';
+import 'package:prysm/util/pending_message_db_helper.dart';
+import 'package:prysm/util/read_receipt_payload.dart';
+import 'package:prysm/util/read_receipt_refresh_notifier.dart';
+import 'package:pointycastle/asymmetric/api.dart';
+
+class ReadReceiptUpdate {
+  final String targetMessageId;
+  final String? groupId;
+  final bool allRead;
+  final Map<String, int> readByMemberId;
+
+  const ReadReceiptUpdate({
+    required this.targetMessageId,
+    this.groupId,
+    required this.allRead,
+    required this.readByMemberId,
+  });
+}
+
+/// Sends, receives, and persists read receipts.
+class ReadReceiptService {
+  final String userId;
+  final KeyManager keyManager;
+  final String? peerId;
+  final String? groupId;
+  final GroupService? groupService;
+  final SettingsService _settings = SettingsService();
+
+  ReadReceiptService.direct({
+    required this.userId,
+    required this.keyManager,
+    required this.peerId,
+  })  : groupId = null,
+        groupService = null;
+
+  ReadReceiptService.group({
+    required this.userId,
+    required this.keyManager,
+    required this.groupId,
+    required this.groupService,
+  }) : peerId = null;
+
+  Future<void> sendReceiptsForMessages(List<String> wireMessageIds) async {
+    if (!_settings.sendReadReceipts || wireMessageIds.isEmpty) return;
+
+    for (final messageId in wireMessageIds) {
+      final payload = ReadReceiptPayload(
+        targetMessageId: messageId,
+        readerId: userId,
+        groupId: groupId,
+        timestamp: DateTime.now().millisecondsSinceEpoch,
+      );
+      if (groupId != null) {
+        await _sendGroupReceipt(payload);
+      } else {
+        await _sendDirectReceipt(payload);
+      }
+    }
+  }
+
+  Future<void> _sendDirectReceipt(ReadReceiptPayload payload) async {
+    final peerKey = await _loadPeerPublicKey();
+    if (peerKey == null) {
+      await _queueDirectReceipt(payload, peerKeyMissing: true);
+      return;
+    }
+
+    final encrypted = keyManager.encryptForPeer(payload.encode(), peerKey);
+    final eventId = readReceiptEventId(
+      targetMessageId: payload.targetMessageId,
+      readerId: userId,
+    );
+
+    final ok = await _postDirect(
+      id: eventId,
+      encrypted: encrypted,
+      timestamp: payload.timestamp,
+    );
+    if (!ok) {
+      await _queueDirectReceipt(payload, encrypted: encrypted);
+    }
+  }
+
+  Future<void> _sendGroupReceipt(ReadReceiptPayload payload) async {
+    final gs = groupService;
+    if (gs == null || groupId == null) return;
+
+    final groupKey = await gs.getDecryptedGroupKey(groupId!);
+    if (groupKey == null) return;
+
+    final encrypted = GroupCrypto.encryptText(groupKey, payload.encode());
+    final members = await gs.getMembers(groupId!);
+    final targets = members.map((m) => m.memberId).where((id) => id != userId);
+
+    final eventId = readReceiptEventId(
+      targetMessageId: payload.targetMessageId,
+      readerId: userId,
+    );
+
+    for (final target in targets) {
+      final ok = await _postGroup(
+        id: eventId,
+        targetMemberId: target,
+        encrypted: encrypted,
+        timestamp: payload.timestamp,
+      );
+      if (!ok) {
+        await PendingMessageDbHelper.insertPendingMessage({
+          'id': '${eventId}__$target',
+          'senderId': userId,
+          'receiverId': target,
+          'message': encrypted,
+          'type': groupReadReceiptType,
+          'timestamp': payload.timestamp,
+          'status': 'pending',
+          'groupId': groupId,
+          'targetMemberId': target,
+        });
+      }
+    }
+  }
+
+  Future<void> _queueDirectReceipt(
+    ReadReceiptPayload payload, {
+    String? encrypted,
+    bool peerKeyMissing = false,
+  }) async {
+    if (peerKeyMissing) return;
+    final eventId = readReceiptEventId(
+      targetMessageId: payload.targetMessageId,
+      readerId: userId,
+    );
+    await PendingMessageDbHelper.insertPendingMessage({
+      'id': eventId,
+      'senderId': userId,
+      'receiverId': peerId,
+      'message': encrypted ?? '',
+      'type': readReceiptType,
+      'timestamp': payload.timestamp,
+      'status': 'pending',
+    });
+  }
+
+  Future<bool> _postDirect({
+    required String id,
+    required String encrypted,
+    required int timestamp,
+  }) async {
+    if (peerId == null) return false;
+    final torClient = TorHttpClient(proxyHost: '127.0.0.1', proxyPort: 9050);
+    try {
+      final uri = Uri.parse('http://$peerId:80/message');
+      final body = jsonEncode({
+        'id': id,
+        'senderId': userId,
+        'receiverId': peerId,
+        'message': encrypted,
+        'type': readReceiptType,
+        'timestamp': timestamp,
+      });
+      final response = await torClient
+          .post(uri, {'Content-Type': 'application/json'}, body)
+          .timeout(const Duration(seconds: 30));
+      await response.transform(utf8.decoder).join();
+      return true;
+    } catch (e) {
+      print('Read receipt send failed: $e');
+      return false;
+    } finally {
+      torClient.close();
+    }
+  }
+
+  Future<bool> _postGroup({
+    required String id,
+    required String targetMemberId,
+    required String encrypted,
+    required int timestamp,
+  }) async {
+    if (groupId == null) return false;
+    final torClient = TorHttpClient(proxyHost: '127.0.0.1', proxyPort: 9050);
+    try {
+      final uri = Uri.parse('http://$targetMemberId:80/message');
+      final body = jsonEncode({
+        'id': id,
+        'senderId': userId,
+        'receiverId': targetMemberId,
+        'groupId': groupId,
+        'message': encrypted,
+        'type': groupReadReceiptType,
+        'timestamp': timestamp,
+      });
+      final response = await torClient
+          .post(uri, {'Content-Type': 'application/json'}, body)
+          .timeout(const Duration(seconds: 30));
+      await response.transform(utf8.decoder).join();
+      return true;
+    } catch (e) {
+      print('Group read receipt send failed: $e');
+      return false;
+    } finally {
+      torClient.close();
+    }
+  }
+
+  Future<RSAPublicKey?> _loadPeerPublicKey() async {
+    if (peerId == null) return null;
+    try {
+      final user = await DBHelper.getUserById(peerId!);
+      final pem = user?['publicKeyPem'] as String?;
+      if (pem == null || pem.isEmpty) return null;
+      return keyManager.importPeerPublicKey(pem);
+    } catch (_) {
+      return null;
+    }
+  }
+
+  static Future<void> applyInbound({
+    required KeyManager keyManager,
+    required String encrypted,
+    required String senderId,
+    required String type,
+    String? groupId,
+    GroupService? groupService,
+  }) async {
+    final plaintext = await _decryptInbound(
+      keyManager: keyManager,
+      encrypted: encrypted,
+      type: type,
+      groupId: groupId,
+      groupService: groupService,
+    );
+    if (plaintext == null) return;
+
+    final payload = ReadReceiptPayload.decode(plaintext);
+    final effectiveGroupId = payload.groupId ?? groupId;
+
+    await MessageReadReceiptsDb.upsertReceipt(
+      wireMessageId: payload.targetMessageId,
+      readerId: payload.readerId,
+      readAt: payload.timestamp,
+      groupId: effectiveGroupId,
+    );
+
+    final receipts = await MessageReadReceiptsDb.getReceiptsForMessage(
+      wireMessageId: payload.targetMessageId,
+      groupId: effectiveGroupId,
+    );
+
+    var requiredReadCount = 1;
+    if (effectiveGroupId != null && groupService != null) {
+      final members = await groupService.getMembers(effectiveGroupId);
+      final msgRows = await MessagesDb.getMessageById(
+        payload.targetMessageId,
+        groupId: effectiveGroupId,
+      );
+      final authorId = msgRows.isNotEmpty
+          ? msgRows.first['senderId'] as String?
+          : null;
+      requiredReadCount = members
+          .where((m) => m.memberId != authorId)
+          .length;
+      if (requiredReadCount < 1) requiredReadCount = 1;
+    }
+
+    final readByMemberId = <String, int>{
+      for (final row in receipts)
+        row['readerId'] as String: row['readAt'] as int,
+    };
+
+    ReadReceiptRefreshNotifier.instance.notify(
+      ReadReceiptUpdate(
+        targetMessageId: payload.targetMessageId,
+        groupId: effectiveGroupId,
+        allRead: receipts.length >= requiredReadCount,
+        readByMemberId: readByMemberId,
+      ),
+    );
+  }
+
+  static Future<String?> _decryptInbound({
+    required KeyManager keyManager,
+    required String encrypted,
+    required String type,
+    String? groupId,
+    GroupService? groupService,
+  }) async {
+    try {
+      if (type == readReceiptType) {
+        return keyManager.decryptMessage(encrypted);
+      }
+      if (type == groupReadReceiptType &&
+          groupId != null &&
+          groupService != null) {
+        final groupKey = await groupService.getDecryptedGroupKey(groupId);
+        if (groupKey == null) return null;
+        return GroupCrypto.decryptText(groupKey, encrypted);
+      }
+    } catch (e) {
+      print('Read receipt decrypt failed: $e');
+    }
+    return null;
+  }
+
+  static Future<bool> processGlobalPendingDirect({
+    required String userId,
+    required KeyManager keyManager,
+    int maxPerCycle = 20,
+  }) async {
+    final pending = await PendingMessageDbHelper.getPendingDirectMessages(
+      senderId: userId,
+      limit: maxPerCycle,
+    );
+    final receipts =
+        pending.where((m) => m['type'] == readReceiptType).toList();
+    if (receipts.isEmpty) return false;
+
+    var any = false;
+    for (final msg in receipts) {
+      final peer = msg['receiverId'] as String?;
+      if (peer == null || peer.isEmpty) continue;
+
+      final service = ReadReceiptService.direct(
+        userId: userId,
+        keyManager: keyManager,
+        peerId: peer,
+      );
+      final encrypted = msg['message'] as String?;
+      if (encrypted == null || encrypted.isEmpty) {
+        continue;
+      }
+      final ok = await service._postDirect(
+        id: msg['id'] as String,
+        encrypted: encrypted,
+        timestamp: msg['timestamp'] as int,
+      );
+      if (ok) {
+        await PendingMessageDbHelper.removeMessage(msg['id'] as String);
+        any = true;
+      }
+    }
+    return any;
+  }
+
+  static Future<bool> processGlobalPendingGroup({
+    required String userId,
+    required KeyManager keyManager,
+    int maxPerCycle = 20,
+  }) async {
+    final pending = await PendingMessageDbHelper.getPendingGroupChatMessages(
+      senderId: userId,
+      limit: maxPerCycle,
+    );
+    final receipts =
+        pending.where((m) => m['type'] == groupReadReceiptType).toList();
+    if (receipts.isEmpty) return false;
+
+    var any = false;
+    for (final msg in receipts) {
+      final groupId = msg['groupId'] as String?;
+      final target = msg['targetMemberId'] as String? ?? msg['receiverId'] as String?;
+      if (groupId == null || target == null) continue;
+
+      final gs = GroupService(userId: userId, keyManager: keyManager);
+      final service = ReadReceiptService.group(
+        userId: userId,
+        keyManager: keyManager,
+        groupId: groupId,
+        groupService: gs,
+      );
+      final ok = await service._postGroup(
+        id: _eventIdFromPending(msg['id'] as String),
+        targetMemberId: target,
+        encrypted: msg['message'] as String,
+        timestamp: msg['timestamp'] as int,
+      );
+      if (ok) {
+        await PendingMessageDbHelper.removeMessage(msg['id'] as String);
+        any = true;
+      }
+    }
+    return any;
+  }
+
+  static String _eventIdFromPending(String pendingId) {
+    final idx = pendingId.lastIndexOf('__');
+    return idx >= 0 ? pendingId.substring(0, idx) : pendingId;
+  }
+}

--- a/lib/services/settings_service.dart
+++ b/lib/services/settings_service.dart
@@ -60,11 +60,24 @@ class SettingsService {
   // Onboarding
   bool get onboardingCompleted => _settings.onboardingCompleted;
 
+  static const String _legacyReadReceiptsKey = 'read_receipts';
+
   // Initialize (call at app startup)
   Future<void> init() async {
     _prefs = await SharedPreferences.getInstance();
     _settingsExistedAtLaunch = _prefs?.getString(_settingsKey) != null;
     await load();
+    await _migrateLegacyPrefs();
+  }
+
+  /// One-time migration from privacy screen SharedPreferences keys.
+  Future<void> _migrateLegacyPrefs() async {
+    if (_prefs == null) return;
+    if (_prefs!.containsKey(_legacyReadReceiptsKey)) {
+      final legacy = _prefs!.getBool(_legacyReadReceiptsKey) ?? true;
+      await setSendReadReceipts(legacy);
+      await _prefs!.remove(_legacyReadReceiptsKey);
+    }
   }
 
   /// Skips onboarding for upgrades: settings existed before this launch and

--- a/lib/services/sync_coordinator.dart
+++ b/lib/services/sync_coordinator.dart
@@ -5,6 +5,7 @@ import 'package:prysm/services/chat_service.dart';
 import 'package:prysm/services/group_chat_service.dart';
 import 'package:prysm/services/message_modify_service.dart';
 import 'package:prysm/services/reaction_service.dart';
+import 'package:prysm/services/read_receipt_service.dart';
 import 'package:prysm/services/group_service.dart';
 import 'package:prysm/util/key_manager.dart';
 import 'package:prysm/util/pending_message_db_helper.dart';
@@ -86,6 +87,16 @@ class SyncCoordinator {
             keyManager: keyManager,
           ) ||
           any;
+      any = await ReadReceiptService.processGlobalPendingGroup(
+            userId: userId,
+            keyManager: keyManager,
+          ) ||
+          any;
+      any = await ReadReceiptService.processGlobalPendingDirect(
+            userId: userId,
+            keyManager: keyManager,
+          ) ||
+          any;
       any = await MessageModifyService.processGlobalPendingGroup(
             userId: userId,
             keyManager: keyManager,
@@ -120,7 +131,7 @@ class SyncCoordinator {
       if (isGroupControlType(type) || type == groupHistoryRelayType) {
         return m['senderId'] == userId;
       }
-      if (isReactionType(type)) {
+      if (isReactionType(type) || isReadReceiptType(type)) {
         return m['senderId'] == userId;
       }
       if (m['groupId'] != null) {

--- a/lib/util/message_status_mapper.dart
+++ b/lib/util/message_status_mapper.dart
@@ -1,0 +1,145 @@
+import 'package:flutter_chat_core/flutter_chat_core.dart';
+
+/// Delivery/read state for outgoing message ticks.
+class OutboundMessageStatus {
+  final bool isPending;
+  final bool isFailed;
+  final bool isDelivered;
+  final bool isRead;
+  final DateTime? sentAt;
+  final DateTime? seenAt;
+
+  const OutboundMessageStatus({
+    this.isPending = false,
+    this.isFailed = false,
+    this.isDelivered = false,
+    this.isRead = false,
+    this.sentAt,
+    this.seenAt,
+  });
+}
+
+OutboundMessageStatus outboundStatusFromDbRow({
+  required Map<String, dynamic> row,
+  required String localUserId,
+  required bool readReceiptsEnabled,
+  List<Map<String, dynamic>> receipts = const [],
+  int requiredReadCount = 1,
+}) {
+  final senderId = row['senderId'] as String;
+  if (senderId != localUserId) {
+    return const OutboundMessageStatus();
+  }
+
+  final status = (row['status'] as String?) ?? 'sent';
+  final timestamp = row['timestamp'] as int?;
+  final sentAt = timestamp != null
+      ? DateTime.fromMillisecondsSinceEpoch(timestamp)
+      : null;
+
+  if (status == 'pending') {
+    return OutboundMessageStatus(isPending: true);
+  }
+
+  final receiptCount = receipts.length;
+  final allRead = receiptCount >= requiredReadCount && requiredReadCount > 0;
+  final isRead = readReceiptsEnabled && allRead;
+  final latestReadAt = receipts.isEmpty
+      ? null
+      : receipts
+          .map((r) => r['readAt'] as int)
+          .reduce((a, b) => a > b ? a : b);
+
+  return OutboundMessageStatus(
+    isDelivered: status == 'sent',
+    isRead: isRead,
+    sentAt: status == 'sent' ? sentAt : null,
+    seenAt: isRead && latestReadAt != null
+        ? DateTime.fromMillisecondsSinceEpoch(latestReadAt)
+        : null,
+  );
+}
+
+Message applyOutboundStatus(
+  Message message, {
+  required OutboundMessageStatus status,
+  bool failed = false,
+}) {
+  final meta = <String, Object?>{...?message.metadata};
+  if (failed) {
+    meta['failed'] = true;
+  } else {
+    meta.remove('failed');
+  }
+  if (status.isPending) {
+    meta['deliveryStatus'] = 'pending';
+  } else if (status.isRead) {
+    meta['deliveryStatus'] = 'read';
+  } else if (status.isDelivered) {
+    meta['deliveryStatus'] = 'sent';
+  } else {
+    meta.remove('deliveryStatus');
+  }
+
+  return message.copyWith(
+    sentAt: status.sentAt,
+    seenAt: status.seenAt,
+    metadata: meta.isEmpty ? null : meta,
+  );
+}
+
+bool isOutboundPending(Message message) =>
+    message.metadata?['deliveryStatus'] == 'pending' ||
+    (message.sentAt == null &&
+        message.seenAt == null &&
+        message.metadata?['failed'] != true);
+
+Message messageWithPendingStatus(Message message) {
+  return message.copyWith(
+    metadata: {...?message.metadata, 'deliveryStatus': 'pending'},
+  );
+}
+
+Message messageWithDeliveryUpdate(
+  Message message, {
+  required String status,
+  required bool readReceiptsEnabled,
+}) {
+  if (status == 'pending') {
+    return message.copyWith(
+      sentAt: null,
+      seenAt: null,
+      metadata: {
+        ...?message.metadata,
+        'failed': false,
+        'deliveryStatus': 'pending',
+      },
+    );
+  }
+  if (status == 'sent') {
+    final meta = <String, Object?>{...?message.metadata};
+    meta.remove('failed');
+    meta['deliveryStatus'] = 'sent';
+    return message.copyWith(
+      sentAt: DateTime.now(),
+      seenAt: null,
+      metadata: meta,
+    );
+  }
+  if (status == 'read' && readReceiptsEnabled) {
+    return message.copyWith(
+      sentAt: message.sentAt ?? DateTime.now(),
+      seenAt: DateTime.now(),
+      metadata: {
+        ...?message.metadata,
+        'deliveryStatus': 'read',
+      },
+    );
+  }
+  if (status == 'failed') {
+    return message.copyWith(
+      metadata: {...?message.metadata, 'failed': true},
+    );
+  }
+  return message;
+}

--- a/lib/util/read_receipt_payload.dart
+++ b/lib/util/read_receipt_payload.dart
@@ -1,0 +1,40 @@
+import 'dart:convert';
+
+/// Plaintext read receipt payload (encrypted before sending over Tor).
+class ReadReceiptPayload {
+  final String targetMessageId;
+  final String readerId;
+  final String? groupId;
+  final int timestamp;
+
+  const ReadReceiptPayload({
+    required this.targetMessageId,
+    required this.readerId,
+    this.groupId,
+    required this.timestamp,
+  });
+
+  Map<String, dynamic> toJson() => {
+        'targetMessageId': targetMessageId,
+        'readerId': readerId,
+        if (groupId != null) 'groupId': groupId,
+        'timestamp': timestamp,
+      };
+
+  factory ReadReceiptPayload.fromJson(Map<String, dynamic> json) {
+    return ReadReceiptPayload(
+      targetMessageId: json['targetMessageId'] as String,
+      readerId: json['readerId'] as String,
+      groupId: json['groupId'] as String?,
+      timestamp: json['timestamp'] as int,
+    );
+  }
+
+  String encode() => jsonEncode(toJson());
+
+  static ReadReceiptPayload decode(String plaintext) {
+    return ReadReceiptPayload.fromJson(
+      jsonDecode(plaintext) as Map<String, dynamic>,
+    );
+  }
+}

--- a/lib/util/read_receipt_refresh_notifier.dart
+++ b/lib/util/read_receipt_refresh_notifier.dart
@@ -1,0 +1,20 @@
+import 'dart:async';
+
+import 'package:prysm/services/read_receipt_service.dart';
+
+/// Broadcasts read receipt changes so open chat screens can refresh tick UI.
+class ReadReceiptRefreshNotifier {
+  ReadReceiptRefreshNotifier._();
+  static final ReadReceiptRefreshNotifier instance =
+      ReadReceiptRefreshNotifier._();
+
+  final _controller = StreamController<ReadReceiptUpdate>.broadcast();
+
+  Stream<ReadReceiptUpdate> get onReadReceiptChanged => _controller.stream;
+
+  void notify(ReadReceiptUpdate update) {
+    if (!_controller.isClosed) {
+      _controller.add(update);
+    }
+  }
+}

--- a/test/message_read_receipts_test.dart
+++ b/test/message_read_receipts_test.dart
@@ -1,0 +1,144 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:prysm/database/message_read_receipts.dart';
+import 'package:prysm/database/messages.dart';
+import 'package:sqflite/sqflite.dart';
+import 'package:sqflite_common_ffi/sqflite_ffi.dart';
+
+void main() {
+  setUpAll(() {
+    sqfliteFfiInit();
+    databaseFactory = databaseFactoryFfi;
+  });
+
+  test('message_read_receipts upsert and query by wire id', () async {
+    final db = await databaseFactory.openDatabase(
+      inMemoryDatabasePath,
+      options: OpenDatabaseOptions(
+        version: 9,
+        onCreate: (db, version) async {
+          await db.execute('''
+            CREATE TABLE messages(
+              id TEXT PRIMARY KEY,
+              senderId TEXT NOT NULL,
+              receiverId TEXT NOT NULL,
+              message TEXT,
+              type TEXT,
+              timestamp INTEGER NOT NULL,
+              status TEXT DEFAULT 'sent',
+              readAt INTEGER,
+              groupId TEXT
+            )
+          ''');
+          await MessageReadReceiptsDb.createTable(db);
+        },
+      ),
+    );
+
+    // Point MessagesDb at in-memory db for this test.
+    // MessageReadReceiptsDb uses MessagesDb.database — open via messages path hack:
+    // Instead test the table operations directly.
+    await db.insert('message_read_receipts', {
+      'messageId': 'group1::msg1',
+      'groupId': 'group1',
+      'readerId': 'readerA',
+      'readAt': 1000,
+    });
+
+    final rows = await db.query(
+      'message_read_receipts',
+      where: 'messageId = ?',
+      whereArgs: ['group1::msg1'],
+    );
+    expect(rows.length, 1);
+    expect(rows.first['readerId'], 'readerA');
+
+    await db.insert(
+      'message_read_receipts',
+      {
+        'messageId': 'group1::msg1',
+        'groupId': 'group1',
+        'readerId': 'readerA',
+        'readAt': 2000,
+      },
+      conflictAlgorithm: ConflictAlgorithm.replace,
+    );
+
+    final updated = await db.query(
+      'message_read_receipts',
+      where: 'messageId = ?',
+      whereArgs: ['group1::msg1'],
+    );
+    expect(updated.first['readAt'], 2000);
+
+    await db.close();
+  });
+
+  test('v9 migration clears outbound delivery readAt artifacts', () async {
+    final db = await databaseFactory.openDatabase(
+      inMemoryDatabasePath,
+      options: OpenDatabaseOptions(version: 9),
+    );
+
+    await db.execute('''
+      CREATE TABLE messages(
+        id TEXT PRIMARY KEY,
+        senderId TEXT NOT NULL,
+        receiverId TEXT NOT NULL,
+        message TEXT,
+        type TEXT,
+        timestamp INTEGER NOT NULL,
+        status TEXT DEFAULT 'sent',
+        readAt INTEGER,
+        groupId TEXT
+      )
+    ''');
+
+    await db.insert('messages', {
+      'id': 'out1',
+      'senderId': 'me',
+      'receiverId': 'peer',
+      'message': 'x',
+      'type': 'text',
+      'timestamp': 1,
+      'status': 'sent',
+      'readAt': 999,
+    });
+    await db.insert('messages', {
+      'id': 'in1',
+      'senderId': 'peer',
+      'receiverId': 'me',
+      'message': 'y',
+      'type': 'text',
+      'timestamp': 2,
+      'status': 'received',
+      'readAt': 888,
+    });
+
+    await db.execute('''
+      UPDATE messages
+      SET readAt = NULL
+      WHERE COALESCE(status, '') = 'sent'
+        AND COALESCE(status, '') != 'received'
+    ''');
+
+    final out = await db.query('messages', where: 'id = ?', whereArgs: ['out1']);
+    final inbound =
+        await db.query('messages', where: 'id = ?', whereArgs: ['in1']);
+
+    expect(out.first['readAt'], isNull);
+    expect(inbound.first['readAt'], 888);
+
+    await db.close();
+  });
+
+  test('scopedId wire roundtrip', () {
+    expect(
+      MessagesDb.wireIdFromStorage('group::wire'),
+      'wire',
+    );
+    expect(
+      MessagesDb.scopedId(wireId: 'wire', groupId: 'group'),
+      'group::wire',
+    );
+  });
+}

--- a/test/message_read_receipts_test.dart
+++ b/test/message_read_receipts_test.dart
@@ -1,7 +1,6 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:prysm/database/message_read_receipts.dart';
 import 'package:prysm/database/messages.dart';
-import 'package:sqflite/sqflite.dart';
 import 'package:sqflite_common_ffi/sqflite_ffi.dart';
 
 void main() {

--- a/test/message_status_mapper_test.dart
+++ b/test/message_status_mapper_test.dart
@@ -1,0 +1,129 @@
+import 'package:flutter_chat_core/flutter_chat_core.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:prysm/util/message_status_mapper.dart';
+
+void main() {
+  test('pending outbound row maps to clock state', () {
+    final status = outboundStatusFromDbRow(
+      row: {
+        'senderId': 'me',
+        'status': 'pending',
+        'timestamp': 1000,
+      },
+      localUserId: 'me',
+      readReceiptsEnabled: true,
+    );
+    expect(status.isPending, isTrue);
+    expect(status.sentAt, isNull);
+    expect(status.seenAt, isNull);
+  });
+
+  test('sent outbound row maps to single tick', () {
+    final status = outboundStatusFromDbRow(
+      row: {
+        'senderId': 'me',
+        'status': 'sent',
+        'timestamp': 1000,
+      },
+      localUserId: 'me',
+      readReceiptsEnabled: true,
+    );
+    expect(status.isDelivered, isTrue);
+    expect(status.isRead, isFalse);
+    expect(status.sentAt, isNotNull);
+    expect(status.seenAt, isNull);
+  });
+
+  test('read receipts disabled hides read state', () {
+    final status = outboundStatusFromDbRow(
+      row: {
+        'senderId': 'me',
+        'status': 'sent',
+        'timestamp': 1000,
+      },
+      localUserId: 'me',
+      readReceiptsEnabled: false,
+      receipts: [
+        {'readerId': 'peer', 'readAt': 2000},
+      ],
+    );
+    expect(status.isRead, isFalse);
+    expect(status.seenAt, isNull);
+  });
+
+  test('direct read when peer receipt exists', () {
+    final status = outboundStatusFromDbRow(
+      row: {
+        'senderId': 'me',
+        'status': 'sent',
+        'timestamp': 1000,
+      },
+      localUserId: 'me',
+      readReceiptsEnabled: true,
+      receipts: [
+        {'readerId': 'peer', 'readAt': 2000},
+      ],
+      requiredReadCount: 1,
+    );
+    expect(status.isRead, isTrue);
+    expect(status.seenAt?.millisecondsSinceEpoch, 2000);
+  });
+
+  test('group read requires all members', () {
+    final partial = outboundStatusFromDbRow(
+      row: {
+        'senderId': 'me',
+        'status': 'sent',
+        'timestamp': 1000,
+      },
+      localUserId: 'me',
+      readReceiptsEnabled: true,
+      receipts: [
+        {'readerId': 'a', 'readAt': 2000},
+      ],
+      requiredReadCount: 2,
+    );
+    expect(partial.isRead, isFalse);
+
+    final allRead = outboundStatusFromDbRow(
+      row: {
+        'senderId': 'me',
+        'status': 'sent',
+        'timestamp': 1000,
+      },
+      localUserId: 'me',
+      readReceiptsEnabled: true,
+      receipts: [
+        {'readerId': 'a', 'readAt': 2000},
+        {'readerId': 'b', 'readAt': 2100},
+      ],
+      requiredReadCount: 2,
+    );
+    expect(allRead.isRead, isTrue);
+  });
+
+  test('messageWithDeliveryUpdate handles sent and pending', () {
+    final msg = TextMessage(
+      authorId: 'me',
+      createdAt: DateTime.now(),
+      id: '1',
+      text: 'hi',
+    );
+
+    final pending = messageWithDeliveryUpdate(
+      msg,
+      status: 'pending',
+      readReceiptsEnabled: true,
+    );
+    expect(pending.sentAt, isNull);
+    expect(pending.metadata?['deliveryStatus'], 'pending');
+
+    final sent = messageWithDeliveryUpdate(
+      pending,
+      status: 'sent',
+      readReceiptsEnabled: true,
+    );
+    expect(sent.sentAt, isNotNull);
+    expect(sent.seenAt, isNull);
+  });
+}


### PR DESCRIPTION
- Added support for read receipts in both direct and group chats.
- Introduced MessageReadReceiptsDb for managing read receipt data in the database.
- Implemented ReadReceiptService to handle sending and processing read receipts.
- Updated chat and group chat screens to display read receipt status.
- Enhanced privacy settings to allow users to toggle read receipt visibility.
- Created UI components for displaying read receipt details and status.