### PR TITLE
feat: implement wake hint service for efficient message delivery

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -52,6 +52,7 @@ import 'package:prysm/services/contact_add_service.dart';
 import 'package:prysm/util/qr_platform.dart';
 import 'package:prysm/util/tor_connection_notifier.dart';
 import 'package:prysm/services/sync_coordinator.dart';
+import 'package:prysm/services/wake_hint_service.dart';
 import 'package:flutter_background/flutter_background.dart';
 import 'package:window_manager/window_manager.dart';
 
@@ -721,6 +722,13 @@ class _HomeScreenState extends State<HomeScreen> with WidgetsBindingObserver {
     );
     if (!widget.decoyMode) {
       _syncCoordinator!.start();
+      WakeHintService.instance.configure(
+        userId: widget.onionAddress,
+        isTorStopped: () => _torStopped,
+        showOnlineStatus: () => appSettings.showOnlineStatus,
+        onFlushPeer: (peerId) =>
+            _syncCoordinator!.flushPendingForPeer(peerId),
+      );
     }
 
     if (widget.decoyMode) {
@@ -732,6 +740,9 @@ class _HomeScreenState extends State<HomeScreen> with WidgetsBindingObserver {
         final flushed = await _syncCoordinator!.flushAllPending();
         if (flushed && mounted) {
           scheduleLoadUsers(light: true);
+        }
+        if (mounted) {
+          unawaited(_maybeBroadcastWakeHints(coldStart: true));
         }
       }
     });
