### PR TITLE
feat: add self-chat functionality

### DIFF
--- a/lib/database/messages.dart
+++ b/lib/database/messages.dart
@@ -1,5 +1,6 @@
 import 'package:prysm/database/message_reactions.dart';
 import 'package:prysm/database/message_read_receipts.dart';
+import 'package:prysm/database/self_messages_db.dart';
 import 'package:prysm/util/db_helper.dart';
 import 'package:prysm/util/read_waterline_mark.dart';
 import 'package:prysm/util/sqflite_platform.dart';
@@ -14,7 +15,7 @@ class MessagesDb {
 	static Future<Database>? _opening;
 	static final _dbMutex = Mutex();
 
-    static const _dbVersion = 9;
+    static const _dbVersion = 10;
 
 	static const String _directChatTypeFilter =
 		"(type IS NULL OR type IN ('text', 'file', 'image', 'audio'))";
@@ -58,6 +59,7 @@ class MessagesDb {
 				if (oldVersion < 7) await _upgradeToV7(db);
 				if (oldVersion < 8) await _upgradeToV8(db);
 				if (oldVersion < 9) await _upgradeToV9(db);
+				if (oldVersion < 10) await _upgradeToV10(db);
 			},
 			onDowngrade: (db, oldVersion, newVersion) async {
 				throw Exception('Database downgrade not supported: $oldVersion -> $newVersion');
@@ -123,6 +125,7 @@ class MessagesDb {
         );
         await MessageReactionsDb.createTable(db);
         await MessageReadReceiptsDb.createTable(db);
+        await SelfMessagesDb.createTable(db);
     }
 
 
@@ -218,6 +221,11 @@ class MessagesDb {
 			WHERE COALESCE(status, '') = 'sent'
 			  AND COALESCE(status, '') != 'received'
 		''');
+	}
+
+	static Future<void> _upgradeToV10(Database db) async {
+		print('UPGRADING DB TO v10');
+		await SelfMessagesDb.createTable(db);
 	}
 
 	/// Storage primary key: group messages are scoped per group to avoid cross-group REPLACE.

--- a/lib/database/self_messages_db.dart
+++ b/lib/database/self_messages_db.dart
@@ -1,0 +1,176 @@
+import 'package:mutex/mutex.dart';
+import 'package:prysm/database/messages.dart';
+import 'package:sqflite/sqflite.dart';
+
+/// Local-only notes-to-self messages (no P2P).
+class SelfMessagesDb {
+  SelfMessagesDb._();
+
+  static final _mutex = Mutex();
+  static Database? _testDatabase;
+
+  static Future<Database> _db() async {
+    if (_testDatabase != null) return _testDatabase!;
+    return MessagesDb.database;
+  }
+
+  static void setDatabaseForTest(Database? db) {
+    _testDatabase = db;
+  }
+
+  static const _typeFilter =
+      "(type IS NULL OR type IN ('text', 'file', 'image', 'audio'))";
+
+  static Future<void> createTable(Database db) async {
+    await db.execute('''
+      CREATE TABLE IF NOT EXISTS self_messages (
+        id TEXT PRIMARY KEY,
+        message TEXT,
+        type TEXT DEFAULT 'text',
+        fileName TEXT,
+        fileSize INTEGER,
+        timestamp INTEGER NOT NULL,
+        replyTo TEXT,
+        viewOnce INTEGER DEFAULT 0,
+        viewed INTEGER DEFAULT 0,
+        deletedAt INTEGER,
+        editedAt INTEGER
+      )
+    ''');
+    await db.execute(
+      'CREATE INDEX IF NOT EXISTS idx_self_messages_ts ON self_messages(timestamp)',
+    );
+  }
+
+  static Future<void> insertMessage(Map<String, dynamic> message) async {
+    await _mutex.protect(() async {
+      final db = await _db();
+      await db.insert(
+        'self_messages',
+        message,
+        conflictAlgorithm: ConflictAlgorithm.replace,
+      );
+    });
+  }
+
+  static Future<List<Map<String, dynamic>>> getMessagesBatch({
+    int limit = 20,
+    int? beforeTimestamp,
+    String? beforeId,
+  }) async {
+    return _mutex.protect(() async {
+      final db = await _db();
+      var where = _typeFilter;
+      final whereArgs = <dynamic>[];
+
+      if (beforeTimestamp != null && beforeId != null) {
+        where += ' AND (timestamp < ? OR (timestamp = ? AND id < ?))';
+        whereArgs.addAll([beforeTimestamp, beforeTimestamp, beforeId]);
+      } else if (beforeTimestamp != null) {
+        where += ' AND timestamp < ?';
+        whereArgs.add(beforeTimestamp);
+      } else if (beforeId != null) {
+        where += ' AND id < ?';
+        whereArgs.add(beforeId);
+      }
+
+      return db.query(
+        'self_messages',
+        where: where,
+        whereArgs: whereArgs.isEmpty ? null : whereArgs,
+        orderBy: 'timestamp DESC, id DESC',
+        limit: limit,
+      );
+    });
+  }
+
+  static Future<int?> getLastTimestamp() async {
+    return _mutex.protect(() async {
+      final db = await _db();
+      final result = await db.rawQuery('''
+        SELECT MAX(timestamp) AS lastTimestamp
+        FROM self_messages
+        WHERE deletedAt IS NULL
+          AND $_typeFilter
+      ''');
+      if (result.isEmpty || result.first['lastTimestamp'] == null) {
+        return null;
+      }
+      final value = result.first['lastTimestamp'];
+      return value is int ? value : int.tryParse(value.toString());
+    });
+  }
+
+  static Future<String?> getLastPreview() async {
+    return _mutex.protect(() async {
+      final db = await _db();
+      final rows = await db.query(
+        'self_messages',
+        columns: ['type', 'deletedAt'],
+        where: 'deletedAt IS NULL AND $_typeFilter',
+        orderBy: 'timestamp DESC',
+        limit: 1,
+      );
+      if (rows.isEmpty) return null;
+      final row = rows.first;
+      return MessagesDb.previewLabelForType(row['type'] as String?);
+    });
+  }
+
+  static Future<void> softDelete(String messageId) async {
+    await _mutex.protect(() async {
+      final db = await _db();
+      await db.update(
+        'self_messages',
+        {
+          'deletedAt': DateTime.now().millisecondsSinceEpoch,
+          'message': null,
+        },
+        where: 'id = ?',
+        whereArgs: [messageId],
+      );
+    });
+  }
+
+  static Future<void> updateContent({
+    required String messageId,
+    required String encryptedMessage,
+  }) async {
+    await _mutex.protect(() async {
+      final db = await _db();
+      await db.update(
+        'self_messages',
+        {
+          'message': encryptedMessage,
+          'editedAt': DateTime.now().millisecondsSinceEpoch,
+        },
+        where: 'id = ?',
+        whereArgs: [messageId],
+      );
+    });
+  }
+
+  static Future<List<Map<String, dynamic>>> getMessageById(String messageId) async {
+    return _mutex.protect(() async {
+      final db = await _db();
+      return db.query(
+        'self_messages',
+        where: 'id = ?',
+        whereArgs: [messageId],
+        limit: 1,
+      );
+    });
+  }
+
+  static Future<void> markViewOnceViewed(String messageId) async {
+    await _mutex.protect(() async {
+      final db = await _db();
+      await db.update(
+        'self_messages',
+        {'viewed': 1, 'message': null},
+        where: 'id = ? AND viewOnce = 1',
+        whereArgs: [messageId],
+      );
+    });
+  }
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -9,6 +9,7 @@ import 'package:http/http.dart' as http;
 import 'package:path_provider/path_provider.dart';
 import 'package:path/path.dart' as p;
 import 'package:prysm/database/messages.dart';
+import 'package:prysm/database/self_messages_db.dart';
 import 'package:prysm/models/panic_action.dart';
 import 'package:prysm/models/unlock_type.dart';
 import 'package:prysm/screens/unlock_screen.dart';
@@ -34,6 +35,7 @@ import 'package:prysm/screens/call/call_overlay.dart';
 import 'package:prysm/services/call/call_foreground_session.dart';
 import 'package:prysm/services/call/call_manager.dart';
 import 'package:prysm/screens/chat.dart';
+import 'package:prysm/screens/self_chat_screen.dart';
 import 'package:prysm/screens/create_group_screen.dart';
 import 'package:prysm/screens/group_chat.dart';
 import 'package:prysm/models/conversation.dart';
@@ -696,6 +698,9 @@ class _HomeScreenState extends State<HomeScreen> with WidgetsBindingObserver {
   Conversation? selectedConversation;
   bool showProfile = false;
   bool showSettings = false;
+  bool showSelfChat = false;
+  int? _selfChatLastTimestamp;
+  String? _selfChatLastPreview;
   bool isLoading = true;
   int currentTheme = 0; // 0: Light, 1: Dark, 2: Pink, 3: Cyan, 4: Purple, 5 Orange
   String _searchQuery = '';
@@ -1138,6 +1143,8 @@ class _HomeScreenState extends State<HomeScreen> with WidgetsBindingObserver {
         MessagesDb.getLastMessagePreviews(widget.onionAddress),
         MessagesDb.getUnreadCounts(widget.onionAddress),
         ConversationPreferencesService.instance.getAll(),
+        SelfMessagesDb.getLastTimestamp(),
+        SelfMessagesDb.getLastPreview(),
       ]);
       if (!mounted) return;
       userMaps = results[0] as List<Map<String, dynamic>>;
@@ -1146,6 +1153,8 @@ class _HomeScreenState extends State<HomeScreen> with WidgetsBindingObserver {
       previews = results[3] as Map<String, String>;
       unread = results[4] as Map<String, int>;
       prefs = results[5] as Map<String, ConversationPreferences>;
+      _selfChatLastTimestamp = results[6] as int?;
+      _selfChatLastPreview = results[7] as String?;
     } else {
       final fastResults = await Future.wait([
         DBHelper.getUsers(),
@@ -1173,10 +1182,14 @@ class _HomeScreenState extends State<HomeScreen> with WidgetsBindingObserver {
       final deferred = await Future.wait([
         MessagesDb.getLastMessagePreviews(widget.onionAddress),
         MessagesDb.getUnreadCounts(widget.onionAddress),
+        SelfMessagesDb.getLastTimestamp(),
+        SelfMessagesDb.getLastPreview(),
       ]);
       if (!mounted) return;
       previews = deferred[0] as Map<String, String>;
       unread = deferred[1] as Map<String, int>;
+      _selfChatLastTimestamp = deferred[2] as int?;
+      _selfChatLastPreview = deferred[3] as String?;
     }
 
     _applyLoadedUsers(
@@ -1370,6 +1383,7 @@ class _HomeScreenState extends State<HomeScreen> with WidgetsBindingObserver {
       selectedConversation = DirectConversation(contact);
       showProfile = false;
       showSettings = false;
+      showSelfChat = false;
     });
     _syncActiveConversationTracker();
     _dismissConversationNotification(senderId: contact.id);
@@ -1381,6 +1395,7 @@ class _HomeScreenState extends State<HomeScreen> with WidgetsBindingObserver {
       selectedConversation = GroupConversation(group);
       showProfile = false;
       showSettings = false;
+      showSelfChat = false;
     });
     _syncActiveConversationTracker();
     _dismissConversationNotification(
@@ -1415,10 +1430,22 @@ class _HomeScreenState extends State<HomeScreen> with WidgetsBindingObserver {
     );
   }
 
+  void onSelectSelfChat() {
+    setState(() {
+      showSelfChat = true;
+      selectedContact = null;
+      selectedConversation = SelfConversation(_selfChatLastTimestamp);
+      showProfile = false;
+      showSettings = false;
+    });
+    _closeMobileDrawerIfOpen();
+  }
+
   void onShowProfile() {
     setState(() {
       showSettings = false;
       showProfile = true;
+      showSelfChat = false;
     });
   }
 
@@ -1426,6 +1453,7 @@ class _HomeScreenState extends State<HomeScreen> with WidgetsBindingObserver {
     setState(() {
       showSettings = true;
       showProfile = false;
+      showSelfChat = false;
     });
   }
 
@@ -1575,6 +1603,33 @@ class _HomeScreenState extends State<HomeScreen> with WidgetsBindingObserver {
       onionId: id,
       displayName: name,
       expectedFingerprint: expectedFingerprint,
+    );
+  }
+
+  bool get _showSelfChatInSidebar {
+    if (widget.decoyMode || _viewingArchived) return false;
+    if (_searchQuery.isEmpty) return true;
+    return 'chat with myself'.contains(_searchQuery);
+  }
+
+  Widget _buildSelfChatSidebarTile() {
+    final timeLabel = formatLastMessageTime(_selfChatLastTimestamp);
+    final preview = _selfChatLastPreview;
+    final subtitle = preview != null ? '$preview · $timeLabel' : timeLabel;
+
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 2),
+      child: ListTile(
+        leading: ContactAvatar(
+          name: appUser.name,
+          avatarBase64: appUser.avatarBase64,
+        ),
+        title: const Text('Chat with myself'),
+        subtitle: Text(subtitle),
+        selected: showSelfChat,
+        shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
+        onTap: onSelectSelfChat,
+      ),
     );
   }
 
@@ -1745,6 +1800,7 @@ class _HomeScreenState extends State<HomeScreen> with WidgetsBindingObserver {
             ),
           ),
           const SizedBox(height: 8),
+          if (_showSelfChatInSidebar) _buildSelfChatSidebarTile(),
           // Conversation list
           Expanded(
             child: ListView.builder(
@@ -2629,6 +2685,7 @@ class _HomeScreenState extends State<HomeScreen> with WidgetsBindingObserver {
       loadUsers();
       selectedContact = null;
       selectedConversation = null;
+      showSelfChat = false;
     });
     _syncActiveConversationTracker();
   }
@@ -2650,6 +2707,17 @@ class _HomeScreenState extends State<HomeScreen> with WidgetsBindingObserver {
         torManager: widget.torManager,
         keyManager: widget.decoyMode ? null : widget.keyManager,
         onionAddress: widget.decoyMode ? null : widget.onionAddress,
+      );
+    }
+    if (showSelfChat && !widget.decoyMode) {
+      return SelfChatScreen(
+        key: const ValueKey('self_chat'),
+        userId: appUser.id,
+        userName: appUser.name,
+        avatarBase64: appUser.avatarBase64,
+        keyManager: widget.keyManager,
+        onCloseChat: () => clearChat(),
+        reloadSidebar: () => loadUsers(),
       );
     }
     if (selectedConversation is GroupConversation) {
@@ -2720,7 +2788,10 @@ class _HomeScreenState extends State<HomeScreen> with WidgetsBindingObserver {
     
     if (isMobile) {
        return Scaffold(
-        appBar: selectedConversation == null && !showProfile && !showSettings
+        appBar: selectedConversation == null &&
+                !showProfile &&
+                !showSettings &&
+                !showSelfChat
             ? AppBar(
           toolbarHeight: 70,
           title: Row(
@@ -2759,7 +2830,10 @@ class _HomeScreenState extends State<HomeScreen> with WidgetsBindingObserver {
             IconButton(
               icon: const Icon(Icons.settings_outlined),
               tooltip: 'Settings',
-              onPressed: () => setState(() => showSettings = true),
+              onPressed: () => setState(() {
+                showSettings = true;
+                showSelfChat = false;
+              }),
             ),
           ],
           elevation: 2,

--- a/lib/models/conversation.dart
+++ b/lib/models/conversation.dart
@@ -37,3 +37,21 @@ class GroupConversation extends Conversation {
   @override
   String get displayName => group.name;
 }
+
+/// Local notes-to-self chat (not P2P).
+class SelfConversation extends Conversation {
+  SelfConversation(this._lastTimestamp);
+
+  static const conversationId = '__self__';
+
+  final int? _lastTimestamp;
+
+  @override
+  String get id => conversationId;
+
+  @override
+  String get displayName => 'Chat with myself';
+
+  @override
+  int? get lastMessageTimestamp => _lastTimestamp;
+}

--- a/lib/screens/self_chat_screen.dart
+++ b/lib/screens/self_chat_screen.dart
@@ -1,0 +1,700 @@
+import 'dart:convert';
+import 'dart:io';
+import 'dart:typed_data';
+
+import 'package:file_picker/file_picker.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_chat_core/flutter_chat_core.dart';
+import 'package:flutter_chat_ui/flutter_chat_ui.dart';
+import 'package:flutter_image_compress/flutter_image_compress.dart';
+import 'package:image_picker/image_picker.dart';
+import 'package:path_provider/path_provider.dart';
+import 'package:prysm/crypto/wire.dart';
+import 'package:prysm/database/self_messages_db.dart';
+import 'package:prysm/screens/widgets/contact_avatar.dart';
+import 'package:prysm/screens/widgets/deleted_message_bubble.dart';
+import 'package:prysm/screens/widgets/file_attachment_bubble.dart';
+import 'package:prysm/screens/widgets/image_message_bubble.dart';
+import 'package:prysm/screens/widgets/image_send_preview_screen.dart';
+import 'package:prysm/screens/widgets/linked_message_text.dart';
+import 'package:prysm/screens/widgets/prysm_chat_composer_overlay.dart';
+import 'package:prysm/screens/widgets/voice_message_bubble.dart';
+import 'package:prysm/services/file_attachment_resolver.dart';
+import 'package:prysm/services/image_attachment_cache.dart';
+import 'package:prysm/services/self_chat_service.dart';
+import 'package:prysm/util/chat_scroll.dart';
+import 'package:prysm/util/key_manager.dart';
+import 'package:prysm/util/message_modify_policy.dart';
+import 'package:prysm/util/waveform_extractor.dart';
+import 'package:url_launcher/url_launcher.dart';
+import 'package:uuid/uuid.dart';
+
+class SelfChatScreen extends StatefulWidget {
+  final String userId;
+  final String userName;
+  final String? avatarBase64;
+  final KeyManager keyManager;
+  final VoidCallback onCloseChat;
+  final VoidCallback reloadSidebar;
+
+  const SelfChatScreen({
+    required this.userId,
+    required this.userName,
+    this.avatarBase64,
+    required this.keyManager,
+    required this.onCloseChat,
+    required this.reloadSidebar,
+    super.key,
+  });
+
+  @override
+  State<SelfChatScreen> createState() => _SelfChatScreenState();
+}
+
+class _SelfChatScreenState extends State<SelfChatScreen> {
+  late final SelfChatService _service;
+  late final User _user;
+  final _messages = InMemoryChatController();
+  final _scrollController = ScrollController();
+
+  bool _loading = false;
+  bool _hasMore = true;
+  int? _oldestTimestamp;
+  String? _oldestMessageId;
+
+  @override
+  void initState() {
+    super.initState();
+    _user = User(id: widget.userId);
+    _service = SelfChatService(
+      userId: widget.userId,
+      keyManager: widget.keyManager,
+    );
+    _scrollController.addListener(_onListScroll);
+    _loadInitialMessages();
+  }
+
+  @override
+  void dispose() {
+    _scrollController.removeListener(_onListScroll);
+    _scrollController.dispose();
+    super.dispose();
+  }
+
+  void _onListScroll() {
+    isChatScrolledToBottom(_scrollController);
+  }
+
+  Future<void> _loadInitialMessages() async {
+    await _loadMoreMessages();
+    if (mounted && _messages.messages.isNotEmpty) {
+      scheduleScrollChatToBottom(_messages, isMounted: () => mounted);
+    }
+  }
+
+  Future<void> _loadMoreMessages() async {
+    if (_loading || !_hasMore) return;
+    _loading = true;
+
+    final batch = await _service.loadMessagesBatch(
+      limit: 20,
+      beforeTimestamp: _oldestTimestamp,
+      beforeId: _oldestMessageId,
+    );
+
+    if (!mounted) return;
+
+    if (batch.length < 20) {
+      _hasMore = false;
+      _loading = false;
+      if (batch.isEmpty) return;
+    }
+
+    final sorted = List<Map<String, dynamic>>.from(batch)
+      ..sort(
+        (a, b) => (a['timestamp'] as int).compareTo(b['timestamp'] as int),
+      );
+
+    final decrypted = await _service.decryptMessages(sorted);
+
+    if (!mounted) return;
+
+    setState(() {
+      _messages.insertAllMessages(decrypted, index: 0);
+      _oldestTimestamp = batch.last['timestamp'] as int;
+      _oldestMessageId = batch.last['id'] as String;
+      _loading = false;
+    });
+  }
+
+  void _scheduleScrollToBottomAfterSend() {
+    scheduleScrollChatToBottom(_messages, isMounted: () => mounted);
+  }
+
+  Future<void> _handleSendText(String text) async {
+    if (!mounted) return;
+
+    final messageId = const Uuid().v4();
+
+    setState(() {
+      _messages.insertMessage(
+        TextMessage(
+          authorId: _user.id,
+          createdAt: DateTime.now(),
+          id: messageId,
+          text: text,
+        ),
+        index: _messages.messages.length,
+      );
+    });
+    _scheduleScrollToBottomAfterSend();
+
+    await _service.sendTextMessage(text, messageId: messageId);
+    widget.reloadSidebar();
+  }
+
+  Future<void> _sendFile(
+    Uint8List bytes,
+    String fileName,
+    String type, {
+    bool viewOnce = false,
+  }) async {
+    if (!mounted) return;
+
+    final messageId = const Uuid().v4();
+
+    setState(() {
+      if (type == 'file') {
+        _messages.insertMessage(
+          FileMessage(
+            authorId: _user.id,
+            createdAt: DateTime.now(),
+            id: messageId,
+            name: fileName,
+            size: bytes.length,
+            source: base64Encode(bytes),
+          ),
+          index: _messages.messages.length,
+        );
+      } else if (type == 'image') {
+        _messages.insertMessage(
+          ImageMessage(
+            authorId: _user.id,
+            createdAt: DateTime.now(),
+            id: messageId,
+            size: bytes.length,
+            source:
+                'data:${ImageAttachmentCache.sniffImageMimeType(bytes)};base64,${base64Encode(bytes)}',
+            metadata: viewOnce ? {'viewOnce': true, 'viewed': false} : null,
+          ),
+          index: _messages.messages.length,
+        );
+      }
+    });
+    _scheduleScrollToBottomAfterSend();
+
+    await _service.sendFileMessage(
+      bytes,
+      fileName,
+      type,
+      messageId: messageId,
+      viewOnce: viewOnce,
+    );
+    widget.reloadSidebar();
+  }
+
+  Future<void> _handleSendImage() async {
+    final picker = ImagePicker();
+    final pickedFile = await picker.pickImage(
+      source: ImageSource.gallery,
+      requestFullMetadata: true,
+    );
+    if (pickedFile == null) return;
+
+    var bytes = await pickedFile.readAsBytes();
+
+    if (bytes.length > 500 * 1024) {
+      try {
+        bytes = await FlutterImageCompress.compressWithList(
+          bytes,
+          minHeight: 1080,
+          minWidth: 1080,
+          quality: 70,
+        );
+      } catch (e) {
+        if (mounted) {
+          ScaffoldMessenger.of(context).showSnackBar(
+            const SnackBar(
+              content: Text('Image compression failed, sending original.'),
+            ),
+          );
+        }
+      }
+    }
+
+    if (!mounted) return;
+
+    final viewOnce = await ImageSendPreviewScreen.open(context, bytes);
+    if (viewOnce == null || !mounted) return;
+
+    await _sendFile(bytes, pickedFile.name, 'image', viewOnce: viewOnce);
+  }
+
+  Future<void> _handleSendFile() async {
+    final result = await FilePicker.platform.pickFiles(withData: true);
+    if (result == null || result.files.isEmpty) return;
+
+    final file = result.files.first;
+    if (file.bytes == null) return;
+    await _sendFile(file.bytes!, file.name, 'file');
+  }
+
+  Future<void> _handleSendVoice(Uint8List bytes, int durationMs) async {
+    if (!mounted) return;
+
+    final messageId = const Uuid().v4();
+    final cacheDir = await getTemporaryDirectory();
+    final cachePath = '${cacheDir.path}/voice_cache_$messageId.wav';
+    await File(cachePath).writeAsBytes(bytes);
+    final peaks = WaveformExtractor.extractPeaks(bytes);
+    final waveformMeta = WaveformExtractor.encodePeaks(peaks);
+
+    if (!mounted) return;
+
+    setState(() {
+      _messages.insertMessage(
+        FileMessage(
+          authorId: _user.id,
+          createdAt: DateTime.now(),
+          id: messageId,
+          name: 'voice_message.wav',
+          size: bytes.length,
+          source: 'audio:$durationMs:$cachePath',
+          metadata: {'waveform': waveformMeta},
+        ),
+        index: _messages.messages.length,
+      );
+    });
+    _scheduleScrollToBottomAfterSend();
+
+    await _service.sendFileMessage(
+      bytes,
+      'voice_message.wav',
+      'audio',
+      messageId: messageId,
+    );
+    widget.reloadSidebar();
+  }
+
+  Future<void> _deleteMessage(Message message) async {
+    await SelfMessagesDb.softDelete(message.id);
+    if (!mounted) return;
+    setState(() {
+      _messages.updateMessage(message, markMessageDeleted(message));
+    });
+    widget.reloadSidebar();
+  }
+
+  void _showMessageMenu(BuildContext context, Message message) {
+    if (isMessageDeleted(message)) return;
+
+    showModalBottomSheet<void>(
+      context: context,
+      builder: (ctx) => SafeArea(
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            ListTile(
+              leading: const Icon(Icons.delete_outline),
+              title: const Text('Delete'),
+              onTap: () {
+                Navigator.pop(ctx);
+                _deleteMessage(message);
+              },
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Future<void> _openUrl(String url) async {
+    final uri = Uri.tryParse(url);
+    if (uri == null) return;
+    await launchUrl(uri, mode: LaunchMode.externalApplication);
+  }
+
+  Widget _displayChildForMessage(Message message, Widget child) {
+    if (isMessageDeleted(message)) {
+      return DeletedMessageBubble(
+        isSentByMe: true,
+        createdAt: message.createdAt ?? DateTime.now(),
+      );
+    }
+    return child;
+  }
+
+  Widget _textMessageBuilder(
+    BuildContext context,
+    TextMessage message,
+    int index, {
+    required bool isSentByMe,
+    MessageGroupStatus? groupStatus,
+  }) {
+    final msgDate = message.createdAt ?? DateTime.now();
+    final timeString =
+        '${msgDate.hour.toString().padLeft(2, '0')}:${msgDate.minute.toString().padLeft(2, '0')}';
+
+    return IntrinsicWidth(
+      child: Container(
+        padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+        decoration: BoxDecoration(
+          color: Theme.of(context).colorScheme.primary.withAlpha(225),
+          borderRadius: BorderRadius.circular(12),
+        ),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            LinkedMessageText(
+              text: message.text,
+              textColor: Theme.of(context).colorScheme.onPrimary,
+              fontSize: 14,
+              onOpenUrl: _openUrl,
+            ),
+            const SizedBox(height: 4),
+            Align(
+              alignment: Alignment.centerRight,
+              child: Text(
+                timeString,
+                style: TextStyle(
+                  fontSize: 10,
+                  color: Theme.of(context).colorScheme.onPrimary.withAlpha(200),
+                ),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _imageMessageBuilder(
+    BuildContext context,
+    ImageMessage message,
+    int index, {
+    required bool isSentByMe,
+    MessageGroupStatus? groupStatus,
+  }) {
+    final msgDate = message.createdAt ?? DateTime.now();
+    final timeString =
+        '${msgDate.hour.toString().padLeft(2, '0')}:${msgDate.minute.toString().padLeft(2, '0')}';
+    final isViewOnce = message.metadata?['viewOnce'] == true;
+    final isViewed = message.metadata?['viewed'] == true;
+
+    if (isViewOnce && isViewed) {
+      return Column(
+        crossAxisAlignment: CrossAxisAlignment.end,
+        children: [
+          Container(
+            width: 200,
+            height: 60,
+            decoration: BoxDecoration(
+              color: Theme.of(context).colorScheme.surfaceContainerHighest,
+              borderRadius: BorderRadius.circular(12),
+            ),
+            child: Row(
+              mainAxisAlignment: MainAxisAlignment.center,
+              children: [
+                Icon(Icons.timer_off, size: 20, color: Colors.grey[500]),
+                const SizedBox(width: 8),
+                Text(
+                  'Opened',
+                  style: TextStyle(
+                    color: Colors.grey[500],
+                    fontStyle: FontStyle.italic,
+                    fontSize: 14,
+                  ),
+                ),
+              ],
+            ),
+          ),
+          const SizedBox(height: 4),
+          Text(timeString, style: TextStyle(fontSize: 10, color: Colors.grey[600])),
+        ],
+      );
+    }
+
+    if (isViewOnce && !isViewed) {
+      return Column(
+        crossAxisAlignment: CrossAxisAlignment.end,
+        children: [
+          GestureDetector(
+            onTap: () async {
+              try {
+                final decryptedBytes =
+                    await _service.decryptImageFromDb(message.id);
+                if (!context.mounted) return;
+                await Navigator.push(
+                  context,
+                  MaterialPageRoute(
+                    builder: (_) =>
+                        _ViewOnceScreen(imageBytes: decryptedBytes),
+                  ),
+                );
+                await SelfMessagesDb.markViewOnceViewed(message.id);
+                if (!mounted) return;
+                setState(() {
+                  _messages.updateMessage(
+                    message,
+                    message.copyWith(
+                      source: '',
+                      metadata: const {'viewOnce': true, 'viewed': true},
+                    ),
+                  );
+                });
+              } catch (e) {
+                debugPrint('View-once decrypt failed: $e');
+              }
+            },
+            child: Container(
+              width: 200,
+              height: 120,
+              decoration: BoxDecoration(
+                color: Theme.of(context).colorScheme.primary.withAlpha(40),
+                borderRadius: BorderRadius.circular(12),
+              ),
+              child: Column(
+                mainAxisAlignment: MainAxisAlignment.center,
+                children: [
+                  Icon(
+                    Icons.remove_red_eye,
+                    color: Theme.of(context).colorScheme.primary,
+                  ),
+                  const SizedBox(height: 4),
+                  Text(
+                    'View once',
+                    style: TextStyle(
+                      color: Theme.of(context).colorScheme.primary,
+                      fontWeight: FontWeight.w600,
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          ),
+          const SizedBox(height: 4),
+          Text(timeString, style: TextStyle(fontSize: 10, color: Colors.grey[600])),
+        ],
+      );
+    }
+
+    return ImageMessageBubble(
+      message: message,
+      isSentByMe: true,
+      timeString: timeString,
+      tickWidget: const SizedBox.shrink(),
+      decryptFromDb: () => _service.decryptImageFromDb(message.id),
+    );
+  }
+
+  Widget _fileMessageBuilder(
+    BuildContext context,
+    FileMessage message,
+    int index, {
+    required bool isSentByMe,
+    MessageGroupStatus? groupStatus,
+  }) {
+    if (message.name.contains('voice_message') ||
+        message.source.startsWith('audio:')) {
+      final msgDate = message.createdAt ?? DateTime.now();
+      final timeString =
+          '${msgDate.hour.toString().padLeft(2, '0')}:${msgDate.minute.toString().padLeft(2, '0')}';
+
+      return VoiceMessageBubble(
+        message: message,
+        isSentByMe: true,
+        timeString: timeString,
+        tickWidget: const SizedBox.shrink(),
+        decryptAudio: message.source.startsWith('audio:')
+            ? null
+            : (encryptedSource) => CryptoWire.decryptFile(
+                  encryptedSource,
+                  widget.keyManager.identity,
+                ),
+      );
+    }
+
+    final msgDate = message.createdAt ?? DateTime.now();
+    final timeString =
+        '${msgDate.hour.toString().padLeft(2, '0')}:${msgDate.minute.toString().padLeft(2, '0')}';
+
+    return FileAttachmentBubble(
+      fileName: message.name,
+      fileSize: message.size,
+      timeString: timeString,
+      isSentByMe: true,
+      tickWidget: const SizedBox.shrink(),
+      resolveBytes: () => FileAttachmentResolver.resolve(
+        message,
+        keyManager: widget.keyManager,
+      ),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        leading: IconButton(
+          icon: const Icon(Icons.arrow_back),
+          onPressed: widget.onCloseChat,
+        ),
+        title: Row(
+          children: [
+            ContactAvatar(
+              name: widget.userName,
+              avatarBase64: widget.avatarBase64,
+              radius: 18,
+            ),
+            const SizedBox(width: 12),
+            Expanded(
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  const Text(
+                    'Chat with myself',
+                    style: TextStyle(fontSize: 16, fontWeight: FontWeight.w600),
+                    overflow: TextOverflow.ellipsis,
+                  ),
+                  Text(
+                    'Notes to yourself',
+                    style: TextStyle(
+                      fontSize: 12,
+                      color: Theme.of(context).hintColor,
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          ],
+        ),
+      ),
+      body: SafeArea(
+        child: Chat(
+          chatController: _messages,
+          currentUserId: widget.userId,
+          theme: ChatTheme.fromThemeData(Theme.of(context)),
+          resolveUser: (_) async => _user,
+          onMessageSend: _handleSendText,
+          builders: Builders(
+            chatAnimatedListBuilder: (context, itemBuilder) {
+              return ChatAnimatedList(
+                scrollController: _scrollController,
+                bottomPadding: 0,
+                handleSafeArea: false,
+                initialScrollToEndMode: InitialScrollToEndMode.none,
+                itemBuilder: itemBuilder,
+                onEndReached: () async {
+                  await _loadMoreMessages();
+                },
+              );
+            },
+            chatMessageBuilder: (
+              context,
+              message,
+              index,
+              animation,
+              child, {
+              bool? isRemoved,
+              required bool isSentByMe,
+              MessageGroupStatus? groupStatus,
+            }) {
+              final msgDate = message.createdAt ?? DateTime.now();
+              final currentDay =
+                  DateTime(msgDate.year, msgDate.month, msgDate.day);
+
+              DateTime? prevDay;
+              if (index > 0 && index - 1 < _messages.messages.length) {
+                final prevMsg = _messages.messages[index - 1];
+                final prevDate = prevMsg.createdAt ?? DateTime.now();
+                prevDay = DateTime(prevDate.year, prevDate.month, prevDate.day);
+              }
+
+              final showDateHeader = index == 0 ||
+                  prevDay == null ||
+                  !currentDay.isAtSameMomentAs(prevDay);
+
+              return Column(
+                children: [
+                  if (showDateHeader)
+                    Container(
+                      padding: const EdgeInsets.symmetric(vertical: 8),
+                      alignment: Alignment.center,
+                      child: Text(
+                        '${msgDate.day}/${msgDate.month}/${msgDate.year}',
+                        style: const TextStyle(fontSize: 12, color: Colors.grey),
+                      ),
+                    ),
+                  GestureDetector(
+                    onLongPress: () => _showMessageMenu(context, message),
+                    child: Padding(
+                      padding: const EdgeInsets.symmetric(
+                        horizontal: 12,
+                        vertical: 4,
+                      ),
+                      child: SizeTransition(
+                        sizeFactor: animation,
+                        child: Row(
+                          mainAxisAlignment: MainAxisAlignment.end,
+                          children: [
+                            Flexible(
+                              child: _displayChildForMessage(message, child),
+                            ),
+                          ],
+                        ),
+                      ),
+                    ),
+                  ),
+                ],
+              );
+            },
+            fileMessageBuilder: _fileMessageBuilder,
+            imageMessageBuilder: _imageMessageBuilder,
+            textMessageBuilder: _textMessageBuilder,
+            composerBuilder: (context) {
+              return PrysmChatComposerOverlay(
+                onSendText: _handleSendText,
+                onSendImage: _handleSendImage,
+                onSendFile: _handleSendFile,
+                onSendVoice: _handleSendVoice,
+              );
+            },
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _ViewOnceScreen extends StatelessWidget {
+  final Uint8List imageBytes;
+
+  const _ViewOnceScreen({required this.imageBytes});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      backgroundColor: Colors.black,
+      appBar: AppBar(
+        backgroundColor: Colors.black,
+        foregroundColor: Colors.white,
+      ),
+      body: Center(
+        child: InteractiveViewer(
+          child: Image.memory(imageBytes, fit: BoxFit.contain),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/services/self_chat_service.dart
+++ b/lib/services/self_chat_service.dart
@@ -1,0 +1,228 @@
+import 'package:flutter/foundation.dart';
+import 'package:flutter_chat_core/flutter_chat_core.dart';
+import 'package:prysm/constants/media_constants.dart';
+import 'package:prysm/crypto/wire.dart';
+import 'package:prysm/database/self_messages_db.dart';
+import 'package:prysm/util/key_manager.dart';
+import 'package:prysm/util/message_modify_policy.dart';
+import 'package:uuid/uuid.dart';
+
+class SelfChatService {
+  SelfChatService({
+    required this.userId,
+    required this.keyManager,
+  });
+
+  final String userId;
+  final KeyManager keyManager;
+
+  Future<String> sendTextMessage(
+    String text, {
+    String? replyToId,
+    String? messageId,
+  }) async {
+    final id = messageId ?? const Uuid().v4();
+    final timestamp = DateTime.now().millisecondsSinceEpoch;
+    final encrypted = await keyManager.encryptForSelf(text);
+
+    await SelfMessagesDb.insertMessage({
+      'id': id,
+      'message': encrypted,
+      'type': 'text',
+      'timestamp': timestamp,
+      'replyTo': replyToId,
+    });
+
+    return id;
+  }
+
+  Future<String> sendFileMessage(
+    Uint8List bytes,
+    String fileName,
+    String type, {
+    String? replyToId,
+    String? messageId,
+    bool viewOnce = false,
+  }) async {
+    final id = messageId ?? const Uuid().v4();
+    final timestamp = DateTime.now().millisecondsSinceEpoch;
+    final selfPub = await keyManager.identity.agreePublicKey;
+    final encrypted = await CryptoWire.encryptFile(
+      bytes,
+      keyManager.identity,
+      selfPub,
+    );
+
+    await SelfMessagesDb.insertMessage({
+      'id': id,
+      'message': encrypted.selfPayload,
+      'type': type,
+      'fileName': fileName,
+      'fileSize': bytes.length,
+      'timestamp': timestamp,
+      'replyTo': replyToId,
+      'viewOnce': viewOnce ? 1 : 0,
+    });
+
+    return id;
+  }
+
+  Future<List<Map<String, dynamic>>> loadMessagesBatch({
+    int limit = 20,
+    int? beforeTimestamp,
+    String? beforeId,
+  }) {
+    return SelfMessagesDb.getMessagesBatch(
+      limit: limit,
+      beforeTimestamp: beforeTimestamp,
+      beforeId: beforeId,
+    );
+  }
+
+  Future<List<Message>> decryptMessages(
+    List<Map<String, dynamic>> rawMessages,
+  ) async {
+    final messages = <Message>[];
+
+    for (final msg in rawMessages) {
+      final meta = metadataFromDbRow(msg);
+      final wire = msg['message'];
+
+      if (meta['deleted'] == true ||
+          wire == null ||
+          (wire is String && wire.isEmpty)) {
+        messages.add(_deletedMessageFromRow(msg, meta));
+        continue;
+      }
+
+      try {
+        final type = msg['type'] as String? ?? 'text';
+        final createdAt =
+            DateTime.fromMillisecondsSinceEpoch(msg['timestamp'] as int);
+        final id = msg['id'] as String;
+        final replyTo = msg['replyTo'] as String?;
+
+        switch (type) {
+          case 'text':
+            messages.add(
+              TextMessage(
+                authorId: userId,
+                createdAt: createdAt,
+                id: id,
+                replyToMessageId: replyTo,
+                text: await keyManager.decryptMessage(wire as String),
+                metadata: meta.isEmpty ? null : meta,
+              ),
+            );
+          case 'file':
+            messages.add(
+              FileMessage(
+                id: id,
+                authorId: userId,
+                createdAt: createdAt,
+                replyToMessageId: replyTo,
+                name: msg['fileName'] as String? ?? 'Unknown',
+                size: msg['fileSize'] as int? ?? 0,
+                source: wire as String,
+                metadata: meta.isEmpty ? null : meta,
+              ),
+            );
+          case 'audio':
+            messages.add(
+              FileMessage(
+                id: id,
+                authorId: userId,
+                createdAt: createdAt,
+                replyToMessageId: replyTo,
+                name: msg['fileName'] as String? ?? 'voice_message.wav',
+                size: msg['fileSize'] as int? ?? 0,
+                source: wire as String,
+                metadata: meta.isEmpty ? null : meta,
+              ),
+            );
+          case 'image':
+            final isViewOnce = (msg['viewOnce'] ?? 0) == 1;
+            final isViewed = (msg['viewed'] ?? 0) == 1;
+            if (isViewOnce && isViewed) {
+              messages.add(
+                ImageMessage(
+                  id: id,
+                  authorId: userId,
+                  createdAt: createdAt,
+                  replyToMessageId: replyTo,
+                  size: 0,
+                  source: '',
+                  metadata: const {'viewOnce': true, 'viewed': true},
+                ),
+              );
+            } else {
+              messages.add(
+                ImageMessage(
+                  id: id,
+                  authorId: userId,
+                  createdAt: createdAt,
+                  replyToMessageId: replyTo,
+                  size: msg['fileSize'] as int? ?? 0,
+                  source: isViewOnce ? '' : deferredImageSourceFor(id),
+                  metadata: isViewOnce
+                      ? const {'viewOnce': true, 'viewed': false}
+                      : (meta.isEmpty ? null : meta),
+                ),
+              );
+            }
+          default:
+            messages.add(
+              TextMessage(
+                authorId: userId,
+                createdAt: createdAt,
+                id: id,
+                text: 'Unsupported message type',
+              ),
+            );
+        }
+      } catch (e) {
+        debugPrint('Self message decrypt failed (${msg['id']}): $e');
+        messages.add(
+          TextMessage(
+            authorId: userId,
+            createdAt:
+                DateTime.fromMillisecondsSinceEpoch(msg['timestamp'] as int),
+            id: msg['id'] as String,
+            text: '🔒 Unable to decrypt message',
+          ),
+        );
+      }
+    }
+
+    return messages;
+  }
+
+  Future<Uint8List> decryptFileFromRow(Map<String, dynamic> row) async {
+    return CryptoWire.decryptFile(
+      row['message'] as String,
+      keyManager.identity,
+    );
+  }
+
+  Future<Uint8List> decryptImageFromDb(String messageId) async {
+    final rows = await SelfMessagesDb.getMessageById(messageId);
+    if (rows.isEmpty) {
+      throw StateError('Image message not found: $messageId');
+    }
+    return decryptFileFromRow(rows.first);
+  }
+
+  Message _deletedMessageFromRow(
+    Map<String, dynamic> row,
+    Map<String, Object?> meta,
+  ) {
+    return TextMessage(
+      authorId: userId,
+      createdAt: DateTime.fromMillisecondsSinceEpoch(row['timestamp'] as int),
+      id: row['id'] as String,
+      replyToMessageId: row['replyTo'] as String?,
+      text: '',
+      metadata: {...meta, 'deleted': true},
+    );
+  }
+}

--- a/test/self_messages_db_test.dart
+++ b/test/self_messages_db_test.dart
@@ -1,0 +1,115 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:prysm/database/self_messages_db.dart';
+import 'package:sqflite_common_ffi/sqflite_ffi.dart';
+
+void main() {
+  setUpAll(() {
+    sqfliteFfiInit();
+    databaseFactory = databaseFactoryFfi;
+  });
+
+  setUp(() async {
+    final db = await databaseFactory.openDatabase(
+      '${inMemoryDatabasePath}_${DateTime.now().microsecondsSinceEpoch}',
+      options: OpenDatabaseOptions(
+        version: 1,
+        onCreate: (db, version) async {
+          await SelfMessagesDb.createTable(db);
+        },
+      ),
+    );
+    SelfMessagesDb.setDatabaseForTest(db);
+  });
+
+  tearDown(() async {
+    SelfMessagesDb.setDatabaseForTest(null);
+  });
+
+  test('insert and batch query returns newest first', () async {
+    await SelfMessagesDb.insertMessage({
+      'id': 'a',
+      'message': 'enc-a',
+      'type': 'text',
+      'timestamp': 100,
+    });
+    await SelfMessagesDb.insertMessage({
+      'id': 'b',
+      'message': 'enc-b',
+      'type': 'text',
+      'timestamp': 200,
+    });
+
+    final batch = await SelfMessagesDb.getMessagesBatch(limit: 10);
+    expect(batch.length, 2);
+    expect(batch.first['id'], 'b');
+    expect(batch.last['id'], 'a');
+  });
+
+  test('getLastPreview returns type labels', () async {
+    await SelfMessagesDb.insertMessage({
+      'id': 'img',
+      'message': 'enc',
+      'type': 'image',
+      'timestamp': 50,
+    });
+    await SelfMessagesDb.insertMessage({
+      'id': 'voice',
+      'message': 'enc',
+      'type': 'audio',
+      'timestamp': 100,
+    });
+
+    final preview = await SelfMessagesDb.getLastPreview();
+    expect(preview, '🎤 Voice');
+  });
+
+  test('pagination with beforeTimestamp', () async {
+    await SelfMessagesDb.insertMessage({
+      'id': '1',
+      'message': 'a',
+      'type': 'text',
+      'timestamp': 100,
+    });
+    await SelfMessagesDb.insertMessage({
+      'id': '2',
+      'message': 'b',
+      'type': 'text',
+      'timestamp': 200,
+    });
+    await SelfMessagesDb.insertMessage({
+      'id': '3',
+      'message': 'c',
+      'type': 'text',
+      'timestamp': 300,
+    });
+
+    final page = await SelfMessagesDb.getMessagesBatch(
+      limit: 2,
+      beforeTimestamp: 300,
+    );
+    expect(page.map((r) => r['id']).toList(), ['2', '1']);
+  });
+
+  test('soft delete excludes from preview', () async {
+    await SelfMessagesDb.insertMessage({
+      'id': 'old',
+      'message': 'enc',
+      'type': 'file',
+      'timestamp': 100,
+    });
+    await SelfMessagesDb.insertMessage({
+      'id': 'new',
+      'message': 'enc',
+      'type': 'text',
+      'timestamp': 200,
+    });
+
+    await SelfMessagesDb.softDelete('new');
+
+    final preview = await SelfMessagesDb.getLastPreview();
+    expect(preview, '📎 File');
+
+    final ts = await SelfMessagesDb.getLastTimestamp();
+    expect(ts, 100);
+  });
+}


### PR DESCRIPTION
- Introduced a new self-chat feature allowing users to send messages to themselves.
- Created SelfMessagesDb for managing local notes-to-self messages.
- Implemented SelfChatService for handling message operations in self-chat.
- Added SelfChatScreen for the user interface of the self-chat feature.
- Updated HomeScreen to integrate self-chat functionality and display recent messages.
- Enhanced conversation model with SelfConversation for self-chat representation.
- Added tests for self-messaging database operations to ensure reliability.