### PR TITLE
fix: wipe deleted message content and harden file POST over Tor

### DIFF
--- a/lib/client/TorHttpClient.dart
+++ b/lib/client/TorHttpClient.dart
@@ -28,10 +28,14 @@ class TorHttpClient {
     String body,
   ) async {
     final request = await _httpClient.postUrl(uri);
+    final bodyBytes = utf8.encode(body);
     headers.forEach((key, value) {
       request.headers.set(key, value);
     });
-    request.write(body);
+    // Explicit length avoids chunked encoding, which can truncate or corrupt
+    // large JSON bodies (e.g. file messages) through Tor/SOCKS.
+    request.contentLength = bodyBytes.length;
+    request.add(bodyBytes);
     return request.close();
   }
 

--- a/lib/database/messages.dart
+++ b/lib/database/messages.dart
@@ -463,6 +463,7 @@ class MessagesDb {
 					'message': null,
 					'fileName': null,
 					'fileSize': null,
+					'viewOnce': 0,
 				},
 				where: 'id = ?',
 				whereArgs: [storageId],

--- a/lib/screens/chat.dart
+++ b/lib/screens/chat.dart
@@ -43,6 +43,7 @@ import 'package:prysm/screens/widgets/read_receipt_details_sheet.dart';
 import 'package:prysm/util/message_status_mapper.dart';
 import 'package:prysm/util/outbound_read_status_refresh.dart';
 import 'package:prysm/util/read_receipt_refresh_notifier.dart';
+import 'package:prysm/util/message_content_wiper.dart';
 import 'package:prysm/util/message_modify_policy.dart';
 import 'package:prysm/util/message_modify_refresh_notifier.dart';
 import 'package:prysm/util/reaction_refresh_notifier.dart';
@@ -582,8 +583,12 @@ class _ChatScreenState extends State<ChatScreen> {
         continue;
       }
       final meta = metadataFromDbRow(msg);
