### PR TITLE
feat: enhance read receipt handling and introduce outbound read statu…

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -54,6 +54,7 @@ import 'package:prysm/screens/onboarding/onboarding_screen.dart';
 import 'package:prysm/services/contact_add_service.dart';
 import 'package:prysm/util/qr_platform.dart';
 import 'package:prysm/util/tor_connection_notifier.dart';
+import 'package:prysm/services/read_receipt_service.dart';
 import 'package:prysm/services/sync_coordinator.dart';
 import 'package:prysm/services/wake_hint_service.dart';
 import 'package:flutter_background/flutter_background.dart';
@@ -736,6 +737,10 @@ class _HomeScreenState extends State<HomeScreen> with WidgetsBindingObserver {
         isTorStopped: () => _torStopped,
         showOnlineStatus: () => appSettings.showOnlineStatus,
         onFlushPeer: (peerId) =>
+            _syncCoordinator!.flushPendingForPeer(peerId),
+      );
+      ReadReceiptService.configure(
+        flushPendingForPeer: (peerId) =>
             _syncCoordinator!.flushPendingForPeer(peerId),
       );
     }

--- a/lib/screens/chat.dart
+++ b/lib/screens/chat.dart
@@ -40,6 +40,7 @@ import 'package:prysm/database/message_read_receipts.dart';
 import 'package:prysm/screens/widgets/message_status_icon.dart';
 import 'package:prysm/screens/widgets/read_receipt_details_sheet.dart';
 import 'package:prysm/util/message_status_mapper.dart';
+import 'package:prysm/util/outbound_read_status_refresh.dart';
 import 'package:prysm/util/read_receipt_refresh_notifier.dart';
 import 'package:prysm/util/message_modify_policy.dart';
 import 'package:prysm/util/message_modify_refresh_notifier.dart';
