### PR TITLE
feat: add typing indicators functionality across chat screens

### DIFF
--- a/lib/models/settings.dart
+++ b/lib/models/settings.dart
@@ -6,6 +6,7 @@ class Settings {
   final bool enableNotifications;
   final bool showOnlineStatus;
   final bool sendReadReceipts;
+  final bool enableTypingIndicators;
   final bool minimizeToTray;
   final bool minimizeOnMinimizeButton;
   final bool enableBatterySaving;
@@ -39,6 +40,7 @@ class Settings {
     this.enableNotifications = true,
     this.showOnlineStatus = true,
     this.sendReadReceipts = true,
+    this.enableTypingIndicators = true,
     this.minimizeToTray = true,
     this.minimizeOnMinimizeButton = false,
     this.enableBatterySaving = false,
@@ -62,6 +64,7 @@ class Settings {
     'enableNotifications': enableNotifications,
     'showOnlineStatus': showOnlineStatus,
     'sendReadReceipts': sendReadReceipts,
+    'enableTypingIndicators': enableTypingIndicators,
     'minimizeToTray': minimizeToTray,
     'minimizeOnMinimizeButton': minimizeOnMinimizeButton,
     'enableBatterySaving': enableBatterySaving,
@@ -85,6 +88,7 @@ class Settings {
     enableNotifications: json['enableNotifications'] ?? true,
     showOnlineStatus: json['showOnlineStatus'] ?? true,
     sendReadReceipts: json['sendReadReceipts'] ?? true,
+    enableTypingIndicators: json['enableTypingIndicators'] ?? true,
     minimizeToTray: json['minimizeToTray'] ?? true,
     minimizeOnMinimizeButton: json['minimizeOnMinimizeButton'] ?? false,
     enableBatterySaving: json['enableBatterySaving'] ?? false,
@@ -108,6 +112,7 @@ class Settings {
     bool? enableNotifications,
     bool? showOnlineStatus,
     bool? sendReadReceipts,
+    bool? enableTypingIndicators,
     bool? minimizeToTray,
     bool? minimizeOnMinimizeButton,
     bool? enableBatterySaving,
@@ -129,6 +134,8 @@ class Settings {
     enableNotifications: enableNotifications ?? this.enableNotifications,
     showOnlineStatus: showOnlineStatus ?? this.showOnlineStatus,
     sendReadReceipts: sendReadReceipts ?? this.sendReadReceipts,
+    enableTypingIndicators:
+        enableTypingIndicators ?? this.enableTypingIndicators,
     minimizeToTray: minimizeToTray ?? this.minimizeToTray,
     minimizeOnMinimizeButton:
         minimizeOnMinimizeButton ?? this.minimizeOnMinimizeButton,
@@ -170,6 +177,7 @@ class Settings {
         other.enableNotifications == enableNotifications &&
         other.showOnlineStatus == showOnlineStatus &&
         other.sendReadReceipts == sendReadReceipts &&
+        other.enableTypingIndicators == enableTypingIndicators &&
         other.minimizeToTray == minimizeToTray &&
         other.minimizeOnMinimizeButton == minimizeOnMinimizeButton &&
         other.enableBatterySaving == enableBatterySaving &&
@@ -193,6 +201,7 @@ class Settings {
     return enableNotifications.hashCode ^
         showOnlineStatus.hashCode ^
         sendReadReceipts.hashCode ^
+        enableTypingIndicators.hashCode ^
         minimizeToTray.hashCode ^
         minimizeOnMinimizeButton.hashCode ^
         enableBatterySaving.hashCode ^

--- a/lib/screens/chat.dart
+++ b/lib/screens/chat.dart
@@ -54,6 +54,9 @@ import 'package:prysm/util/waveform_extractor.dart';
 import 'package:prysm/services/battery_saver_service.dart';
 import 'package:prysm/services/chat_service.dart'; // ✅ ADD THIS
 import 'package:prysm/services/conversation_preferences_service.dart';
+import 'package:prysm/services/typing_indicator_service.dart';
+import 'package:prysm/services/typing_state_tracker.dart';
+import 'package:prysm/util/typing_indicator_notifier.dart';
 import 'package:prysm/util/battery_saver_policy.dart';
 import 'package:prysm/util/db_helper.dart';
 import 'package:prysm/util/file_encrypt.dart';
@@ -148,6 +151,10 @@ class _ChatScreenState extends State<ChatScreen> {
   late MessageModifyService _modifyService;
   String? _highlightedMessageId;
   Timer? _highlightTimer;
+  late TypingIndicatorService _typingService;
+  final _typingTracker = TypingStateTracker();
+  StreamSubscription<TypingIndicatorEvent>? _typingSub;
+  StreamSubscription<void>? _typingTrackerSub;
 
   void _onListScroll() {
     _stickToBottom = isChatScrolledToBottom(_listScrollController);
@@ -196,6 +203,15 @@ class _ChatScreenState extends State<ChatScreen> {
       keyManager: widget.keyManager,
       peerId: widget.peerId,
     );
+    _typingService = TypingIndicatorService.direct(
+      userId: widget.userId,
+      peerId: widget.peerId,
+      settings: _settings,
+    );
+    _typingSub = TypingIndicatorNotifier.instance.events.listen(_onTypingEvent);
+    _typingTrackerSub = _typingTracker.onChanged.listen((_) {
+      if (mounted) setState(() {});
+    });
 
     _presenceTracker = PeerPresenceTracker();
     _listScrollController.addListener(_onListScroll);
@@ -288,6 +304,30 @@ class _ChatScreenState extends State<ChatScreen> {
     _presenceTracker.suspendProbeFailuresFor(
       BatterySaverPolicy.mediaUploadPresenceGrace,
     );
+  }
+
+  void _onTypingEvent(TypingIndicatorEvent event) {
+    if (event.groupId != null) return;
+    if (event.senderId != widget.peerId) return;
+
+    _typingTracker.applyEvent(
+      conversationKey: widget.peerId,
+      senderId: event.senderId,
+      typing: event.typing,
+      timestamp: event.timestamp,
+    );
+  }
+
+  List<String> _typingTypistNames() {
+    if (!_settings.enableTypingIndicators) return const [];
+    return _typingTracker
+        .activeTypists(widget.peerId)
+        .map((id) => _peerName.isNotEmpty ? _peerName : id)
+        .toList(growable: false);
+  }
+
+  void _onComposerTypingChanged(bool isTyping) {
+    _typingService.onComposerTypingChanged(isTyping);
   }
 
   // ✅ NEW: Handle incoming messages from ChatService
@@ -394,6 +434,10 @@ class _ChatScreenState extends State<ChatScreen> {
 
   @override
   void dispose() {
+    _typingService.dispose();
+    _typingSub?.cancel();
+    _typingTrackerSub?.cancel();
+    _typingTracker.dispose();
     // ✅ DISPOSE ChatService
     _chatService.dispose();
     _reactionService.dispose();
@@ -531,6 +575,13 @@ class _ChatScreenState extends State<ChatScreen> {
         userId: widget.userId,
         keyManager: widget.keyManager,
         peerId: widget.peerId,
+      );
+      _typingService.dispose();
+      _typingTracker.clearConversation(oldWidget.peerId);
+      _typingService = TypingIndicatorService.direct(
+        userId: widget.userId,
+        peerId: widget.peerId,
+        settings: _settings,
       );
 
       _initializeChat();
@@ -1843,10 +1894,12 @@ class _ChatScreenState extends State<ChatScreen> {
                       replyPreview: _replyToMessage != null
                           ? _buildReplyPreview()
                           : null,
+                      typingTypistNames: _typingTypistNames(),
                       onSendText: _handleSendText,
                       onSendImage: _handleSendImage,
                       onSendFile: _handleSendFile,
                       onSendVoice: _handleSendVoice,
+                      onTypingChanged: _onComposerTypingChanged,
                     );
                   },
                 ),

--- a/lib/screens/group_chat.dart
+++ b/lib/screens/group_chat.dart
@@ -52,6 +52,9 @@ import 'package:prysm/util/reaction_refresh_notifier.dart';
 import 'package:prysm/util/waveform_extractor.dart';
 import 'package:prysm/services/group_chat_service.dart';
 import 'package:prysm/services/group_service.dart';
+import 'package:prysm/services/typing_indicator_service.dart';
+import 'package:prysm/services/typing_state_tracker.dart';
+import 'package:prysm/util/typing_indicator_notifier.dart';
 import 'package:prysm/util/db_helper.dart';
 import 'package:prysm/util/group_crypto.dart';
 import 'package:prysm/util/group_membership_notifier.dart';
@@ -117,6 +120,10 @@ class _GroupChatScreenState extends State<GroupChatScreen> {
   Message? _replyToMessage;
   final Set<String> selectedMessageIds = {};
   final Map<String, double> _dragOffsets = {};
+  late TypingIndicatorService _typingService;
+  final _typingTracker = TypingStateTracker();
+  StreamSubscription<TypingIndicatorEvent>? _typingSub;
+  StreamSubscription<void>? _typingTrackerSub;
 
   @override
   void initState() {
@@ -170,6 +177,16 @@ class _GroupChatScreenState extends State<GroupChatScreen> {
       groupId: widget.group.id,
       groupService: _groupService,
     );
+    _typingService = TypingIndicatorService.group(
+      userId: widget.userId,
+      groupId: widget.group.id,
+      memberIds: const [],
+      settings: _settings,
+    );
+    _typingSub = TypingIndicatorNotifier.instance.events.listen(_onTypingEvent);
+    _typingTrackerSub = _typingTracker.onChanged.listen((_) {
+      if (mounted) setState(() {});
+    });
     _init();
   }
 
@@ -190,6 +207,10 @@ class _GroupChatScreenState extends State<GroupChatScreen> {
   }
 
   void _teardown() {
+    _typingService.dispose();
+    _typingSub?.cancel();
+    _typingTrackerSub?.cancel();
+    _typingTracker.clearConversation(widget.group.id);
     _newMessagesSub?.cancel();
     _statusSub?.cancel();
     _reactionSub?.cancel();
@@ -235,6 +256,13 @@ class _GroupChatScreenState extends State<GroupChatScreen> {
     _memberCount = members.length;
     _groupMemberIds = members.map((m) => m.memberId).toList();
     await _resolveSenderNames(_groupMemberIds);
+    _typingService.dispose();
+    _typingService = TypingIndicatorService.group(
+      userId: widget.userId,
+      groupId: widget.group.id,
+      memberIds: _groupMemberIds,
+      settings: _settings,
+    );
 
     final ok = await _chatService.initialize();
     if (!ok && mounted) {
@@ -267,6 +295,30 @@ class _GroupChatScreenState extends State<GroupChatScreen> {
     }
 
     if (mounted) setState(() {});
+  }
+
+  void _onTypingEvent(TypingIndicatorEvent event) {
+    if (event.groupId != widget.group.id) return;
+    if (event.senderId == widget.userId) return;
+
+    _typingTracker.applyEvent(
+      conversationKey: widget.group.id,
+      senderId: event.senderId,
+      typing: event.typing,
+      timestamp: event.timestamp,
+    );
+  }
+
+  List<String> _typingTypistNames() {
+    if (!_settings.enableTypingIndicators) return const [];
+    return _typingTracker
+        .activeTypists(widget.group.id)
+        .map((id) => _senderNames[id] ?? id)
+        .toList(growable: false);
+  }
+
+  void _onComposerTypingChanged(bool isTyping) {
+    _typingService.onComposerTypingChanged(isTyping);
   }
 
   Widget _buildReplyPreview() {
@@ -1171,6 +1223,7 @@ class _GroupChatScreenState extends State<GroupChatScreen> {
   @override
   void dispose() {
     _teardown();
+    _typingTracker.dispose();
     _highlightTimer?.cancel();
     _listScrollController.removeListener(_onListScroll);
     _listScrollController.dispose();
@@ -1733,10 +1786,12 @@ class _GroupChatScreenState extends State<GroupChatScreen> {
                 replyPreview: _replyToMessage != null
                     ? _buildReplyPreview()
                     : null,
+                typingTypistNames: _typingTypistNames(),
                 onSendText: _handleSendText,
                 onSendImage: _handleSendImage,
                 onSendFile: _handleSendFile,
                 onSendVoice: _handleSendVoice,
+                onTypingChanged: _onComposerTypingChanged,
               );
             },
           ),

--- a/lib/screens/message_composer.dart
+++ b/lib/screens/message_composer.dart
@@ -13,6 +13,7 @@ class MessageComposer extends StatefulWidget {
   final VoidCallback onSendImage;
   final VoidCallback onSendFile;
   final Function(Uint8List bytes, int durationMs)? onSendVoice;
+  final ValueChanged<bool>? onTypingChanged;
   final VoidCallback? onLayoutChanged;
 
   const MessageComposer({
@@ -21,6 +22,7 @@ class MessageComposer extends StatefulWidget {
     required this.onSendImage,
     required this.onSendFile,
     this.onSendVoice,
+    this.onTypingChanged,
     this.onLayoutChanged,
   });
 
@@ -42,6 +44,7 @@ class MessageComposerState extends State<MessageComposer> {
 
   @override
   void dispose() {
+    widget.onTypingChanged?.call(false);
     _textController.dispose();
     _recordTimer?.cancel();
     _recorder.dispose();
@@ -52,10 +55,15 @@ class MessageComposerState extends State<MessageComposer> {
     widget.onLayoutChanged?.call();
   }
 
+  void _notifyTypingFromText(String text) {
+    widget.onTypingChanged?.call(text.trim().isNotEmpty);
+  }
+
   void _handleSend() {
     final text = currentText.trim();
     if (text.isEmpty) return;
     widget.onSendText(text);
+    widget.onTypingChanged?.call(false);
     _textController.clear();
     setState(() {
       currentText = '';
@@ -79,6 +87,7 @@ class MessageComposerState extends State<MessageComposer> {
     setState(() {
       currentText = newText;
     });
+    _notifyTypingFromText(newText);
   }
 
   Future<void> _startRecording() async {
@@ -111,6 +120,7 @@ class MessageComposerState extends State<MessageComposer> {
       _isRecording = true;
       _recordDuration = Duration.zero;
     });
+    widget.onTypingChanged?.call(false);
     WidgetsBinding.instance.addPostFrameCallback((_) => _notifyLayoutChanged());
 
     _recordTimer = Timer.periodic(const Duration(seconds: 1), (_) {
@@ -262,7 +272,10 @@ class MessageComposerState extends State<MessageComposer> {
         Expanded(
           child: TextField(
             controller: _textController,
-            onChanged: (text) => setState(() => currentText = text),
+            onChanged: (text) {
+              setState(() => currentText = text);
+              _notifyTypingFromText(text);
+            },
             onSubmitted: (_) => _handleSend(),
             decoration: InputDecoration(
               hintText: 'Type a message',

--- a/lib/screens/privacy_settings_screen.dart
+++ b/lib/screens/privacy_settings_screen.dart
@@ -24,6 +24,7 @@ class _PrivacySettingsScreenState extends State<PrivacySettingsScreen> {
 
   bool _showOnlineStatus = true;
   bool _readReceipts = true;
+  bool _typingIndicators = true;
   bool _lastSeen = true;
   bool _profilePhoto = true;
 
@@ -38,6 +39,7 @@ class _PrivacySettingsScreenState extends State<PrivacySettingsScreen> {
     setState(() {
       _showOnlineStatus = prefs.getBool('show_online_status') ?? true;
       _readReceipts = settings.sendReadReceipts;
+      _typingIndicators = settings.enableTypingIndicators;
       _lastSeen = prefs.getBool('last_seen') ?? true;
       _profilePhoto = prefs.getBool('profile_photo') ?? true;
     });
@@ -61,6 +63,13 @@ class _PrivacySettingsScreenState extends State<PrivacySettingsScreen> {
       _readReceipts = value;
     });
     await settings.setSendReadReceipts(value);
+  }
+
+  Future<void> _onTypingIndicatorsToggle(bool value) async {
+    setState(() {
+      _typingIndicators = value;
+    });
+    await settings.setEnableTypingIndicators(value);
   }
 
   void _onLastSeenToggle(bool value) {
@@ -148,6 +157,35 @@ class _PrivacySettingsScreenState extends State<PrivacySettingsScreen> {
                       Icons.check_circle_outline_outlined,
                       _readReceipts,
                       _onReadReceiptsToggle,
+                    ),
+                    const Divider(height: 1),
+                    ListTile(
+                      leading: const Icon(Icons.edit_outlined),
+                      title: const Text('Typing Indicators'),
+                      subtitle: const Text(
+                        "When disabled, you won't send or see typing activity in chats.",
+                      ),
+                      trailing: Container(
+                        padding: const EdgeInsets.all(2),
+                        decoration: BoxDecoration(
+                          borderRadius: BorderRadius.circular(12),
+                          color: Theme.of(context).brightness == Brightness.dark
+                              ? Colors.white.withValues(alpha: 0.1)
+                              : Colors.black.withValues(alpha: 0.05),
+                        ),
+                        child: Switch(
+                          value: _typingIndicators,
+                          onChanged: _onTypingIndicatorsToggle,
+                          activeThumbColor: Colors.white,
+                          activeTrackColor: Theme.of(context).primaryColor,
+                          inactiveThumbColor: Colors.white,
+                          inactiveTrackColor:
+                              Theme.of(context).brightness == Brightness.dark
+                                  ? Colors.grey[700]
+                                  : Colors.grey[400],
+                        ),
+                      ),
+                      onTap: () => _onTypingIndicatorsToggle(!_typingIndicators),
                     ),
                     const Divider(height: 1),
                     _buildPrivacyOption(

--- a/lib/screens/widgets/prysm_chat_composer_overlay.dart
+++ b/lib/screens/widgets/prysm_chat_composer_overlay.dart
@@ -4,22 +4,27 @@ import 'package:flutter/material.dart';
 import 'package:flutter_chat_ui/flutter_chat_ui.dart';
 import 'package:provider/provider.dart';
 import 'package:prysm/screens/message_composer.dart';
+import 'package:prysm/screens/widgets/typing_indicator_bar.dart';
 
 /// Bottom overlay composer for [Chat], reporting height to [ComposerHeightNotifier].
 class PrysmChatComposerOverlay extends StatefulWidget {
   final Widget? replyPreview;
+  final List<String> typingTypistNames;
   final void Function(String) onSendText;
   final VoidCallback onSendImage;
   final VoidCallback onSendFile;
   final void Function(Uint8List bytes, int durationMs)? onSendVoice;
+  final ValueChanged<bool>? onTypingChanged;
 
   const PrysmChatComposerOverlay({
     super.key,
     this.replyPreview,
+    this.typingTypistNames = const [],
     required this.onSendText,
     required this.onSendImage,
     required this.onSendFile,
     this.onSendVoice,
+    this.onTypingChanged,
   });
 
   @override
@@ -39,7 +44,8 @@ class _PrysmChatComposerOverlayState extends State<PrysmChatComposerOverlay> {
   @override
   void didUpdateWidget(covariant PrysmChatComposerOverlay oldWidget) {
     super.didUpdateWidget(oldWidget);
-    if (oldWidget.replyPreview != widget.replyPreview) {
+    if (oldWidget.replyPreview != widget.replyPreview ||
+        oldWidget.typingTypistNames != widget.typingTypistNames) {
       WidgetsBinding.instance.addPostFrameCallback((_) => _measure());
     }
   }
@@ -68,11 +74,13 @@ class _PrysmChatComposerOverlayState extends State<PrysmChatComposerOverlay> {
           mainAxisSize: MainAxisSize.min,
           children: [
             if (widget.replyPreview != null) widget.replyPreview!,
+            TypingIndicatorBar(typistNames: widget.typingTypistNames),
             MessageComposer(
               onSendText: widget.onSendText,
               onSendImage: widget.onSendImage,
               onSendFile: widget.onSendFile,
               onSendVoice: widget.onSendVoice,
+              onTypingChanged: widget.onTypingChanged,
               onLayoutChanged: _measure,
             ),
           ],

--- a/lib/screens/widgets/typing_indicator_bar.dart
+++ b/lib/screens/widgets/typing_indicator_bar.dart
@@ -1,0 +1,104 @@
+import 'package:flutter/material.dart';
+
+class TypingIndicatorBar extends StatelessWidget {
+  final List<String> typistNames;
+
+  const TypingIndicatorBar({
+    required this.typistNames,
+    super.key,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    if (typistNames.isEmpty) return const SizedBox.shrink();
+
+    final label = _labelFor(typistNames);
+    final theme = Theme.of(context);
+
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(12, 4, 12, 0),
+      child: Row(
+        children: [
+          _TypingDots(color: theme.colorScheme.primary),
+          const SizedBox(width: 8),
+          Expanded(
+            child: Text(
+              label,
+              maxLines: 1,
+              overflow: TextOverflow.ellipsis,
+              style: TextStyle(
+                fontSize: 12,
+                color: theme.colorScheme.onSurfaceVariant,
+                fontStyle: FontStyle.italic,
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  String _labelFor(List<String> names) {
+    if (names.length == 1) {
+      return '${names.first} is typing…';
+    }
+    if (names.length == 2) {
+      return '${names[0]} and ${names[1]} are typing…';
+    }
+    return 'Several people are typing…';
+  }
+}
+
+class _TypingDots extends StatefulWidget {
+  final Color color;
+
+  const _TypingDots({required this.color});
+
+  @override
+  State<_TypingDots> createState() => _TypingDotsState();
+}
+
+class _TypingDotsState extends State<_TypingDots>
+    with SingleTickerProviderStateMixin {
+  late final AnimationController _controller;
+
+  @override
+  void initState() {
+    super.initState();
+    _controller = AnimationController(
+      vsync: this,
+      duration: const Duration(milliseconds: 1200),
+    )..repeat();
+  }
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return AnimatedBuilder(
+      animation: _controller,
+      builder: (context, child) {
+        return Row(
+          mainAxisSize: MainAxisSize.min,
+          children: List.generate(3, (index) {
+            final phase = (_controller.value + index * 0.2) % 1.0;
+            final opacity = 0.3 + (phase < 0.5 ? phase : 1 - phase);
+            return Container(
+              width: 5,
+              height: 5,
+              margin: const EdgeInsets.symmetric(horizontal: 1.5),
+              decoration: BoxDecoration(
+                color: widget.color.withValues(alpha: opacity),
+                shape: BoxShape.circle,
+              ),
+            );
+          }),
+        );
+      },
+    );
+  }
+}

--- a/lib/server/PrysmServer.dart
+++ b/lib/server/PrysmServer.dart
@@ -7,6 +7,7 @@ import 'package:prysm/client/TorHttpClient.dart';
 import 'package:prysm/server/inbound_message_router.dart';
 import 'package:prysm/transport/transport_preference.dart';
 import 'package:prysm/transport/transport_provider.dart';
+import 'package:prysm/util/typing_indicator_notifier.dart';
 import 'package:prysm/transport/ws_protocol.dart';
 import 'package:prysm/util/db_helper.dart';
 import 'package:prysm/util/key_manager.dart';
@@ -240,6 +241,14 @@ class PrysmServer {
           payload: {'publicKeyPem': result.plainTextBody ?? ''},
         ).encode(),
       );
+      return;
+    }
+
+    if (frame.op == 'typing_update') {
+      final payload = frame.payload;
+      if (payload != null) {
+        TypingIndicatorNotifier.instance.applyInbound(payload);
+      }
       return;
     }
 

--- a/lib/services/settings_service.dart
+++ b/lib/services/settings_service.dart
@@ -32,6 +32,7 @@ class SettingsService {
   bool get enableNotifications => _settings.enableNotifications;
   bool get showOnlineStatus => _settings.showOnlineStatus;
   bool get sendReadReceipts => _settings.sendReadReceipts;
+  bool get enableTypingIndicators => _settings.enableTypingIndicators;
   bool get minimizeToTray => _settings.minimizeToTray;
   bool get minimizeOnMinimizeButton => _settings.minimizeOnMinimizeButton;
   bool get enableBatterySaving => _settings.enableBatterySaving;
@@ -135,6 +136,11 @@ class SettingsService {
 
   Future<void> setSendReadReceipts(bool value) async {
     _settings = _settings.copyWith(sendReadReceipts: value);
+    await save();
+  }
+
+  Future<void> setEnableTypingIndicators(bool value) async {
+    _settings = _settings.copyWith(enableTypingIndicators: value);
     await save();
   }
 

--- a/lib/services/typing_indicator_service.dart
+++ b/lib/services/typing_indicator_service.dart
@@ -30,23 +30,21 @@ class TypingIndicatorService {
 
   TypingIndicatorService.direct({
     required this.userId,
-    required String peerId,
+    required this.peerId,
     SettingsService? settings,
     TypingSendFn? sendOverride,
-  })  : peerId = peerId,
-        groupId = null,
+  })  : groupId = null,
         memberIds = null,
         _settings = settings ?? SettingsService(),
         _sendOverride = sendOverride;
 
   TypingIndicatorService.group({
     required this.userId,
-    required String groupId,
+    required this.groupId,
     required List<String> memberIds,
     SettingsService? settings,
     TypingSendFn? sendOverride,
   })  : peerId = null,
-        groupId = groupId,
         memberIds = List<String>.from(memberIds),
         _settings = settings ?? SettingsService(),
         _sendOverride = sendOverride;

--- a/lib/services/typing_indicator_service.dart
+++ b/lib/services/typing_indicator_service.dart
@@ -1,0 +1,162 @@
+import 'dart:async';
+
+import 'package:flutter/foundation.dart';
+import 'package:prysm/services/settings_service.dart';
+import 'package:prysm/transport/transport_provider.dart';
+
+typedef TypingSendFn = Future<void> Function(
+  String peerOnion,
+  Map<String, dynamic> payload,
+);
+
+/// Sends debounced typing_update frames over WebSocket.
+class TypingIndicatorService {
+  static const _idleStopDelay = Duration(seconds: 3);
+  static const _refreshInterval = Duration(seconds: 3);
+  static const _throttleInterval = Duration(seconds: 2);
+
+  final String userId;
+  final String? peerId;
+  final String? groupId;
+  final List<String>? memberIds;
+  final SettingsService _settings;
+  final TypingSendFn? _sendOverride;
+
+  bool _isTyping = false;
+  Timer? _idleTimer;
+  Timer? _refreshTimer;
+  DateTime? _lastSentAt;
+  bool _disposed = false;
+
+  TypingIndicatorService.direct({
+    required this.userId,
+    required String peerId,
+    SettingsService? settings,
+    TypingSendFn? sendOverride,
+  })  : peerId = peerId,
+        groupId = null,
+        memberIds = null,
+        _settings = settings ?? SettingsService(),
+        _sendOverride = sendOverride;
+
+  TypingIndicatorService.group({
+    required this.userId,
+    required String groupId,
+    required List<String> memberIds,
+    SettingsService? settings,
+    TypingSendFn? sendOverride,
+  })  : peerId = null,
+        groupId = groupId,
+        memberIds = List<String>.from(memberIds),
+        _settings = settings ?? SettingsService(),
+        _sendOverride = sendOverride;
+
+  bool get isGroup => groupId != null;
+
+  void onComposerTypingChanged(bool isTyping) {
+    if (_disposed) return;
+    if (!_settings.enableTypingIndicators) return;
+
+    if (!isTyping) {
+      _stopTyping();
+      return;
+    }
+
+    if (!_isTyping) {
+      _isTyping = true;
+      unawaited(_sendTyping(true));
+    }
+
+    _idleTimer?.cancel();
+    _idleTimer = Timer(_idleStopDelay, _stopTyping);
+
+    _refreshTimer ??= Timer.periodic(_refreshInterval, (_) {
+      if (_isTyping) {
+        unawaited(_sendTyping(true));
+      }
+    });
+  }
+
+  void dispose() {
+    if (_disposed) return;
+    _disposed = true;
+    _stopTyping();
+  }
+
+  void _stopTyping() {
+    _idleTimer?.cancel();
+    _idleTimer = null;
+    _refreshTimer?.cancel();
+    _refreshTimer = null;
+    if (_isTyping) {
+      _isTyping = false;
+      unawaited(_sendTyping(false));
+    }
+  }
+
+  Future<void> _sendTyping(bool typing) async {
+    if (!_settings.enableTypingIndicators) return;
+
+    final now = DateTime.now();
+    if (typing &&
+        _lastSentAt != null &&
+        now.difference(_lastSentAt!) < _throttleInterval) {
+      return;
+    }
+    _lastSentAt = now;
+
+    final timestamp = now.millisecondsSinceEpoch;
+    if (isGroup) {
+      final targets = memberIds!
+          .where((memberId) => memberId != userId)
+          .toList(growable: false);
+      for (final target in targets) {
+        await _sendToPeer(
+          target,
+          {
+            'senderId': userId,
+            'receiverId': target,
+            'groupId': groupId,
+            'typing': typing,
+            'timestamp': timestamp,
+          },
+        );
+      }
+      return;
+    }
+
+    await _sendToPeer(
+      peerId!,
+      {
+        'senderId': userId,
+        'receiverId': peerId,
+        'typing': typing,
+        'timestamp': timestamp,
+      },
+    );
+  }
+
+  Future<void> _sendToPeer(
+    String peerOnion,
+    Map<String, dynamic> payload,
+  ) async {
+    final send = _sendOverride;
+    if (send != null) {
+      await send(peerOnion, payload);
+      return;
+    }
+
+    if (!TransportProvider.isConfigured) return;
+    final manager = TransportProvider.instance.wsManager;
+    if (!manager.isConnected(peerOnion)) return;
+
+    try {
+      await manager.send(peerOnion, 'typing_update', payload: payload);
+    } catch (_) {
+      // Typing is best-effort when the socket is unavailable.
+    }
+  }
+
+  @visibleForTesting
+  bool get isTypingActive => _isTyping;
+}

--- a/lib/services/typing_state_tracker.dart
+++ b/lib/services/typing_state_tracker.dart
@@ -1,0 +1,82 @@
+import 'dart:async';
+
+/// Tracks who is currently typing in each conversation with auto-expiry.
+class TypingStateTracker {
+  static const _expiryDuration = Duration(seconds: 5);
+
+  final Map<String, Map<String, DateTime>> _lastSeenByConversation = {};
+  final Map<String, Map<String, Timer>> _expiryTimersByConversation = {};
+  final _changeController = StreamController<void>.broadcast();
+
+  Stream<void> get onChanged => _changeController.stream;
+
+  List<String> activeTypists(String conversationKey) {
+    final typists = _lastSeenByConversation[conversationKey];
+    if (typists == null || typists.isEmpty) return const [];
+
+    final now = DateTime.now();
+    return typists.entries
+        .where((entry) => now.difference(entry.value) < _expiryDuration)
+        .map((entry) => entry.key)
+        .toList()
+      ..sort();
+  }
+
+  void applyEvent({
+    required String conversationKey,
+    required String senderId,
+    required bool typing,
+    required int timestamp,
+  }) {
+    if (conversationKey.isEmpty || senderId.isEmpty) return;
+
+    final typists =
+        _lastSeenByConversation.putIfAbsent(conversationKey, () => {});
+    final timers =
+        _expiryTimersByConversation.putIfAbsent(conversationKey, () => {});
+
+    if (!typing) {
+      typists.remove(senderId);
+      timers.remove(senderId)?.cancel();
+      _notify();
+      return;
+    }
+
+    typists[senderId] = DateTime.fromMillisecondsSinceEpoch(timestamp);
+    timers.remove(senderId)?.cancel();
+    timers[senderId] = Timer(_expiryDuration, () {
+      typists.remove(senderId);
+      timers.remove(senderId);
+      _notify();
+    });
+    _notify();
+  }
+
+  void clearConversation(String conversationKey) {
+    final timers = _expiryTimersByConversation.remove(conversationKey);
+    if (timers != null) {
+      for (final timer in timers.values) {
+        timer.cancel();
+      }
+    }
+    _lastSeenByConversation.remove(conversationKey);
+    _notify();
+  }
+
+  void dispose() {
+    for (final timers in _expiryTimersByConversation.values) {
+      for (final timer in timers.values) {
+        timer.cancel();
+      }
+    }
+    _expiryTimersByConversation.clear();
+    _lastSeenByConversation.clear();
+    unawaited(_changeController.close());
+  }
+
+  void _notify() {
+    if (!_changeController.isClosed) {
+      _changeController.add(null);
+    }
+  }
+}

--- a/lib/services/ws_inbound_dispatcher.dart
+++ b/lib/services/ws_inbound_dispatcher.dart
@@ -3,6 +3,7 @@ import 'dart:async';
 import 'package:flutter/foundation.dart';
 import 'package:prysm/server/inbound_message_router.dart';
 import 'package:prysm/server/PrysmServer.dart';
+import 'package:prysm/util/typing_indicator_notifier.dart';
 import 'package:prysm/transport/ws_protocol.dart';
 
 /// Routes inbound WebSocket frames received on outbound peer connections.
@@ -47,11 +48,20 @@ class WsInboundDispatcher {
       _handleFrame(frame);
 
   Future<void> _handleFrame(Map<String, dynamic> frame) async {
+    final op = frame['op'];
+    if (op is! String) return;
+
+    if (WsFrame.isTypingOp(op)) {
+      final payload = frame['payload'];
+      if (payload is Map<String, dynamic>) {
+        TypingIndicatorNotifier.instance.applyInbound(payload);
+      }
+      return;
+    }
+
     final router = _router;
     if (router == null) return;
 
-    final op = frame['op'];
-    if (op is! String) return;
     if (op == 'message' || WsFrame.isInboundSideChannelOp(op)) {
       final payload = frame['payload'];
       if (payload is! Map<String, dynamic>) return;

--- a/lib/transport/ws_protocol.dart
+++ b/lib/transport/ws_protocol.dart
@@ -9,6 +9,7 @@ const List<String> wsSupportedOps = [
   'read_update',
   'reaction_update',
   'message_modify',
+  'typing_update',
   'sync-hint',
   'profile',
   'public',
@@ -96,6 +97,8 @@ class WsFrame {
       op == 'read_update' ||
       op == 'reaction_update' ||
       op == 'message_modify';
+
+  static bool isTypingOp(String op) => op == 'typing_update';
 
   static bool routesToMessageHandler(String op) =>
       op == 'message' || isInboundSideChannelOp(op);

--- a/lib/util/typing_indicator_notifier.dart
+++ b/lib/util/typing_indicator_notifier.dart
@@ -1,0 +1,62 @@
+import 'dart:async';
+
+import 'package:flutter/foundation.dart';
+import 'package:prysm/services/settings_service.dart';
+
+class TypingIndicatorEvent {
+  final String senderId;
+  final String? groupId;
+  final String? peerId;
+  final bool typing;
+  final int timestamp;
+
+  const TypingIndicatorEvent({
+    required this.senderId,
+    required this.groupId,
+    required this.peerId,
+    required this.typing,
+    required this.timestamp,
+  });
+}
+
+/// Broadcasts ephemeral typing events received over WebSocket.
+class TypingIndicatorNotifier {
+  TypingIndicatorNotifier._();
+
+  static final TypingIndicatorNotifier instance = TypingIndicatorNotifier._();
+
+  final _controller = StreamController<TypingIndicatorEvent>.broadcast();
+
+  Stream<TypingIndicatorEvent> get events => _controller.stream;
+
+  @visibleForTesting
+  void resetForTest() {
+    // StreamController is not reset; tests should listen before emit.
+  }
+
+  void applyInbound(Map<String, dynamic> payload) {
+    if (!SettingsService().enableTypingIndicators) return;
+
+    final senderId = payload['senderId'];
+    if (senderId is! String || senderId.isEmpty) return;
+
+    final typing = payload['typing'];
+    if (typing is! bool) return;
+
+    final timestamp = payload['timestamp'];
+    final groupId = payload['groupId'];
+    final receiverId = payload['receiverId'];
+
+    _controller.add(
+      TypingIndicatorEvent(
+        senderId: senderId,
+        groupId: groupId is String && groupId.isNotEmpty ? groupId : null,
+        peerId: groupId == null || (groupId is String && groupId.isEmpty)
+            ? senderId
+            : null,
+        typing: typing,
+        timestamp: timestamp is int ? timestamp : DateTime.now().millisecondsSinceEpoch,
+      ),
+    );
+  }
+}

--- a/lib/util/typing_indicator_notifier.dart
+++ b/lib/util/typing_indicator_notifier.dart
@@ -45,7 +45,6 @@ class TypingIndicatorNotifier {
 
     final timestamp = payload['timestamp'];
     final groupId = payload['groupId'];
-    final receiverId = payload['receiverId'];
 
     _controller.add(
       TypingIndicatorEvent(

--- a/test/typing_indicator_notifier_test.dart
+++ b/test/typing_indicator_notifier_test.dart
@@ -1,0 +1,55 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:prysm/services/settings_service.dart';
+import 'package:prysm/util/typing_indicator_notifier.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  group('TypingIndicatorNotifier', () {
+    setUp(() async {
+      SharedPreferences.setMockInitialValues({});
+      final settings = SettingsService();
+      await settings.init();
+      await settings.setEnableTypingIndicators(true);
+    });
+
+    test('emits inbound typing events when enabled', () async {
+      final events = <TypingIndicatorEvent>[];
+      final sub = TypingIndicatorNotifier.instance.events.listen(events.add);
+
+      TypingIndicatorNotifier.instance.applyInbound({
+        'senderId': 'alice.onion',
+        'receiverId': 'me.onion',
+        'typing': true,
+        'timestamp': 1710000000000,
+      });
+
+      await Future<void>.delayed(Duration.zero);
+      expect(events, hasLength(1));
+      expect(events.first.senderId, 'alice.onion');
+      expect(events.first.typing, isTrue);
+
+      await sub.cancel();
+    });
+
+    test('ignores inbound when enableTypingIndicators is false', () async {
+      await SettingsService().setEnableTypingIndicators(false);
+
+      final events = <TypingIndicatorEvent>[];
+      final sub = TypingIndicatorNotifier.instance.events.listen(events.add);
+
+      TypingIndicatorNotifier.instance.applyInbound({
+        'senderId': 'alice.onion',
+        'receiverId': 'me.onion',
+        'typing': true,
+        'timestamp': 1710000000000,
+      });
+
+      await Future<void>.delayed(Duration.zero);
+      expect(events, isEmpty);
+
+      await sub.cancel();
+    });
+  });
+}

--- a/test/typing_indicator_service_test.dart
+++ b/test/typing_indicator_service_test.dart
@@ -1,0 +1,82 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:prysm/services/settings_service.dart';
+import 'package:prysm/services/typing_indicator_service.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  group('TypingIndicatorService', () {
+    late List<Map<String, dynamic>> sent;
+
+    setUp(() async {
+      sent = [];
+      SharedPreferences.setMockInitialValues({});
+      final settings = SettingsService();
+      await settings.init();
+      await settings.setEnableTypingIndicators(true);
+    });
+
+    TypingIndicatorService directService({
+      SettingsService? settings,
+    }) {
+      return TypingIndicatorService.direct(
+        userId: 'me.onion',
+        peerId: 'peer.onion',
+        settings: settings ?? SettingsService(),
+        sendOverride: (peer, payload) async {
+          sent.add({'peer': peer, ...payload});
+        },
+      );
+    }
+
+    test('privacy off does not send', () async {
+      final settings = SettingsService();
+      await settings.setEnableTypingIndicators(false);
+      final service = directService(settings: settings);
+
+      service.onComposerTypingChanged(true);
+      await Future<void>.delayed(const Duration(milliseconds: 50));
+
+      expect(sent, isEmpty);
+      service.dispose();
+    });
+
+    test('rapid keystrokes send one start then stop on idle', () async {
+      final service = directService();
+
+      service.onComposerTypingChanged(true);
+      service.onComposerTypingChanged(true);
+      service.onComposerTypingChanged(true);
+      await Future<void>.delayed(const Duration(milliseconds: 50));
+
+      expect(sent.where((frame) => frame['typing'] == true).length, 1);
+
+      service.onComposerTypingChanged(false);
+      await Future<void>.delayed(const Duration(milliseconds: 50));
+
+      expect(sent.where((frame) => frame['typing'] == false).length, 1);
+      service.dispose();
+    });
+
+    test('group fan-out excludes self', () async {
+      final service = TypingIndicatorService.group(
+        userId: 'me.onion',
+        groupId: 'group-1',
+        memberIds: ['me.onion', 'alice.onion', 'bob.onion'],
+        settings: SettingsService(),
+        sendOverride: (peer, payload) async {
+          sent.add({'peer': peer, ...payload});
+        },
+      );
+
+      service.onComposerTypingChanged(true);
+      await Future<void>.delayed(const Duration(milliseconds: 50));
+
+      final peers = sent.map((frame) => frame['peer']).toSet();
+      expect(peers, {'alice.onion', 'bob.onion'});
+      expect(peers.contains('me.onion'), isFalse);
+      service.dispose();
+    });
+  });
+}

--- a/test/typing_state_tracker_test.dart
+++ b/test/typing_state_tracker_test.dart
@@ -1,0 +1,61 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:prysm/services/typing_state_tracker.dart';
+
+void main() {
+  group('TypingStateTracker', () {
+    late TypingStateTracker tracker;
+
+    setUp(() {
+      tracker = TypingStateTracker();
+    });
+
+    tearDown(() {
+      tracker.dispose();
+    });
+
+    test('expires typist after 5 seconds without refresh', () async {
+      tracker.applyEvent(
+        conversationKey: 'conv-1',
+        senderId: 'alice.onion',
+        typing: true,
+        timestamp: DateTime.now().millisecondsSinceEpoch,
+      );
+
+      expect(tracker.activeTypists('conv-1'), ['alice.onion']);
+
+      await Future<void>.delayed(const Duration(seconds: 6));
+
+      expect(tracker.activeTypists('conv-1'), isEmpty);
+    });
+
+    test('tracks multiple typists in a group conversation', () {
+      final now = DateTime.now().millisecondsSinceEpoch;
+      tracker.applyEvent(
+        conversationKey: 'group-1',
+        senderId: 'alice.onion',
+        typing: true,
+        timestamp: now,
+      );
+      tracker.applyEvent(
+        conversationKey: 'group-1',
+        senderId: 'bob.onion',
+        typing: true,
+        timestamp: now,
+      );
+
+      expect(
+        tracker.activeTypists('group-1'),
+        ['alice.onion', 'bob.onion'],
+      );
+
+      tracker.applyEvent(
+        conversationKey: 'group-1',
+        senderId: 'alice.onion',
+        typing: false,
+        timestamp: now,
+      );
+
+      expect(tracker.activeTypists('group-1'), ['bob.onion']);
+    });
+  });
+}

--- a/test/ws_protocol_test.dart
+++ b/test/ws_protocol_test.dart
@@ -28,6 +28,12 @@ void main() {
       expect(wsOpForPayloadType('text'), 'message');
     });
 
+    test('typing_update is a supported op and typing side channel', () {
+      expect(wsSupportedOps, contains('typing_update'));
+      expect(WsFrame.isTypingOp('typing_update'), isTrue);
+      expect(WsFrame.isTypingOp('message'), isFalse);
+    });
+
     test('response frame preserves correlation id', () {
       final frame = WsFrame.response(
         op: 'profile',


### PR DESCRIPTION
- Introduced typing indicators in both direct and group chat screens to enhance user experience.
- Updated Settings model to include enableTypingIndicators option.
- Implemented TypingIndicatorService and TypingStateTracker for managing typing state.
- Enhanced MessageComposer and PrysmChatComposerOverlay to handle typing events.
- Added privacy settings toggle for typing indicators.
- Updated WebSocket handling to support typing updates.
- Refactored relevant components to integrate typing indicator functionality seamlessly.