-      if (meta['deleted'] == true) {
-        messages.add(_deletedMessageFromRow(msg, meta));
+      final wire = msg['message'];
+      if (meta['deleted'] == true || wire == null || (wire is String && wire.isEmpty)) {
+        messages.add(_deletedMessageFromRow(msg, {
+          ...meta,
+          'deleted': true,
+        }));
         continue;
       }
       try {
@@ -1346,6 +1351,7 @@ class _ChatScreenState extends State<ChatScreen> {
     if (canDeleteForEveryone(message, widget.userId)) {
       await _modifyService.deleteMessage(targetMessageId: message.id);
       await MessageReactionsDb.deleteReactionsForMessage(message.id);
+      _messageCache.remove(message.id);
       if (!mounted) return;
       setState(() {
         _messages.updateMessage(message, markMessageDeleted(message));
@@ -1354,8 +1360,10 @@ class _ChatScreenState extends State<ChatScreen> {
       return;
     }
 
+    await MessageContentWiper.wipeLocalArtifacts(wireId: message.id);
     await MessagesDb.deleteMessageById(message.id);
     await MessageReactionsDb.deleteReactionsForMessage(message.id);
+    _messageCache.remove(message.id);
     setState(() {
       _messages.removeMessage(message);
       selectedMessageIds.remove(message.id);
@@ -1403,14 +1411,17 @@ class _ChatScreenState extends State<ChatScreen> {
       if (canDeleteForEveryone(message, widget.userId)) {
         await _modifyService.deleteMessage(targetMessageId: id);
         await MessageReactionsDb.deleteReactionsForMessage(id);
+        _messageCache.remove(id);
         if (mounted) {
           setState(() {
             _messages.updateMessage(message, markMessageDeleted(message));
           });
         }
       } else {
+        await MessageContentWiper.wipeLocalArtifacts(wireId: id);
         await MessagesDb.deleteMessageById(id);
         await MessageReactionsDb.deleteReactionsForMessage(id);
+        _messageCache.remove(id);
         if (mounted) {
           setState(() {
             _messages.removeMessage(message);

--- a/lib/screens/group_chat.dart
+++ b/lib/screens/group_chat.dart
@@ -41,6 +41,7 @@ import 'package:prysm/screens/widgets/read_receipt_details_sheet.dart';
 import 'package:prysm/util/message_status_mapper.dart';
 import 'package:prysm/util/outbound_read_status_refresh.dart';
 import 'package:prysm/util/read_receipt_refresh_notifier.dart';
+import 'package:prysm/util/message_content_wiper.dart';
 import 'package:prysm/util/message_modify_policy.dart';
 import 'package:prysm/util/message_modify_refresh_notifier.dart';
 import 'package:prysm/util/reaction_refresh_notifier.dart';
@@ -379,6 +380,10 @@ class _GroupChatScreenState extends State<GroupChatScreen> {
     }
 
     final storageId = MessagesDb.scopedId(
+      wireId: message.id,
+      groupId: widget.group.id,
+    );
+    await MessageContentWiper.wipeLocalArtifacts(
       wireId: message.id,
       groupId: widget.group.id,
     );
@@ -759,20 +764,21 @@ class _GroupChatScreenState extends State<GroupChatScreen> {
         final replyTo = msg['replyTo'] as String?;
         final meta = metadataFromDbRow(msg);
 
-        if (meta['deleted'] == true) {
+        final wire = msg['message'];
+        if (meta['deleted'] == true || wire == null || (wire is String && wire.isEmpty)) {
           result.add(TextMessage(
             authorId: authorId,
             createdAt: createdAt,
             id: id,
             replyToMessageId: replyTo,
             text: '',
-            metadata: meta,
+            metadata: {...meta, 'deleted': true},
           ));
           continue;
         }
 
         if (type == groupTextType) {
-          final text = GroupCrypto.decryptText(groupKey, msg['message'] as String);
+          final text = GroupCrypto.decryptText(groupKey, wire as String);
           result.add(TextMessage(
             authorId: authorId,
             createdAt: createdAt,

--- a/lib/server/PrysmServer.dart
+++ b/lib/server/PrysmServer.dart
@@ -96,10 +96,32 @@ class PrysmServer {
     }
   }
 
+  Future<Map<String, dynamic>> _readJsonBody(Request request) async {
+    final bodyBytes = await request.read().expand((chunk) => chunk).toList();
+    if (bodyBytes.isEmpty) {
+      throw const FormatException('Empty request body');
+    }
+
+    late final String payload;
+    try {
+      payload = utf8.decode(bodyBytes);
+    } on FormatException catch (e) {
+      print(
+        'PrysmServer: invalid UTF-8 request body (${bodyBytes.length} bytes): $e',
+      );
+      rethrow;
+    }
+
+    final decoded = jsonDecode(payload);
+    if (decoded is! Map<String, dynamic>) {
+      throw const FormatException('JSON body must be an object');
+    }
+    return decoded;
+  }
+
   Future<Response> _handlePostMessage(Request request) async {
     try {
-      final payload = await request.readAsString();
-      final data = jsonDecode(payload) as Map<String, dynamic>;
+      final data = await _readJsonBody(request);
 
       print('PrysmServer: Received ${data['type']} from ${data['senderId']}');
 
@@ -423,6 +445,9 @@ class PrysmServer {
           'timestamp': timeReceived,
         }),
       );
+    } on FormatException catch (e, stack) {
+      print('PrysmServer POST /message invalid body: $e\n$stack');
+      return _badRequest('Invalid message body');
     } catch (e, stack) {
       print('PrysmServer POST /message Error $e\n$stack');
       return Response.internalServerError(
@@ -434,8 +459,7 @@ class PrysmServer {
 
   Future<Response> _handlePostSyncHint(Request request) async {
     try {
-      final payload = await request.readAsString();
-      final data = jsonDecode(payload) as Map<String, dynamic>;
+      final data = await _readJsonBody(request);
 
       final validationError = WakeHintService.validateSyncHintPayload(
         data,
@@ -460,6 +484,9 @@ class PrysmServer {
         jsonEncode({'status': 'ok'}),
         headers: {'Content-Type': 'application/json'},
       );
+    } on FormatException catch (e, stack) {
+      print('PrysmServer POST /sync-hint invalid body: $e\n$stack');
+      return _badRequest('Invalid sync-hint body');
     } catch (e, stack) {
       print('PrysmServer POST /sync-hint Error $e\n$stack');
       return Response.internalServerError(

--- a/lib/services/chat_service.dart
+++ b/lib/services/chat_service.dart
@@ -640,9 +640,19 @@ class ChatService {
           continue;
         }
         final msgId = msg['id'] as String;
+        final stored = await MessagesDb.getMessageById(msgId);
+        if (stored.isNotEmpty && stored.first['deletedAt'] != null) {
+          await PendingMessageDbHelper.removeOutboundPendingForWireId(msgId);
+          continue;
+        }
+        final encrypted = msg['message'] as String?;
+        if (encrypted == null || encrypted.isEmpty) {
+          await PendingMessageDbHelper.removeOutboundPendingForWireId(msgId);
+          continue;
+        }
         final success = await _sendOverTor(
           msgId,
-          msg['message'] as String,
+          encrypted,
           msg['type'] as String,
           replyToId: msg['replyTo'] as String?,
           fileName: msg['fileName'] as String?,
@@ -685,6 +695,10 @@ class ChatService {
     final rows = await MessagesDb.getMessageById(messageId);
     if (rows.isEmpty) return;
     final msg = rows.first;
+    if (msg['deletedAt'] != null) {
+      await PendingMessageDbHelper.removeOutboundPendingForWireId(messageId);
+      return;
+    }
 
     // Re-encrypt the stored self-payload for the peer
     // The message column has the self-encrypted payload, but we need

--- a/lib/services/group_chat_service.dart
+++ b/lib/services/group_chat_service.dart
@@ -580,11 +580,30 @@ class GroupChatService {
         if (_disposed) break;
         final pendingId = msg['id'] as String;
         final messageId = _messageIdFromPendingId(pendingId);
+        final stored = await MessagesDb.getMessageById(
+          messageId,
+          groupId: groupId,
+        );
+        if (stored.isNotEmpty && stored.first['deletedAt'] != null) {
+          await PendingMessageDbHelper.removeOutboundPendingForWireId(
+            messageId,
+            groupId: groupId,
+          );
+          continue;
+        }
+        final encrypted = msg['message'] as String?;
+        if (encrypted == null || encrypted.isEmpty) {
+          await PendingMessageDbHelper.removeOutboundPendingForWireId(
+            messageId,
+            groupId: groupId,
+          );
+          continue;
+        }
         final target = msg['targetMemberId'] as String? ?? msg['receiverId'] as String;
         final success = await _sendOverTor(
           id: messageId,
           targetMemberId: target,
-          encrypted: msg['message'] as String,
+          encrypted: encrypted,
           type: msg['type'] as String,
           replyToId: msg['replyTo'] as String?,
           timestamp: msg['timestamp'] as int? ?? DateTime.now().millisecondsSinceEpoch,

--- a/lib/services/message_modify_service.dart
+++ b/lib/services/message_modify_service.dart
@@ -11,6 +11,7 @@ import 'package:prysm/services/group_service.dart';
 import 'package:prysm/util/db_helper.dart';
 import 'package:prysm/util/group_crypto.dart';
 import 'package:prysm/util/key_manager.dart';
+import 'package:prysm/util/message_content_wiper.dart';
 import 'package:prysm/util/message_modify_payload.dart';
 import 'package:prysm/util/message_modify_refresh_notifier.dart';
 import 'package:prysm/util/pending_message_db_helper.dart';
@@ -70,6 +71,10 @@ class MessageModifyService {
       targetMessageId,
       groupId: groupId,
       deletedAt: modifiedAt,
+    );
+    await MessageContentWiper.wipeLocalArtifacts(
+      wireId: targetMessageId,
+      groupId: groupId,
     );
 
     final payload = MessageModifyPayload(
@@ -480,6 +485,10 @@ class MessageModifyService {
         payload.targetMessageId,
         groupId: groupId,
         deletedAt: payload.modifiedAt,
+      );
+      await MessageContentWiper.wipeLocalArtifacts(
+        wireId: payload.targetMessageId,
+        groupId: groupId,
       );
     } else if (payload.isEdit && payload.encryptedBody != null) {
       await MessagesDb.updateMessageContent(

--- a/lib/util/message_content_wiper.dart
+++ b/lib/util/message_content_wiper.dart
@@ -1,0 +1,37 @@
+import 'dart:io';
+
+import 'package:path_provider/path_provider.dart';
+import 'package:prysm/services/image_attachment_cache.dart';
+import 'package:prysm/util/pending_message_db_helper.dart';
+
+/// Removes ciphertext and media artifacts for a message id.
+class MessageContentWiper {
+  MessageContentWiper._();
+
+  static Future<void> wipeLocalArtifacts({
+    required String wireId,
+    String? groupId,
+  }) async {
+    await PendingMessageDbHelper.removeOutboundPendingForWireId(
+      wireId,
+      groupId: groupId,
+    );
+    await ImageAttachmentCache.invalidate(wireId);
+    await _deleteVoiceCaches(wireId);
+  }
+
+  static Future<void> _deleteVoiceCaches(String messageId) async {
+    try {
+      final dir = await getTemporaryDirectory();
+      for (final name in [
+        'voice_cache_$messageId.wav',
+        'group_voice_cache_$messageId.wav',
+      ]) {
+        final file = File('${dir.path}/$name');
+        if (await file.exists()) {
+          await file.delete();
+        }
+      }
+    } catch (_) {}
+  }
+}

--- a/lib/util/pending_message_db_helper.dart
+++ b/lib/util/pending_message_db_helper.dart
@@ -189,6 +189,28 @@ class PendingMessageDbHelper {
     PendingActivityNotifier.instance.notify();
   }
 
+  /// Drops queued outbound chat deliveries for a wire message id.
+  static Future<void> removeOutboundPendingForWireId(
+    String wireId, {
+    String? groupId,
+  }) async {
+    final db = await database;
+    if (groupId != null) {
+      await db.delete(
+        'pending_messages',
+        where: 'groupId = ? AND (id = ? OR id LIKE ?)',
+        whereArgs: [groupId, wireId, '${wireId}__%'],
+      );
+    } else {
+      await db.delete(
+        'pending_messages',
+        where: 'groupId IS NULL AND id = ?',
+        whereArgs: [wireId],
+      );
+    }
+    PendingActivityNotifier.instance.notify();
+  }
+
   static Future<void> closeForWipe() async {
     if (_database != null) {
       await _database!.close();

--- a/test/message_content_wiper_test.dart
+++ b/test/message_content_wiper_test.dart
@@ -1,0 +1,76 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:prysm/constants/group_constants.dart';
+import 'package:prysm/util/pending_message_db_helper.dart';
+import 'package:sqflite_common_ffi/sqflite_ffi.dart';
+
+void main() {
+  setUpAll(() {
+    sqfliteFfiInit();
+    databaseFactory = databaseFactoryFfi;
+  });
+
+  test('removeOutboundPendingForWireId drops direct and group rows', () async {
+    final db = await databaseFactory.openDatabase(
+      inMemoryDatabasePath,
+      options: OpenDatabaseOptions(
+        version: 4,
+        onCreate: (db, version) async {
+          await db.execute('''
+            CREATE TABLE pending_messages(
+              id TEXT PRIMARY KEY,
+              senderId TEXT,
+              receiverId TEXT,
+              message TEXT,
+              type TEXT,
+              fileName TEXT,
+              fileSize INTEGER,
+              timestamp INTEGER,
+              status TEXT,
+              replyTo TEXT,
+              viewOnce INTEGER DEFAULT 0,
+              groupId TEXT,
+              targetMemberId TEXT
+            )
+          ''');
+        },
+      ),
+    );
+    PendingMessageDbHelper.setDatabaseForTest(db);
+
+    await PendingMessageDbHelper.insertPendingMessage({
+      'id': 'msg1',
+      'senderId': 'me',
+      'receiverId': 'peer',
+      'message': 'cipher',
+      'type': 'file',
+      'timestamp': 1,
+      'status': 'pending',
+    });
+    await PendingMessageDbHelper.insertPendingMessage({
+      'id': 'msg2__memberB',
+      'senderId': 'me',
+      'receiverId': 'memberB',
+      'message': 'cipher',
+      'type': groupFileType,
+      'timestamp': 1,
+      'status': 'pending',
+      'groupId': 'g1',
+      'targetMemberId': 'memberB',
+    });
+
+    await PendingMessageDbHelper.removeOutboundPendingForWireId('msg1');
+    var rows = await db.query('pending_messages');
+    expect(rows.length, 1);
+    expect(rows.first['id'], 'msg2__memberB');
+
+    await PendingMessageDbHelper.removeOutboundPendingForWireId(
+      'msg2',
+      groupId: 'g1',
+    );
+    rows = await db.query('pending_messages');
+    expect(rows, isEmpty);
+
+    PendingMessageDbHelper.setDatabaseForTest(null);
+    await db.close();
+  });
+}


### PR DESCRIPTION
- Send POST bodies with explicit Content-Length in TorHttpClient to avoid chunked encoding corrupting large file message JSON through Tor/SOCKS.
- Read /message and /sync-hint bodies as bytes in PrysmServer and return 400 on invalid UTF-8/JSON instead of 500.
- Add MessageContentWiper to purge pending outbound rows, image cache, and voice temp files when a message is deleted.
- Stop pending retry and resend for soft-deleted or empty-ciphertext messages.
- Treat null/empty DB payloads as deleted in chat UI and clear message cache on delete; clear viewOnce on soft delete.