@@ -332,35 +333,46 @@ class _ChatScreenState extends State<ChatScreen> {
     if (waterline == null) return;
 
     _readReceiptDebounce?.cancel();
-    _readReceiptDebounce = Timer(const Duration(milliseconds: 300), () async {
+    _readReceiptDebounce = Timer(const Duration(milliseconds: 100), () async {
       if (_settings.sendReadReceipts) {
         await _readReceiptService.sendWaterline(waterline);
       }
     });
   }
 
-  void _applyReadReceiptUpdate(ReadReceiptUpdate update) {
+  Future<void> _applyReadReceiptUpdate(ReadReceiptUpdate update) async {
     if (!mounted || !_settings.sendReadReceipts) return;
     if (update.groupId != null) return;
 
-    try {
-      final msg = _messages.messages.firstWhere((m) => m.id == update.targetMessageId);
-      if (msg.authorId != widget.userId) return;
-      if (!update.allRead) return;
+    final refreshed = await refreshOutboundReadStatus(
+      messages: _messages.messages,
+      localUserId: widget.userId,
+      readReceiptsEnabled: _settings.sendReadReceipts,
+      requiredReadCount: 1,
+    );
+    if (!mounted) return;
 
-      _recordPeerActivity();
+    var anyNewlyRead = false;
+    setState(() {
+      for (final updated in refreshed) {
+        if (updated.authorId != widget.userId) continue;
+        try {
+          final old = _messages.messages.firstWhere((m) => m.id == updated.id);
+          if (old.seenAt == updated.seenAt &&
+              old.metadata?['deliveryStatus'] ==
+                  updated.metadata?['deliveryStatus']) {
+            continue;
+          }
+          if (updated.seenAt != null && old.seenAt == null) {
+            anyNewlyRead = true;
+          }
+          _messages.updateMessage(old, updated);
+          _messageCache[updated.id] = updated;
+        } catch (_) {}
+      }
+    });
 
-      final latest = update.readByMemberId.values.reduce(max);
-      final updated = msg.copyWith(
-        sentAt: msg.sentAt ?? DateTime.now(),
-        seenAt: DateTime.fromMillisecondsSinceEpoch(latest),
-        metadata: {...?msg.metadata, 'deliveryStatus': 'read'},
-      );
-      setState(() {
-        _messages.updateMessage(msg, updated);
-        _messageCache[msg.id] = updated;
-      });
-    } catch (_) {}
+    if (anyNewlyRead) _recordPeerActivity();
   }
 
   @override

--- a/lib/screens/group_chat.dart
+++ b/lib/screens/group_chat.dart
@@ -1,7 +1,6 @@
 import 'dart:async';
 import 'dart:convert';
 import 'dart:io';
-import 'dart:math';
 
 import 'package:file_picker/file_picker.dart';
 import 'package:flutter/foundation.dart';
@@ -39,6 +38,7 @@ import 'package:prysm/database/message_read_receipts.dart';
 import 'package:prysm/screens/widgets/message_status_icon.dart';
 import 'package:prysm/screens/widgets/read_receipt_details_sheet.dart';
 import 'package:prysm/util/message_status_mapper.dart';
+import 'package:prysm/util/outbound_read_status_refresh.dart';
 import 'package:prysm/util/read_receipt_refresh_notifier.dart';
 import 'package:prysm/util/message_modify_policy.dart';
 import 'package:prysm/util/message_modify_refresh_notifier.dart';
@@ -629,32 +629,41 @@ class _GroupChatScreenState extends State<GroupChatScreen> {
     if (waterline == null) return;
 
     _readReceiptDebounce?.cancel();
-    _readReceiptDebounce = Timer(const Duration(milliseconds: 300), () async {
+    _readReceiptDebounce = Timer(const Duration(milliseconds: 100), () async {
       if (_settings.sendReadReceipts) {
         await _readReceiptService.sendWaterline(waterline);
       }
     });
   }
 
-  void _applyReadReceiptUpdate(ReadReceiptUpdate update) {
+  Future<void> _applyReadReceiptUpdate(ReadReceiptUpdate update) async {
     if (!mounted || !_settings.sendReadReceipts) return;
     if (update.groupId != widget.group.id) return;
 
-    try {
-      final msg = _messages.messages.firstWhere((m) => m.id == update.targetMessageId);
-      if (msg.authorId != widget.userId) return;
-      if (!update.allRead) return;
+    final requiredReadCount = _memberCount > 1 ? _memberCount - 1 : 1;
+    final refreshed = await refreshOutboundReadStatus(
+      messages: _messages.messages,
+      localUserId: widget.userId,
+      readReceiptsEnabled: _settings.sendReadReceipts,
+      groupId: widget.group.id,
+      requiredReadCount: requiredReadCount,
+    );
+    if (!mounted) return;
 
-      final latest = update.readByMemberId.values.reduce(max);
-      final updated = msg.copyWith(
-        sentAt: msg.sentAt ?? DateTime.now(),
-        seenAt: DateTime.fromMillisecondsSinceEpoch(latest),
-        metadata: {...?msg.metadata, 'deliveryStatus': 'read'},
-      );
-      setState(() {
-        _messages.updateMessage(msg, updated);
-      });
-    } catch (_) {}
+    setState(() {
+      for (final updated in refreshed) {
+        if (updated.authorId != widget.userId) continue;
+        try {
+          final old = _messages.messages.firstWhere((m) => m.id == updated.id);
+          if (old.seenAt == updated.seenAt &&
+              old.metadata?['deliveryStatus'] ==
+                  updated.metadata?['deliveryStatus']) {
+            continue;
+          }
+          _messages.updateMessage(old, updated);
+        } catch (_) {}
+      }
+    });
   }
 
   void _resendMessage(Message message) {

--- a/lib/services/read_receipt_service.dart
+++ b/lib/services/read_receipt_service.dart
@@ -24,17 +24,45 @@ class ReadReceiptUpdate {
   final String? groupId;
   final bool allRead;
   final Map<String, int> readByMemberId;
+  final int? readUpToTimestamp;
+  final bool isWaterline;
 
   const ReadReceiptUpdate({
     required this.targetMessageId,
     this.groupId,
     required this.allRead,
     required this.readByMemberId,
+    this.readUpToTimestamp,
+    this.isWaterline = false,
   });
 }
 
 /// Sends, receives, and persists read receipts.
 class ReadReceiptService {
+  static Future<bool> Function(String peerId)? _flushPendingForPeer;
+  static final Map<String, int> _lastDispatchedReadUpTo = {};
+
+  static void configure({
+    Future<bool> Function(String peerId)? flushPendingForPeer,
+  }) {
+    _flushPendingForPeer = flushPendingForPeer;
+  }
+
+  @visibleForTesting
+  static void resetForTest() {
+    _flushPendingForPeer = null;
+    _lastDispatchedReadUpTo.clear();
+  }
+
+  static String _dispatchKey({
+    required String readerId,
+    required String? peerId,
+    required String? groupId,
+  }) {
+    if (groupId != null) return '$readerId::group::$groupId';
+    return '$readerId::$peerId';
+  }
+
   final String userId;
   final KeyManager keyManager;
   final String? peerId;
@@ -59,6 +87,22 @@ class ReadReceiptService {
   /// Send one read waterline for a batch of locally-marked-read messages.
   Future<void> sendWaterline(ReadWaterlineMark mark) async {
     if (!_settings.sendReadReceipts) return;
+
+    final dispatchKey = _dispatchKey(
+      readerId: userId,
+      peerId: peerId,
+      groupId: groupId ?? mark.groupId,
+    );
+    final lastDispatched = _lastDispatchedReadUpTo[dispatchKey] ?? 0;
+    if (mark.readUpToTimestamp <= lastDispatched) {
+      if (peerId != null) {
+        final flush = _flushPendingForPeer;
+        if (flush != null) {
+          unawaited(flush(peerId!));
+        }
+      }
+      return;
+    }
 
     final payload = ReadReceiptPayload(
       targetMessageId: mark.latestMessageId,
@@ -90,7 +134,10 @@ class ReadReceiptService {
       encrypted: encrypted,
       timestamp: payload.timestamp,
       messageType: readWaterlineType,
+      fastFail: true,
     );
+    _lastDispatchedReadUpTo[_dispatchKey(readerId: userId, peerId: peerId, groupId: null)] =
+        payload.readUpToTimestamp ?? payload.timestamp;
     if (!ok) {
       await PendingMessageDbHelper.insertPendingMessage({
         'id': eventId,
@@ -101,6 +148,10 @@ class ReadReceiptService {
         'timestamp': payload.timestamp,
         'status': 'pending',
       });
+      final flush = _flushPendingForPeer;
+      if (flush != null) {
+        unawaited(flush(peerId!));
+      }
     }
   }
 
@@ -120,6 +171,10 @@ class ReadReceiptService {
       groupId: groupId,
     );
 
+    _lastDispatchedReadUpTo[
+      _dispatchKey(readerId: userId, peerId: null, groupId: groupId)
+    ] = payload.readUpToTimestamp ?? payload.timestamp;
+
     for (final target in targets) {
       final pendingId = '$eventId::$target';
       final ok = await _postGroup(
@@ -128,6 +183,7 @@ class ReadReceiptService {
         encrypted: encrypted,
         timestamp: payload.timestamp,
         messageType: groupReadWaterlineType,
+        fastFail: true,
       );
       if (!ok) {
         await PendingMessageDbHelper.insertPendingMessage({
@@ -141,6 +197,10 @@ class ReadReceiptService {
           'groupId': groupId,
           'targetMemberId': target,
         });
+        final flush = _flushPendingForPeer;
+        if (flush != null) {
+          unawaited(flush(target));
+        }
       }
     }
   }
@@ -150,11 +210,13 @@ class ReadReceiptService {
     required String encrypted,
     required int timestamp,
     required String messageType,
+    bool fastFail = false,
+    bool logOnFailure = true,
   }) async {
     if (peerId == null) return false;
     try {
       await TorDelivery.withTorRetry<void>(
-        maxAttempts: 2,
+        maxAttempts: fastFail ? 1 : 2,
         attempt: () => _postDirectOnce(
           id: id,
           encrypted: encrypted,
@@ -164,7 +226,9 @@ class ReadReceiptService {
       );
       return true;
     } catch (e) {
-      debugPrint('Read waterline deferred (will retry via sync): $e');
+      if (logOnFailure) {
+        debugPrint('Read waterline deferred (will retry via sync): $e');
+      }
       return false;
     }
   }
@@ -211,11 +275,13 @@ class ReadReceiptService {
     required String encrypted,
     required int timestamp,
     required String messageType,
+    bool fastFail = false,
+    bool logOnFailure = true,
   }) async {
     if (groupId == null) return false;
     try {
       await TorDelivery.withTorRetry<void>(
-        maxAttempts: 2,
+        maxAttempts: fastFail ? 1 : 2,
         attempt: () => _postGroupOnce(
           id: id,
           targetMemberId: targetMemberId,
@@ -226,7 +292,9 @@ class ReadReceiptService {
       );
       return true;
     } catch (e) {
-      debugPrint('Group read waterline deferred (will retry via sync): $e');
+      if (logOnFailure) {
+        debugPrint('Group read waterline deferred (will retry via sync): $e');
+      }
       return false;
     }
   }
@@ -366,6 +434,8 @@ class ReadReceiptService {
       readAt: payload.timestamp,
       effectiveGroupId: effectiveGroupId,
       groupService: groupService,
+      readUpToTimestamp: payload.effectiveReadUpToTimestamp,
+      isWaterline: true,
     );
   }
 
@@ -375,6 +445,8 @@ class ReadReceiptService {
     required int readAt,
     required String? effectiveGroupId,
     GroupService? groupService,
+    int? readUpToTimestamp,
+    bool isWaterline = false,
   }) async {
     final receipts = await MessageReadReceiptsDb.getReceiptsForMessage(
       wireMessageId: wireMessageId,
@@ -406,6 +478,8 @@ class ReadReceiptService {
         groupId: effectiveGroupId,
         allRead: receipts.length >= requiredReadCount,
         readByMemberId: readByMemberId,
+        readUpToTimestamp: readUpToTimestamp,
+        isWaterline: isWaterline,
       ),
     );
   }
@@ -465,6 +539,8 @@ class ReadReceiptService {
         encrypted: encrypted,
         timestamp: msg['timestamp'] as int,
         messageType: msg['type'] as String,
+        fastFail: true,
+        logOnFailure: false,
       );
       if (ok) {
         await PendingMessageDbHelper.removeMessage(msg['id'] as String);
@@ -508,6 +584,8 @@ class ReadReceiptService {
         encrypted: encrypted,
         timestamp: msg['timestamp'] as int,
         messageType: msg['type'] as String,
+        fastFail: true,
+        logOnFailure: false,
       );
       if (ok) {
         await PendingMessageDbHelper.removeMessage(msg['id'] as String);
@@ -552,6 +630,8 @@ class ReadReceiptService {
         encrypted: msg['message'] as String,
         timestamp: msg['timestamp'] as int,
         messageType: msg['type'] as String,
+        fastFail: true,
+        logOnFailure: false,
       );
       if (ok) {
         await PendingMessageDbHelper.removeMessage(msg['id'] as String);

--- a/lib/util/outbound_read_status_refresh.dart
+++ b/lib/util/outbound_read_status_refresh.dart
@@ -1,0 +1,76 @@
+import 'package:flutter_chat_core/flutter_chat_core.dart';
+import 'package:prysm/database/message_read_receipts.dart';
+import 'package:prysm/util/message_status_mapper.dart';
+
+Map<String, dynamic> dbRowFromOutboundMessage(
+  Message message,
+  String localUserId,
+) {
+  final deliveryStatus = message.metadata?['deliveryStatus'] as String?;
+  final isFailed = message.metadata?['failed'] == true;
+  final isPending = !isFailed &&
+      (deliveryStatus == 'pending' || isOutboundPending(message));
+
+  return {
+    'senderId': localUserId,
+    'status': isPending ? 'pending' : 'sent',
+    'timestamp': message.createdAt?.millisecondsSinceEpoch ?? 0,
+  };
+}
+
+/// Applies read receipt data to [messages] without hitting the database.
+List<Message> applyReadStatusFromReceipts({
+  required List<Message> messages,
+  required String localUserId,
+  required bool readReceiptsEnabled,
+  required Map<String, List<Map<String, dynamic>>> receiptsByWireId,
+  int requiredReadCount = 1,
+}) {
+  if (!readReceiptsEnabled) return messages;
+
+  return messages.map((message) {
+    if (message.authorId != localUserId) return message;
+
+    final isFailed = message.metadata?['failed'] == true;
+    final row = dbRowFromOutboundMessage(message, localUserId);
+    final status = outboundStatusFromDbRow(
+      row: row,
+      localUserId: localUserId,
+      readReceiptsEnabled: readReceiptsEnabled,
+      receipts: receiptsByWireId[message.id] ?? const [],
+      requiredReadCount: requiredReadCount,
+    );
+
+    return applyOutboundStatus(message, status: status, failed: isFailed);
+  }).toList();
+}
+
+/// Re-derives outbound tick/read state from [message_read_receipts] for visible messages.
+Future<List<Message>> refreshOutboundReadStatus({
+  required List<Message> messages,
+  required String localUserId,
+  required bool readReceiptsEnabled,
+  String? groupId,
+  int requiredReadCount = 1,
+}) async {
+  if (!readReceiptsEnabled || messages.isEmpty) return messages;
+
+  final outboundWireIds = messages
+      .where((m) => m.authorId == localUserId)
+      .map((m) => m.id)
+      .toList();
+  if (outboundWireIds.isEmpty) return messages;
+
+  final receipts = await MessageReadReceiptsDb.getReceiptsForMessages(
+    outboundWireIds,
+    groupId: groupId,
+  );
+
+  return applyReadStatusFromReceipts(
+    messages: messages,
+    localUserId: localUserId,
+    readReceiptsEnabled: readReceiptsEnabled,
+    receiptsByWireId: receipts,
+    requiredReadCount: requiredReadCount,
+  );
+}

--- a/test/outbound_read_status_refresh_test.dart
+++ b/test/outbound_read_status_refresh_test.dart
@@ -1,0 +1,134 @@
+import 'package:flutter_chat_core/flutter_chat_core.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:prysm/util/outbound_read_status_refresh.dart';
+
+TextMessage _outbound({
+  required String id,
+  int timestamp = 1000,
+  DateTime? sentAt,
+}) {
+  return TextMessage(
+    authorId: 'me',
+    createdAt: DateTime.fromMillisecondsSinceEpoch(timestamp),
+    id: id,
+    text: 'hi',
+    sentAt: sentAt ?? DateTime.fromMillisecondsSinceEpoch(timestamp),
+    metadata: const {'deliveryStatus': 'sent'},
+  );
+}
+
+void main() {
+  group('applyReadStatusFromReceipts', () {
+    test('waterline: all three outbound messages marked read', () {
+      final messages = [
+        _outbound(id: 'msg-1', timestamp: 100),
+        _outbound(id: 'msg-2', timestamp: 200),
+        _outbound(id: 'msg-3', timestamp: 300),
+      ];
+
+      final refreshed = applyReadStatusFromReceipts(
+        messages: messages,
+        localUserId: 'me',
+        readReceiptsEnabled: true,
+        receiptsByWireId: {
+          'msg-1': [
+            {'readerId': 'peer', 'readAt': 500},
+          ],
+          'msg-2': [
+            {'readerId': 'peer', 'readAt': 500},
+          ],
+          'msg-3': [
+            {'readerId': 'peer', 'readAt': 500},
+          ],
+        },
+      );
+
+      for (final msg in refreshed) {
+        expect(msg.seenAt, isNotNull);
+        expect(msg.metadata?['deliveryStatus'], 'read');
+      }
+    });
+
+    test('direct chat: only messaged with receipt marked read', () {
+      final messages = [
+        _outbound(id: 'msg-1', timestamp: 100),
+        _outbound(id: 'msg-2', timestamp: 200),
+      ];
+
+      final refreshed = applyReadStatusFromReceipts(
+        messages: messages,
+        localUserId: 'me',
+        readReceiptsEnabled: true,
+        receiptsByWireId: {
+          'msg-2': [
+            {'readerId': 'peer', 'readAt': 500},
+          ],
+        },
+      );
+
+      expect(refreshed[0].seenAt, isNull);
+      expect(refreshed[1].seenAt, isNotNull);
+    });
+
+    test('group: partial reads do not mark fully read', () {
+      final messages = [_outbound(id: 'msg-1')];
+
+      final oneReader = applyReadStatusFromReceipts(
+        messages: messages,
+        localUserId: 'me',
+        readReceiptsEnabled: true,
+        receiptsByWireId: {
+          'msg-1': [
+            {'readerId': 'a', 'readAt': 500},
+          ],
+        },
+        requiredReadCount: 2,
+      );
+      expect(oneReader.single.seenAt, isNull);
+
+      final twoReaders = applyReadStatusFromReceipts(
+        messages: messages,
+        localUserId: 'me',
+        readReceiptsEnabled: true,
+        receiptsByWireId: {
+          'msg-1': [
+            {'readerId': 'a', 'readAt': 500},
+            {'readerId': 'b', 'readAt': 600},
+          ],
+        },
+        requiredReadCount: 2,
+      );
+      expect(twoReaders.single.seenAt, isNotNull);
+      expect(
+        twoReaders.single.seenAt!.millisecondsSinceEpoch,
+        600,
+      );
+    });
+
+    test('inbound messages are unchanged', () {
+      final messages = [
+        TextMessage(
+          authorId: 'peer',
+          createdAt: DateTime.fromMillisecondsSinceEpoch(100),
+          id: 'in-1',
+          text: 'hello',
+        ),
+        _outbound(id: 'msg-1'),
+      ];
+
+      final refreshed = applyReadStatusFromReceipts(
+        messages: messages,
+        localUserId: 'me',
+        readReceiptsEnabled: true,
+        receiptsByWireId: {
+          'msg-1': [
+            {'readerId': 'peer', 'readAt': 500},
+          ],
+        },
+      );
+
+      expect(refreshed[0].seenAt, isNull);
+      expect(refreshed[1].seenAt, isNotNull);
+    });
+  });
+}


### PR DESCRIPTION
…s refresh

- Added ReadReceiptService configuration to manage read receipt flushing for peers.
- Implemented outbound read status refresh logic to update message read statuses based on read receipts.
- Refactored _applyReadReceiptUpdate methods in ChatScreen and GroupChatScreen to utilize the new refresh logic.
- Introduced utility functions for applying read status from receipts and added unit tests to ensure functionality.