@@ -1660,6 +1671,7 @@ class _HomeScreenState extends State<HomeScreen> with WidgetsBindingObserver {
   bool _torRestartInProgress = false;
   TorConnectionState _torConnectionState = TorConnectionState.connected;
   Timer? _torHealthTimer;
+  DateTime? _lastTorDisconnectedAt;
 
   void _startTorHealthMonitor() {
     _torHealthTimer?.cancel();
@@ -1676,6 +1688,7 @@ class _HomeScreenState extends State<HomeScreen> with WidgetsBindingObserver {
   Future<void> _checkTorHealth() async {
     if (!mounted || _torStopped || _torRestartInProgress) {
       if (mounted && _torConnectionState != TorConnectionState.disconnected) {
+        _lastTorDisconnectedAt = DateTime.now();
         setState(() => _torConnectionState = TorConnectionState.disconnected);
         TorConnectionNotifier.instance.update(TorConnectionState.disconnected);
       }
@@ -1691,12 +1704,28 @@ class _HomeScreenState extends State<HomeScreen> with WidgetsBindingObserver {
     if (next != _torConnectionState) {
       final wasDisconnected =
           _torConnectionState == TorConnectionState.disconnected;
+      if (next == TorConnectionState.disconnected) {
+        _lastTorDisconnectedAt = DateTime.now();
+      }
       setState(() => _torConnectionState = next);
       TorConnectionNotifier.instance.update(next);
       if (wasDisconnected && next == TorConnectionState.connected) {
         unawaited(_onTorReconnected());
       }
     }
+  }
+
+  Future<void> _maybeBroadcastWakeHints({bool coldStart = false}) async {
+    if (_torStopped || widget.decoyMode) return;
+    if (!coldStart) {
+      final disconnectedAt = _lastTorDisconnectedAt;
+      if (disconnectedAt == null) return;
+      final offlineFor = DateTime.now().difference(disconnectedAt);
+      if (offlineFor < BatterySaverPolicy.wakeHintMinOfflineBeforeBroadcast) {
+        return;
+      }
+    }
+    await WakeHintService.instance.broadcastRecentPeerHints();
   }
 
   Future<void> _onTorReconnected() async {
@@ -1706,6 +1735,7 @@ class _HomeScreenState extends State<HomeScreen> with WidgetsBindingObserver {
       if (flushed) {
         _syncCoordinator?.notifyPendingActivity();
       }
+      unawaited(_maybeBroadcastWakeHints());
     }
   }
 

--- a/lib/screens/privacy_settings_screen.dart
+++ b/lib/screens/privacy_settings_screen.dart
@@ -53,6 +53,7 @@ class _PrivacySettingsScreenState extends State<PrivacySettingsScreen> {
       _showOnlineStatus = value;
     });
     _savePrivacySetting('show_online_status', value);
+    settings.setShowOnlineStatus(value);
   }
 
   Future<void> _onReadReceiptsToggle(bool value) async {
@@ -112,12 +113,33 @@ class _PrivacySettingsScreenState extends State<PrivacySettingsScreen> {
                 ),
                 child: Column(
                   children: [
-                    _buildPrivacyOption(
-                      context,
-                      'Show Online Status',
-                      Icons.visibility_outlined,
-                      _showOnlineStatus,
-                      _onOnlineStatusToggle,
+                    ListTile(
+                      leading: const Icon(Icons.visibility_outlined),
+                      title: const Text('Show Online Status'),
+                      subtitle: const Text(
+                        'When enabled, recent contacts are notified when you come online so they can deliver pending messages faster.',
+                      ),
+                      trailing: Container(
+                        padding: const EdgeInsets.all(2),
+                        decoration: BoxDecoration(
+                          borderRadius: BorderRadius.circular(12),
+                          color: Theme.of(context).brightness == Brightness.dark
+                              ? Colors.white.withValues(alpha: 0.1)
+                              : Colors.black.withValues(alpha: 0.05),
+                        ),
+                        child: Switch(
+                          value: _showOnlineStatus,
+                          onChanged: _onOnlineStatusToggle,
+                          activeThumbColor: Colors.white,
+                          activeTrackColor: Theme.of(context).primaryColor,
+                          inactiveThumbColor: Colors.white,
+                          inactiveTrackColor:
+                              Theme.of(context).brightness == Brightness.dark
+                                  ? Colors.grey[700]
+                                  : Colors.grey[400],
+                        ),
+                      ),
+                      onTap: () => _onOnlineStatusToggle(!_showOnlineStatus),
                     ),
                     const Divider(height: 1),
                     _buildPrivacyOption(

--- a/lib/server/PrysmServer.dart
+++ b/lib/server/PrysmServer.dart
@@ -18,6 +18,7 @@ import 'package:prysm/services/read_receipt_service.dart';
 import 'package:prysm/services/notification_mute_service.dart';
 import 'package:prysm/services/settings_service.dart';
 import 'package:prysm/util/conversation_refresh_notifier.dart';
+import 'package:prysm/services/wake_hint_service.dart';
 import 'package:prysm/util/peer_profile_cache.dart';
 
 class PrysmServer {
@@ -73,6 +74,11 @@ class PrysmServer {
       // GET /profile (public key + username + avatar)
       if (request.method == 'GET' && request.url.path == 'profile') {
         return _handleGetProfile();
+      }
+
+      // POST /sync-hint — peer reachable; flush pending if any
+      if (request.method == 'POST' && request.url.path == 'sync-hint') {
+        return await _handlePostSyncHint(request);
       }
 
       return Response.notFound(
@@ -408,6 +414,43 @@ class PrysmServer {
       );
     } catch (e, stack) {
       print('PrysmServer POST /message Error $e\n$stack');
+      return Response.internalServerError(
+        body: jsonEncode({'error': 'Processing failed'}),
+        headers: {'Content-Type': 'application/json'},
+      );
+    }
+  }
+
+  Future<Response> _handlePostSyncHint(Request request) async {
+    try {
+      final payload = await request.readAsString();
+      final data = jsonDecode(payload) as Map<String, dynamic>;
+
+      final validationError = WakeHintService.validateSyncHintPayload(
+        data,
+        localOnionAddress,
+      );
+      if (validationError != null) {
+        return _badRequest(validationError);
+      }
+
+      final senderId = data['senderId'] as String;
+      final contact = await DBHelper.getUserById(senderId);
+      if (contact == null) {
+        return Response.forbidden(
+          jsonEncode({'error': 'Unknown sender'}),
+          headers: {'Content-Type': 'application/json'},
+        );
+      }
+
+      unawaited(WakeHintService.instance.handleIncomingHint(senderId));
+
+      return Response.ok(
+        jsonEncode({'status': 'ok'}),
+        headers: {'Content-Type': 'application/json'},
+      );
+    } catch (e, stack) {
+      print('PrysmServer POST /sync-hint Error $e\n$stack');
       return Response.internalServerError(
         body: jsonEncode({'error': 'Processing failed'}),
         headers: {'Content-Type': 'application/json'},

--- a/lib/services/chat_service.dart
+++ b/lib/services/chat_service.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 import 'dart:convert';
 import 'package:flutter/foundation.dart';
+import 'package:prysm/constants/group_constants.dart';
 import 'package:prysm/client/TorHttpClient.dart';
 import 'package:prysm/database/messages.dart';
 import 'package:prysm/util/db_helper.dart';
@@ -451,6 +452,45 @@ class ChatService {
     } catch (e) {
       print('Failed to persist peer public key: $e');
     }
+  }
+
+  /// Retry pending 1:1 deliveries for one peer (wake-hint response).
+  static Future<bool> processPendingForPeer({
+    required String userId,
+    required String peerId,
+    required KeyManager keyManager,
+  }) async {
+    final pending = await PendingMessageDbHelper.getPendingDirectMessagesForReceiver(
+      senderId: userId,
+      receiverId: peerId,
+    );
+    final chatPending = pending.where((m) {
+      final type = m['type'] as String?;
+      if (type == null) return false;
+      return !isReadReceiptType(type) &&
+          !isReactionType(type) &&
+          !isMessageModifyType(type);
+    }).toList();
+    if (chatPending.isEmpty) return false;
+
+    final service = ChatService(
+      userId: userId,
+      peerId: peerId,
+      keyManager: keyManager,
+    );
+    final cached = await service._getPeerPublicKeyFromDb();
+    if (cached != null) {
+      service.peerPublicKey = keyManager.importPeerPublicKey(cached);
+    } else {
+      final ok = await service._fetchPeerPublicKeyOverTor();
+      if (!ok) {
+        service.dispose();
+        return false;
+      }
+    }
+    await service._processPendingOnce();
+    service.dispose();
+    return true;
   }
 
   /// Retry pending 1:1 deliveries for all peers (called from global sync timer).

--- a/lib/services/message_modify_service.dart
+++ b/lib/services/message_modify_service.dart
@@ -419,6 +419,39 @@ class MessageModifyService {
     return null;
   }
 
+  static Future<bool> processPendingForPeer({
+    required String userId,
+    required String peerId,
+    required KeyManager keyManager,
+  }) async {
+    final pending = await PendingMessageDbHelper.getPendingDirectMessagesForReceiver(
+      senderId: userId,
+      receiverId: peerId,
+    );
+    final modifies =
+        pending.where((m) => m['type'] == messageModifyType).toList();
+    if (modifies.isEmpty) return false;
+
+    var any = false;
+    for (final row in modifies) {
+      final service = MessageModifyService.direct(
+        userId: userId,
+        keyManager: keyManager,
+        peerId: peerId,
+      );
+      final ok = await service._postDirect(
+        id: row['id'] as String,
+        encrypted: row['message'] as String,
+        timestamp: row['timestamp'] as int,
+      );
+      if (ok) {
+        await PendingMessageDbHelper.removeMessages([row['id'] as String]);
+        any = true;
+      }
+    }
+    return any;
+  }
+
   static Future<bool> processGlobalPendingDirect({
     required String userId,
     required KeyManager keyManager,

--- a/lib/services/reaction_service.dart
+++ b/lib/services/reaction_service.dart
@@ -355,6 +355,46 @@ class ReactionService {
     return null;
   }
 
+  /// Retry pending direct reactions for one peer.
+  static Future<bool> processPendingForPeer({
+    required String userId,
+    required String peerId,
+    required KeyManager keyManager,
+  }) async {
+    final pending = await PendingMessageDbHelper.getPendingDirectMessagesForReceiver(
+      senderId: userId,
+      receiverId: peerId,
+    );
+    final reactions =
+        pending.where((m) => m['type'] == reactionType).toList();
+    if (reactions.isEmpty) return false;
+
+    var any = false;
+    for (final msg in reactions) {
+      final service = ReactionService.direct(
+        userId: userId,
+        keyManager: keyManager,
+        peerId: peerId,
+      );
+      final encrypted = msg['message'] as String?;
+      if (encrypted == null || encrypted.isEmpty) {
+        service.dispose();
+        continue;
+      }
+      final ok = await service._postDirect(
+        id: msg['id'] as String,
+        encrypted: encrypted,
+        timestamp: msg['timestamp'] as int,
+      );
+      if (ok) {
+        await PendingMessageDbHelper.removeMessage(msg['id'] as String);
+        any = true;
+      }
+      service.dispose();
+    }
+    return any;
+  }
+
   /// Retry pending direct reactions for all peers.
   static Future<bool> processGlobalPendingDirect({
     required String userId,

--- a/lib/services/read_receipt_service.dart
+++ b/lib/services/read_receipt_service.dart
@@ -314,6 +314,43 @@ class ReadReceiptService {
     return null;
   }
 
+  static Future<bool> processPendingForPeer({
+    required String userId,
+    required String peerId,
+    required KeyManager keyManager,
+  }) async {
+    final pending = await PendingMessageDbHelper.getPendingDirectMessagesForReceiver(
+      senderId: userId,
+      receiverId: peerId,
+    );
+    final receipts =
+        pending.where((m) => m['type'] == readReceiptType).toList();
+    if (receipts.isEmpty) return false;
+
+    var any = false;
+    for (final msg in receipts) {
+      final service = ReadReceiptService.direct(
+        userId: userId,
+        keyManager: keyManager,
+        peerId: peerId,
+      );
+      final encrypted = msg['message'] as String?;
+      if (encrypted == null || encrypted.isEmpty) {
+        continue;
+      }
+      final ok = await service._postDirect(
+        id: msg['id'] as String,
+        encrypted: encrypted,
+        timestamp: msg['timestamp'] as int,
+      );
+      if (ok) {
+        await PendingMessageDbHelper.removeMessage(msg['id'] as String);
+        any = true;
+      }
+    }
+    return any;
+  }
+
   static Future<bool> processGlobalPendingDirect({
     required String userId,
     required KeyManager keyManager,

--- a/lib/services/sync_coordinator.dart
+++ b/lib/services/sync_coordinator.dart
@@ -147,6 +147,55 @@ class SyncCoordinator {
     return flushAllPending();
   }
 
+  /// Flush outbound pending queues for one direct peer (wake-hint response).
+  Future<bool> flushPendingForPeer(String receiverId) async {
+    if (isTorStopped() || _flushing) return false;
+
+    final hasPending = await PendingMessageDbHelper.hasOutboundDirectPending(
+      userId,
+      receiverId,
+    );
+    if (!hasPending) return false;
+
+    _flushing = true;
+    try {
+      var any = false;
+
+      any = await ReadReceiptService.processPendingForPeer(
+            userId: userId,
+            peerId: receiverId,
+            keyManager: keyManager,
+          ) ||
+          any;
+      any = await ReactionService.processPendingForPeer(
+            userId: userId,
+            peerId: receiverId,
+            keyManager: keyManager,
+          ) ||
+          any;
+      any = await MessageModifyService.processPendingForPeer(
+            userId: userId,
+            peerId: receiverId,
+            keyManager: keyManager,
+          ) ||
+          any;
+      any = await ChatService.processPendingForPeer(
+            userId: userId,
+            peerId: receiverId,
+            keyManager: keyManager,
+          ) ||
+          any;
+
+      await _refreshPendingBacklogFlag();
+      if (any) {
+        PendingActivityNotifier.instance.notify();
+      }
+      return any;
+    } finally {
+      _flushing = false;
+    }
+  }
+
   /// Speed up ticks while backlog exists.
   void notifyPendingActivity() {
     _hasPendingBacklog = true;

--- a/lib/services/wake_hint_service.dart
+++ b/lib/services/wake_hint_service.dart
@@ -1,0 +1,157 @@
+import 'dart:async';
+import 'dart:convert';
+import 'dart:math';
+
+import 'package:prysm/client/TorHttpClient.dart';
+import 'package:prysm/database/messages.dart';
+import 'package:prysm/util/battery_saver_policy.dart';
+import 'package:prysm/util/pending_message_db_helper.dart';
+
+/// Lightweight delivery wake hints: notify recent peers to flush pending outbound
+/// traffic toward this node when it becomes reachable over Tor.
+class WakeHintService {
+  WakeHintService._();
+  static final WakeHintService instance = WakeHintService._();
+
+  static const Duration _hintTimeout = Duration(seconds: 10);
+  static const Duration _timestampSkewTolerance = Duration(minutes: 5);
+
+  String? _userId;
+  bool Function()? _isTorStopped;
+  bool Function()? _showOnlineStatus;
+  Future<bool> Function(String peerId)? _onFlushPeer;
+  Future<bool> Function(String senderId)? _hasOutboundPendingForSender;
+
+  final Map<String, DateTime> _lastSentToPeer = {};
+  final Map<String, DateTime> _lastReceivedFromPeer = {};
+
+  void configure({
+    required String userId,
+    required bool Function() isTorStopped,
+    required bool Function() showOnlineStatus,
+    required Future<bool> Function(String peerId) onFlushPeer,
+    Future<bool> Function(String senderId)? hasOutboundPendingForSender,
+  }) {
+    _userId = userId;
+    _isTorStopped = isTorStopped;
+    _showOnlineStatus = showOnlineStatus;
+    _onFlushPeer = onFlushPeer;
+    _hasOutboundPendingForSender = hasOutboundPendingForSender;
+  }
+
+  /// Clears in-memory dedupe state (for tests).
+  void resetForTest() {
+    _lastSentToPeer.clear();
+    _lastReceivedFromPeer.clear();
+  }
+
+  /// Validates sync-hint payload. Returns null when valid, or an error message.
+  static String? validateSyncHintPayload(
+    Map<String, dynamic> data,
+    String? localOnionAddress,
+  ) {
+    final senderId = data['senderId'];
+    final timestamp = data['timestamp'];
+    if (senderId is! String || senderId.isEmpty) {
+      return 'senderId required';
+    }
+    if (timestamp is! int) {
+      return 'timestamp required';
+    }
+    if (localOnionAddress != null && senderId == localOnionAddress) {
+      return 'self wake rejected';
+    }
+    final now = DateTime.now().millisecondsSinceEpoch;
+    if ((now - timestamp).abs() > _timestampSkewTolerance.inMilliseconds) {
+      return 'timestamp out of range';
+    }
+    return null;
+  }
+
+  Future<void> broadcastRecentPeerHints() async {
+    final userId = _userId;
+    if (userId == null || _isTorStopped?.call() == true) return;
+    if (_showOnlineStatus?.call() != true) return;
+
+    final timestamps = await MessagesDb.getLastMessageTimestampsForAllUsers();
+    final peers = timestamps.entries
+        .where((e) => e.key != userId)
+        .toList()
+      ..sort((a, b) => b.value.compareTo(a.value));
+
+    final targets = peers
+        .take(BatterySaverPolicy.wakeHintMaxPeers)
+        .map((e) => e.key)
+        .where(_canSendToPeer)
+        .toList();
+
+    if (targets.isEmpty) return;
+
+    final random = Random();
+    final staggerMin = BatterySaverPolicy.wakeHintStaggerMin().inMilliseconds;
+    final staggerMax = BatterySaverPolicy.wakeHintStaggerMax().inMilliseconds;
+
+    for (var i = 0; i < targets.length; i++) {
+      if (_isTorStopped?.call() == true) break;
+      if (i > 0) {
+        final delayMs = staggerMin +
+            random.nextInt(max(1, staggerMax - staggerMin + 1));
+        await Future.delayed(Duration(milliseconds: delayMs));
+      }
+      await _sendHintToPeer(userId, targets[i]);
+    }
+  }
+
+  bool _canSendToPeer(String peerId) {
+    final lastSent = _lastSentToPeer[peerId];
+    if (lastSent == null) return true;
+    return DateTime.now().difference(lastSent) >=
+        BatterySaverPolicy.wakeHintSendCooldown;
+  }
+
+  Future<void> _sendHintToPeer(String userId, String peerId) async {
+    final torClient = TorHttpClient(proxyHost: '127.0.0.1', proxyPort: 9050);
+    try {
+      final uri = Uri.parse('http://$peerId:80/sync-hint');
+      final body = jsonEncode({
+        'senderId': userId,
+        'timestamp': DateTime.now().millisecondsSinceEpoch,
+      });
+      final response = await torClient
+          .post(uri, {'Content-Type': 'application/json'}, body)
+          .timeout(_hintTimeout);
+      await response.transform(utf8.decoder).join();
+      _lastSentToPeer[peerId] = DateTime.now();
+    } catch (e) {
+      print('Wake hint send to $peerId failed: $e');
+    } finally {
+      torClient.close();
+    }
+  }
+
+  Future<void> handleIncomingHint(String senderId) async {
+    final userId = _userId;
+    if (userId == null || senderId.isEmpty) return;
+
+    final lastReceived = _lastReceivedFromPeer[senderId];
+    if (lastReceived != null &&
+        DateTime.now().difference(lastReceived) <
+            BatterySaverPolicy.wakeHintReceiveDebounce) {
+      return;
+    }
+    _lastReceivedFromPeer[senderId] = DateTime.now();
+
+    final hasPending = await _hasPendingForSender(senderId);
+    if (!hasPending) return;
+
+    await _onFlushPeer?.call(senderId);
+  }
+
+  Future<bool> _hasPendingForSender(String senderId) async {
+    final custom = _hasOutboundPendingForSender;
+    if (custom != null) return custom(senderId);
+    final userId = _userId;
+    if (userId == null) return false;
+    return PendingMessageDbHelper.hasOutboundDirectPending(userId, senderId);
+  }
+}

--- a/lib/util/battery_saver_policy.dart
+++ b/lib/util/battery_saver_policy.dart
@@ -46,4 +46,22 @@ class BatterySaverPolicy {
       (saving ?? active)
           ? const Duration(milliseconds: 800)
           : const Duration(milliseconds: 400);
+
+  static const int wakeHintMaxPeers = 20;
+
+  static const Duration wakeHintSendCooldown = Duration(minutes: 5);
+
+  static const Duration wakeHintReceiveDebounce = Duration(seconds: 30);
+
+  static const Duration wakeHintMinOfflineBeforeBroadcast = Duration(seconds: 30);
+
+  static Duration wakeHintStaggerMin([bool? saving]) =>
+      (saving ?? active)
+          ? const Duration(milliseconds: 500)
+          : const Duration(milliseconds: 200);
+
+  static Duration wakeHintStaggerMax([bool? saving]) =>
+      (saving ?? active)
+          ? const Duration(milliseconds: 800)
+          : const Duration(milliseconds: 400);
 }

--- a/lib/util/pending_message_db_helper.dart
+++ b/lib/util/pending_message_db_helper.dart
@@ -110,6 +110,35 @@ class PendingMessageDbHelper {
     );
   }
 
+  /// Pending 1:1 outbound rows for a specific peer.
+  static Future<List<Map<String, dynamic>>> getPendingDirectMessagesForReceiver({
+    required String senderId,
+    required String receiverId,
+    int? limit,
+  }) async {
+    final db = await database;
+    return db.query(
+      'pending_messages',
+      where: 'groupId IS NULL AND senderId = ? AND receiverId = ?',
+      whereArgs: [senderId, receiverId],
+      orderBy: 'timestamp ASC',
+      limit: limit,
+    );
+  }
+
+  static Future<bool> hasOutboundDirectPending(
+    String senderId,
+    String receiverId,
+  ) async {
+    final db = await database;
+    final result = await db.rawQuery(
+      'SELECT COUNT(*) AS c FROM pending_messages '
+      'WHERE groupId IS NULL AND senderId = ? AND receiverId = ?',
+      [senderId, receiverId],
+    );
+    return (Sqflite.firstIntValue(result) ?? 0) > 0;
+  }
+
   static Future<int> countOutboundPending(String senderId) async {
     final db = await database;
     final result = await db.rawQuery(

--- a/test/pending_routing_test.dart
+++ b/test/pending_routing_test.dart
@@ -68,4 +68,65 @@ void main() {
 
     await db.close();
   });
+
+  test('hasOutboundDirectPending and filtered query', () async {
+    final db = await databaseFactory.openDatabase(
+      inMemoryDatabasePath,
+      options: OpenDatabaseOptions(
+        version: 4,
+        onCreate: (db, version) async {
+          await db.execute('''
+            CREATE TABLE pending_messages(
+              id TEXT PRIMARY KEY,
+              senderId TEXT,
+              receiverId TEXT,
+              message TEXT,
+              type TEXT,
+              fileName TEXT,
+              fileSize INTEGER,
+              timestamp INTEGER,
+              status TEXT,
+              replyTo TEXT,
+              viewOnce INTEGER DEFAULT 0,
+              groupId TEXT,
+              targetMemberId TEXT
+            )
+          ''');
+        },
+      ),
+    );
+
+    await db.insert('pending_messages', {
+      'id': 'a1',
+      'senderId': 'me.onion',
+      'receiverId': 'peer-a.onion',
+      'message': 'enc',
+      'type': 'text',
+      'timestamp': 1,
+    });
+    await db.insert('pending_messages', {
+      'id': 'b1',
+      'senderId': 'me.onion',
+      'receiverId': 'peer-b.onion',
+      'message': 'enc',
+      'type': 'text',
+      'timestamp': 2,
+    });
+
+    final forPeerA = await db.query(
+      'pending_messages',
+      where: 'groupId IS NULL AND senderId = ? AND receiverId = ?',
+      whereArgs: ['me.onion', 'peer-a.onion'],
+    );
+    expect(forPeerA.length, 1);
+
+    final countResult = await db.rawQuery(
+      'SELECT COUNT(*) AS c FROM pending_messages '
+      'WHERE groupId IS NULL AND senderId = ? AND receiverId = ?',
+      ['me.onion', 'peer-a.onion'],
+    );
+    expect((countResult.first['c'] as int?) ?? 0, 1);
+
+    await db.close();
+  });
 }

--- a/test/sync_coordinator_test.dart
+++ b/test/sync_coordinator_test.dart
@@ -32,4 +32,16 @@ void main() {
     expect(await coordinator.onTorReconnected(), false);
     coordinator.dispose();
   });
+
+  test('flushPendingForPeer is skipped when Tor is stopped', () async {
+    final coordinator = SyncCoordinator(
+      userId: 'me.onion',
+      keyManager: KeyManager(),
+      torManager: TorManager(torPath: '', dataDir: '', controlPassword: ''),
+      isTorStopped: () => true,
+    );
+
+    expect(await coordinator.flushPendingForPeer('peer.onion'), false);
+    coordinator.dispose();
+  });
 }

--- a/test/wake_hint_service_test.dart
+++ b/test/wake_hint_service_test.dart
@@ -1,0 +1,110 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:prysm/services/wake_hint_service.dart';
+import 'package:prysm/util/battery_saver_policy.dart';
+
+void main() {
+  group('WakeHintService.validateSyncHintPayload', () {
+    test('accepts valid payload', () {
+      expect(
+        WakeHintService.validateSyncHintPayload(
+          {
+            'senderId': 'peer.onion',
+            'timestamp': DateTime.now().millisecondsSinceEpoch,
+          },
+          'me.onion',
+        ),
+        isNull,
+      );
+    });
+
+    test('rejects self wake', () {
+      expect(
+        WakeHintService.validateSyncHintPayload(
+          {
+            'senderId': 'me.onion',
+            'timestamp': DateTime.now().millisecondsSinceEpoch,
+          },
+          'me.onion',
+        ),
+        isNotNull,
+      );
+    });
+
+    test('rejects stale timestamp', () {
+      final stale = DateTime.now()
+          .subtract(const Duration(minutes: 10))
+          .millisecondsSinceEpoch;
+      expect(
+        WakeHintService.validateSyncHintPayload(
+          {'senderId': 'peer.onion', 'timestamp': stale},
+          'me.onion',
+        ),
+        isNotNull,
+      );
+    });
+  });
+
+  group('WakeHintService.handleIncomingHint', () {
+    setUp(() {
+      WakeHintService.instance.resetForTest();
+    });
+
+    test('skips flush when no pending outbound for sender', () async {
+      var flushCount = 0;
+      WakeHintService.instance.configure(
+        userId: 'me.onion',
+        isTorStopped: () => false,
+        showOnlineStatus: () => true,
+        onFlushPeer: (_) async {
+          flushCount++;
+          return true;
+        },
+        hasOutboundPendingForSender: (_) async => false,
+      );
+
+      await WakeHintService.instance.handleIncomingHint('peer.onion');
+      expect(flushCount, 0);
+    });
+
+    test('flushes when pending outbound exists for sender', () async {
+      String? flushedPeer;
+      WakeHintService.instance.configure(
+        userId: 'me.onion',
+        isTorStopped: () => false,
+        showOnlineStatus: () => true,
+        onFlushPeer: (peerId) async {
+          flushedPeer = peerId;
+          return true;
+        },
+        hasOutboundPendingForSender: (_) async => true,
+      );
+
+      await WakeHintService.instance.handleIncomingHint('peer.onion');
+      expect(flushedPeer, 'peer.onion');
+    });
+
+    test('debounces repeated hints from same peer', () async {
+      var flushCount = 0;
+      WakeHintService.instance.configure(
+        userId: 'me.onion',
+        isTorStopped: () => false,
+        showOnlineStatus: () => true,
+        onFlushPeer: (_) async {
+          flushCount++;
+          return true;
+        },
+        hasOutboundPendingForSender: (_) async => true,
+      );
+
+      await WakeHintService.instance.handleIncomingHint('peer.onion');
+      await WakeHintService.instance.handleIncomingHint('peer.onion');
+      expect(flushCount, 1);
+    });
+  });
+
+  test('wake hint policy constants are sensible', () {
+    expect(BatterySaverPolicy.wakeHintMaxPeers, 20);
+    expect(BatterySaverPolicy.wakeHintReceiveDebounce.inSeconds, 30);
+    expect(BatterySaverPolicy.wakeHintSendCooldown.inMinutes, 5);
+  });
+}


### PR DESCRIPTION
- Added WakeHintService to notify recent peers to flush pending outbound messages when reachable over Tor.
- Integrated wake hint functionality into the sync coordinator and chat services to enhance message delivery.
- Updated privacy settings to allow users to manage online status visibility.
- Implemented database helper methods for managing pending direct messages.
- Added unit tests for wake hint service and related functionalities to ensure reliability.