### PR TITLE
feat: implement inbound message notification system

### DIFF
--- a/lib/database/messages.dart
+++ b/lib/database/messages.dart
@@ -260,11 +260,12 @@ class MessagesDb {
 	}
 
 	/// Insert an inbound delivery without clobbering our outbound encrypted-for-self copy.
-	static Future<void> insertInboundMessage(
+	/// Returns the stored row, or null when an existing outbound copy is kept.
+	static Future<Map<String, dynamic>?> insertInboundMessage(
 		Map<String, dynamic> message,
 		String localUserId,
 	) async {
-		await _dbMutex.protect(() async {
+		return await _dbMutex.protect(() async {
 			final db = await database;
 			final normalized = _withStorageId(message);
 			final id = normalized['id'] as String;
@@ -278,7 +279,7 @@ class MessagesDb {
 				final wasOutbound = row['senderId'] == localUserId &&
 					row['status'] != 'received';
 				if (wasOutbound) {
-					return;
+					return null;
 				}
 			}
 			await db.insert(
@@ -286,6 +287,7 @@ class MessagesDb {
 				normalized,
 				conflictAlgorithm: ConflictAlgorithm.replace,
 			);
+			return normalized;
 		});
 	}
 

--- a/lib/server/PrysmServer.dart
+++ b/lib/server/PrysmServer.dart
@@ -20,6 +20,7 @@ import 'package:prysm/services/read_receipt_service.dart';
 import 'package:prysm/services/notification_mute_service.dart';
 import 'package:prysm/services/settings_service.dart';
 import 'package:prysm/util/conversation_refresh_notifier.dart';
+import 'package:prysm/util/inbound_message_notifier.dart';
 import 'package:prysm/services/wake_hint_service.dart';
 import 'package:prysm/util/peer_profile_cache.dart';
 
@@ -360,7 +361,7 @@ class PrysmServer {
       }
 
       final localId = localOnionAddress ?? receiverId;
-      await MessagesDb.insertInboundMessage({
+      final inserted = await MessagesDb.insertInboundMessage({
         'id': data['id'] as String,
         'senderId': senderId,
         'receiverId': receiverId,
@@ -374,6 +375,12 @@ class PrysmServer {
         if (data['replyTo'] != null) 'replyTo': data['replyTo'],
         'viewOnce': (data['viewOnce'] == true || data['viewOnce'] == 1) ? 1 : 0,
       }, localId);
+
+      if (inserted != null) {
+        InboundMessageNotifier.instance.notify(
+          InboundMessageEvent.fromRow(inserted),
+        );
+      }
 
       ConversationRefreshNotifier.instance.notifyInboundMessage();
 

--- a/lib/services/chat_service.dart
+++ b/lib/services/chat_service.dart
@@ -12,6 +12,7 @@ import 'package:prysm/util/tor_outbound_gateway.dart';
 import 'package:prysm/util/tor_runtime_gate.dart';
 import 'package:prysm/util/key_manager.dart';
 import 'package:prysm/util/pending_message_db_helper.dart';
+import 'package:prysm/util/inbound_message_notifier.dart';
 import 'package:prysm/util/rsa_helper.dart';
 import 'package:uuid/uuid.dart';
 import 'package:pointycastle/asymmetric/api.dart';
@@ -46,6 +47,8 @@ class ChatService {
   DateTime? lastSuccessfulActivity;
 
   int? _newestTimestamp;
+  final Set<String> _seenMessageIds = {};
+  StreamSubscription<InboundMessageEvent>? _inboundSub;
 
   ChatService({
     required this.userId,
@@ -57,6 +60,8 @@ class ChatService {
     _disposed = true;
     _isPolling = false;
     _isSending = false;
+    _inboundSub?.cancel();
+    _inboundSub = null;
     _newMessagesController.close();
     _messageStatusController.close();
     _peerReachableController.close();
@@ -92,7 +97,26 @@ class ChatService {
   void startPolling() {
     if (_isPolling) return;
     _isPolling = true;
+    _subscribeInbound();
     _loopPoll();
+  }
+
+  @visibleForTesting
+  void startInboundPushListener() {
+    _subscribeInbound();
+  }
+
+  void _subscribeInbound() {
+    _inboundSub ??= InboundMessageNotifier.instance.onInboundMessage.listen(
+      _onInboundMessage,
+    );
+  }
+
+  void _onInboundMessage(InboundMessageEvent event) {
+    if (_disposed) return;
+    if (event.groupId != null) return;
+    if (event.senderId != peerId) return;
+    _deliverNewRows([event.row]);
   }
 
   void stopPolling() {
@@ -257,30 +281,41 @@ class ChatService {
     );
 
     if (batch.isEmpty) return false;
+    return _deliverNewRows(batch);
+  }
 
-    final newMessages = batch
-        .where(
-          (msg) =>
-              _newestTimestamp == null ||
-              (msg['timestamp'] as int) > _newestTimestamp!,
-        )
-        .toList();
+  bool _deliverNewRows(List<Map<String, dynamic>> rows) {
+    if (_disposed) return false;
+
+    final newMessages = rows.where((msg) {
+      final id = msg['id'] as String;
+      if (_seenMessageIds.contains(id)) return false;
+      if (_newestTimestamp != null &&
+          (msg['timestamp'] as int) <= _newestTimestamp!) {
+        return false;
+      }
+      return true;
+    }).toList();
 
     if (newMessages.isEmpty) return false;
+
+    for (final msg in newMessages) {
+      _seenMessageIds.add(msg['id'] as String);
+    }
 
     _newestTimestamp = newMessages
         .map((m) => m['timestamp'] as int)
         .reduce(max);
 
-    // seedNewestTimestamp() prevents historical messages from counting; any
-    // new peer-originated row here is live traffic.
     final hasNewPeerMessage =
         newMessages.any((msg) => msg['senderId'] == peerId);
     if (hasNewPeerMessage) {
       _notifyPeerReachable();
     }
 
-    _newMessagesController.add(newMessages);
+    if (!_disposed) {
+      _newMessagesController.add(newMessages);
+    }
     return true;
   }
 

--- a/lib/services/group_chat_service.dart
+++ b/lib/services/group_chat_service.dart
@@ -14,6 +14,7 @@ import 'package:prysm/util/tor_delivery.dart';
 import 'package:prysm/util/tor_outbound_gateway.dart';
 import 'package:prysm/util/tor_runtime_gate.dart';
 import 'package:prysm/util/pending_message_db_helper.dart';
+import 'package:prysm/util/inbound_message_notifier.dart';
 import 'package:uuid/uuid.dart';
 
 class GroupChatService {
@@ -32,6 +33,7 @@ class GroupChatService {
   int _consecutivePollErrors = 0;
   int? _newestTimestamp;
   final Set<String> _seenMessageIds = {};
+  StreamSubscription<InboundMessageEvent>? _inboundSub;
 
   final _newMessagesController =
       StreamController<List<Map<String, dynamic>>>.broadcast();
@@ -54,6 +56,8 @@ class GroupChatService {
     _disposed = true;
     _isPolling = false;
     _isSending = false;
+    _inboundSub?.cancel();
+    _inboundSub = null;
     _newMessagesController.close();
     _messageStatusController.close();
   }
@@ -77,7 +81,20 @@ class GroupChatService {
   void startPolling() {
     if (_isPolling) return;
     _isPolling = true;
+    _subscribeInbound();
     _loopPoll();
+  }
+
+  void _subscribeInbound() {
+    _inboundSub ??= InboundMessageNotifier.instance.onInboundMessage.listen(
+      _onInboundMessage,
+    );
+  }
+
+  void _onInboundMessage(InboundMessageEvent event) {
+    if (_disposed) return;
+    if (event.groupId != groupId) return;
+    _deliverNewRows([event.row]);
   }
 
   void stopPolling() {
@@ -258,11 +275,17 @@ class GroupChatService {
       afterTimestamp: joinedAt,
     );
     if (batch.isEmpty) return false;
+    return _deliverNewRows(batch);
+  }
 
-    final newMessages = batch.where((msg) {
+  bool _deliverNewRows(List<Map<String, dynamic>> rows) {
+    if (_disposed) return false;
+
+    final newMessages = rows.where((msg) {
       final msgId = msg['id'] as String;
       if (_seenMessageIds.contains(msgId)) return false;
-      if (_newestTimestamp != null && (msg['timestamp'] as int) <= _newestTimestamp!) {
+      if (_newestTimestamp != null &&
+          (msg['timestamp'] as int) <= _newestTimestamp!) {
         return false;
       }
       return true;
@@ -278,7 +301,9 @@ class GroupChatService {
         .map((m) => m['timestamp'] as int)
         .reduce(max);
 
-    _newMessagesController.add(newMessages);
+    if (!_disposed) {
+      _newMessagesController.add(newMessages);
+    }
     return true;
   }
 

--- a/lib/util/inbound_message_notifier.dart
+++ b/lib/util/inbound_message_notifier.dart
@@ -1,0 +1,52 @@
+import 'dart:async';
+
+/// Fired when PrysmServer stores an inbound chat message so open chats can
+/// update immediately without waiting for the DB poll loop.
+class InboundMessageEvent {
+  final Map<String, dynamic> row;
+  final String? groupId;
+  final String senderId;
+  final String receiverId;
+
+  const InboundMessageEvent({
+    required this.row,
+    required this.groupId,
+    required this.senderId,
+    required this.receiverId,
+  });
+
+  factory InboundMessageEvent.fromRow(Map<String, dynamic> row) {
+    return InboundMessageEvent(
+      row: row,
+      groupId: row['groupId'] as String?,
+      senderId: row['senderId'] as String,
+      receiverId: row['receiverId'] as String,
+    );
+  }
+}
+
+class InboundMessageNotifier {
+  InboundMessageNotifier._();
+  static final InboundMessageNotifier instance = InboundMessageNotifier._();
+
+  StreamController<InboundMessageEvent>? _controller;
+
+  StreamController<InboundMessageEvent> get _ensureController {
+    return _controller ??= StreamController<InboundMessageEvent>.broadcast();
+  }
+
+  Stream<InboundMessageEvent> get onInboundMessage => _ensureController.stream;
+
+  void notify(InboundMessageEvent event) {
+    final controller = _controller;
+    if (controller != null && !controller.isClosed) {
+      controller.add(event);
+    }
+  }
+
+  /// Clears stream state between tests.
+  void resetForTest() {
+    _controller?.close();
+    _controller = null;
+  }
+}

--- a/test/chat_service_inbound_push_test.dart
+++ b/test/chat_service_inbound_push_test.dart
@@ -1,0 +1,121 @@
+import 'dart:async';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:pointycastle/asymmetric/api.dart';
+import 'package:prysm/services/chat_service.dart';
+import 'package:prysm/util/inbound_message_notifier.dart';
+import 'package:prysm/util/key_manager.dart';
+import 'package:prysm/util/rsa_helper.dart';
+
+void main() {
+  late KeyManager keyManager;
+  late ChatService service;
+
+  setUp(() {
+    InboundMessageNotifier.instance.resetForTest();
+
+    final pair = RSAHelper.generateKeyPair();
+    keyManager = KeyManager.fromKeys(
+      pair.privateKey as RSAPrivateKey,
+      pair.publicKey as RSAPublicKey,
+    );
+
+    service = ChatService(
+      userId: 'me.onion',
+      peerId: 'peer.onion',
+      keyManager: keyManager,
+    );
+    service.peerPublicKey = pair.publicKey as RSAPublicKey;
+  });
+
+  tearDown(() {
+    service.dispose();
+    InboundMessageNotifier.instance.resetForTest();
+  });
+
+  Map<String, dynamic> _directRow({
+    required String storageId,
+    required String wireId,
+    int timestamp = 1000,
+  }) {
+    return {
+      'id': storageId,
+      'senderId': 'peer.onion',
+      'receiverId': 'me.onion',
+      'message': 'cipher',
+      'type': 'text',
+      'timestamp': timestamp,
+      'status': 'received',
+    };
+  }
+
+  test('push delivers matching direct message immediately', () async {
+    final delivered = <List<Map<String, dynamic>>>[];
+    service.onNewMessages.listen(delivered.add);
+    service.startInboundPushListener();
+
+    final row = _directRow(storageId: 'peer.onion::msg-1', wireId: 'msg-1');
+    InboundMessageNotifier.instance.notify(InboundMessageEvent.fromRow(row));
+
+    await Future<void>.delayed(Duration.zero);
+    expect(delivered, hasLength(1));
+    expect(delivered.first.single['id'], 'peer.onion::msg-1');
+  });
+
+  test('push ignores messages for other peers', () async {
+    final delivered = <List<Map<String, dynamic>>>[];
+    service.onNewMessages.listen(delivered.add);
+    service.startInboundPushListener();
+
+    InboundMessageNotifier.instance.notify(
+      InboundMessageEvent.fromRow({
+        'id': 'other.onion::msg-1',
+        'senderId': 'other.onion',
+        'receiverId': 'me.onion',
+        'message': 'cipher',
+        'type': 'text',
+        'timestamp': 1000,
+        'status': 'received',
+      }),
+    );
+
+    await Future<void>.delayed(Duration.zero);
+    expect(delivered, isEmpty);
+  });
+
+  test('duplicate push is deduped', () async {
+    final delivered = <List<Map<String, dynamic>>>[];
+    service.onNewMessages.listen(delivered.add);
+    service.startInboundPushListener();
+
+    final row = _directRow(storageId: 'peer.onion::msg-1', wireId: 'msg-1');
+    final event = InboundMessageEvent.fromRow(row);
+    InboundMessageNotifier.instance.notify(event);
+    InboundMessageNotifier.instance.notify(event);
+
+    await Future<void>.delayed(Duration.zero);
+    expect(delivered, hasLength(1));
+  });
+
+  test('push ignores group messages for direct chat service', () async {
+    final delivered = <List<Map<String, dynamic>>>[];
+    service.onNewMessages.listen(delivered.add);
+    service.startInboundPushListener();
+
+    InboundMessageNotifier.instance.notify(
+      InboundMessageEvent.fromRow({
+        'id': 'group1::msg-1',
+        'senderId': 'peer.onion',
+        'receiverId': 'me.onion',
+        'groupId': 'group1',
+        'message': 'cipher',
+        'type': 'group_text',
+        'timestamp': 1000,
+        'status': 'received',
+      }),
+    );
+
+    await Future<void>.delayed(Duration.zero);
+    expect(delivered, isEmpty);
+  });
+}

--- a/test/chat_service_inbound_push_test.dart
+++ b/test/chat_service_inbound_push_test.dart
@@ -1,5 +1,3 @@
-import 'dart:async';
-
 import 'package:flutter_test/flutter_test.dart';
 import 'package:pointycastle/asymmetric/api.dart';
 import 'package:prysm/services/chat_service.dart';
@@ -33,7 +31,7 @@ void main() {
     InboundMessageNotifier.instance.resetForTest();
   });
 
-  Map<String, dynamic> _directRow({
+  Map<String, dynamic> directRow({
     required String storageId,
     required String wireId,
     int timestamp = 1000,
@@ -54,7 +52,7 @@ void main() {
     service.onNewMessages.listen(delivered.add);
     service.startInboundPushListener();
 
-    final row = _directRow(storageId: 'peer.onion::msg-1', wireId: 'msg-1');
+    final row = directRow(storageId: 'peer.onion::msg-1', wireId: 'msg-1');
     InboundMessageNotifier.instance.notify(InboundMessageEvent.fromRow(row));
 
     await Future<void>.delayed(Duration.zero);
@@ -88,7 +86,7 @@ void main() {
     service.onNewMessages.listen(delivered.add);
     service.startInboundPushListener();
 
-    final row = _directRow(storageId: 'peer.onion::msg-1', wireId: 'msg-1');
+    final row = directRow(storageId: 'peer.onion::msg-1', wireId: 'msg-1');
     final event = InboundMessageEvent.fromRow(row);
     InboundMessageNotifier.instance.notify(event);
     InboundMessageNotifier.instance.notify(event);

--- a/test/inbound_message_notifier_test.dart
+++ b/test/inbound_message_notifier_test.dart
@@ -1,0 +1,48 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:prysm/util/inbound_message_notifier.dart';
+
+void main() {
+  setUp(() {
+    InboundMessageNotifier.instance.resetForTest();
+  });
+
+  test('notify delivers event to subscriber', () async {
+    InboundMessageEvent? received;
+    InboundMessageNotifier.instance.onInboundMessage.listen((event) {
+      received = event;
+    });
+
+    const row = {
+      'id': 'peer.onion::msg-1',
+      'senderId': 'peer.onion',
+      'receiverId': 'me.onion',
+      'message': 'cipher',
+      'type': 'text',
+      'timestamp': 1000,
+      'status': 'received',
+    };
+
+    InboundMessageNotifier.instance.notify(InboundMessageEvent.fromRow(row));
+
+    await Future<void>.delayed(Duration.zero);
+    expect(received, isNotNull);
+    expect(received!.senderId, 'peer.onion');
+    expect(received!.groupId, isNull);
+    expect(received!.row['id'], 'peer.onion::msg-1');
+  });
+
+  test('fromRow extracts groupId when present', () {
+    final event = InboundMessageEvent.fromRow({
+      'id': 'group1::msg-1',
+      'senderId': 'peer.onion',
+      'receiverId': 'me.onion',
+      'groupId': 'group1',
+      'message': 'cipher',
+      'type': 'group_text',
+      'timestamp': 1000,
+      'status': 'received',
+    });
+
+    expect(event.groupId, 'group1');
+  });
+}


### PR DESCRIPTION
- Added InboundMessageNotifier to facilitate immediate updates for inbound messages without waiting for the database polling loop.
- Updated MessagesDb to return the stored row or null if an existing outbound copy is retained.
- Enhanced ChatService and GroupChatService to subscribe to inbound message notifications and handle new messages accordingly.
- Introduced unit tests for inbound message delivery and notification functionality to ensure reliability.