### PR TITLE
feat: add jump-to-bottom functionality in chat screens

### DIFF
--- a/lib/screens/chat.dart
+++ b/lib/screens/chat.dart
@@ -18,6 +18,7 @@ import 'package:prysm/util/tor_runtime_gate.dart';
 import 'package:prysm/database/message_reactions.dart';
 import 'package:prysm/database/messages.dart';
 import 'package:prysm/screens/chat_profile_screen.dart';
+import 'package:prysm/screens/widgets/jump_to_bottom_fab.dart';
 import 'package:prysm/screens/widgets/prysm_chat_composer_overlay.dart';
 import 'package:prysm/util/chat_scroll.dart';
 import 'package:prysm/util/scroll_to_chat_message.dart';
@@ -161,7 +162,19 @@ class _ChatScreenState extends State<ChatScreen> {
   StreamSubscription<void>? _typingTrackerSub;
 
   void _onListScroll() {
-    _stickToBottom = isChatScrolledToBottom(_listScrollController);
+    final atBottom = isChatScrolledToBottom(_listScrollController);
+    if (atBottom == _stickToBottom) return;
+    setState(() => _stickToBottom = atBottom);
+  }
+
+  void _jumpToBottom() {
+    _stickToBottom = true;
+    scheduleScrollChatToBottom(
+      _messages,
+      animated: true,
+      isMounted: () => mounted,
+    );
+    setState(() {});
   }
 
   void _scheduleScrollToBottomIfNeeded({bool animated = false}) {
@@ -1779,7 +1792,12 @@ class _ChatScreenState extends State<ChatScreen> {
         shadowColor: Colors.black.withValues(alpha: 0.1),
       ),
       body: SafeArea(
-        child: Chat(
+        child: JumpToBottomFabOverlay(
+          visible: !_stickToBottom &&
+              _messages.messages.isNotEmpty &&
+              selectedMessageIds.isEmpty,
+          onPressed: _jumpToBottom,
+          child: Chat(
           key: _chatKey,
                 chatController: _messages,
                 currentUserId: widget.userId,
@@ -1987,6 +2005,7 @@ class _ChatScreenState extends State<ChatScreen> {
                     );
                   },
                 ),
+        ),
         ),
       ),
     );

--- a/lib/screens/decoy_chat_screen.dart
+++ b/lib/screens/decoy_chat_screen.dart
@@ -1,6 +1,8 @@
 import 'package:flutter/material.dart';
 import 'package:prysm/screens/message_composer.dart';
 import 'package:prysm/screens/widgets/contact_avatar.dart';
+import 'package:prysm/screens/widgets/jump_to_bottom_fab.dart';
+import 'package:prysm/util/chat_scroll.dart';
 import 'package:prysm/util/decoy_session_data.dart';
 import 'package:uuid/uuid.dart';
 
@@ -30,21 +32,31 @@ class DecoyChatScreen extends StatefulWidget {
 class _DecoyChatScreenState extends State<DecoyChatScreen> {
   late List<DecoyMessage> _messages;
   final _scrollController = ScrollController();
+  bool _atBottom = true;
 
   @override
   void initState() {
     super.initState();
     _messages = List.of(widget.initialMessages);
+    _scrollController.addListener(_onListScroll);
     WidgetsBinding.instance.addPostFrameCallback((_) => _scrollToBottom());
+  }
+
+  void _onListScroll() {
+    final atBottom = isChatScrolledToBottom(_scrollController);
+    if (atBottom == _atBottom) return;
+    setState(() => _atBottom = atBottom);
   }
 
   void _scrollToBottom() {
     if (!_scrollController.hasClients) return;
+    _atBottom = true;
     _scrollController.animateTo(
       _scrollController.position.maxScrollExtent,
       duration: const Duration(milliseconds: 200),
       curve: Curves.easeOut,
     );
+    if (mounted) setState(() {});
   }
 
   void _handleSend(String text) {
@@ -63,6 +75,7 @@ class _DecoyChatScreenState extends State<DecoyChatScreen> {
 
   @override
   void dispose() {
+    _scrollController.removeListener(_onListScroll);
     _scrollController.dispose();
     super.dispose();
   }
@@ -110,14 +123,19 @@ class _DecoyChatScreenState extends State<DecoyChatScreen> {
       body: Column(
         children: [
           Expanded(
-            child: ListView.builder(
-              controller: _scrollController,
-              padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
-              itemCount: _messages.length,
-              itemBuilder: (context, index) {
-                final msg = _messages[index];
-                return _DecoyMessageBubble(message: msg, isGroup: widget.isGroup);
-              },
+            child: JumpToBottomFabOverlay(
+              visible: !_atBottom && _messages.isNotEmpty,
+              onPressed: _scrollToBottom,
+              bottom: 16,
+              child: ListView.builder(
+                controller: _scrollController,
+                padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+                itemCount: _messages.length,
+                itemBuilder: (context, index) {
+                  final msg = _messages[index];
+                  return _DecoyMessageBubble(message: msg, isGroup: widget.isGroup);
+                },
+              ),
             ),
           ),
           MessageComposer(

--- a/lib/screens/group_chat.dart
+++ b/lib/screens/group_chat.dart
@@ -17,6 +17,7 @@ import 'package:prysm/database/messages.dart';
 import 'package:prysm/models/contact.dart';
 import 'package:prysm/models/group.dart';
 import 'package:prysm/screens/group_settings_screen.dart';
+import 'package:prysm/screens/widgets/jump_to_bottom_fab.dart';
 import 'package:prysm/screens/widgets/prysm_chat_composer_overlay.dart';
 import 'package:prysm/util/chat_scroll.dart';
 import 'package:prysm/util/scroll_to_chat_message.dart';
@@ -136,7 +137,19 @@ class _GroupChatScreenState extends State<GroupChatScreen> {
   }
 
   void _onListScroll() {
-    _stickToBottom = isChatScrolledToBottom(_listScrollController);
+    final atBottom = isChatScrolledToBottom(_listScrollController);
+    if (atBottom == _stickToBottom) return;
+    setState(() => _stickToBottom = atBottom);
+  }
+
+  void _jumpToBottom() {
+    _stickToBottom = true;
+    scheduleScrollChatToBottom(
+      _messages,
+      animated: true,
+      isMounted: () => mounted,
+    );
+    setState(() {});
   }
 
   void _scheduleScrollToBottomIfNeeded({bool animated = false}) {
@@ -1624,7 +1637,12 @@ class _GroupChatScreenState extends State<GroupChatScreen> {
         shadowColor: Colors.black.withValues(alpha: 0.1),
       ),
       body: SafeArea(
-        child: Chat(
+        child: JumpToBottomFabOverlay(
+          visible: !_stickToBottom &&
+              _messages.messages.isNotEmpty &&
+              selectedMessageIds.isEmpty,
+          onPressed: _jumpToBottom,
+          child: Chat(
           currentUserId: _user.id,
           resolveUser: (id) async => User(id: id),
           chatController: _messages,
@@ -1815,6 +1833,7 @@ class _GroupChatScreenState extends State<GroupChatScreen> {
               );
             },
           ),
+        ),
         ),
       ),
     );

--- a/lib/screens/self_chat_screen.dart
+++ b/lib/screens/self_chat_screen.dart
@@ -17,6 +17,7 @@ import 'package:prysm/screens/widgets/file_attachment_bubble.dart';
 import 'package:prysm/screens/widgets/image_message_bubble.dart';
 import 'package:prysm/screens/widgets/image_send_preview_screen.dart';
 import 'package:prysm/screens/widgets/linked_message_text.dart';
+import 'package:prysm/screens/widgets/jump_to_bottom_fab.dart';
 import 'package:prysm/screens/widgets/prysm_chat_composer_overlay.dart';
 import 'package:prysm/screens/widgets/voice_message_bubble.dart';
 import 'package:prysm/services/file_attachment_resolver.dart';
@@ -57,6 +58,7 @@ class _SelfChatScreenState extends State<SelfChatScreen> {
   final _messages = InMemoryChatController();
   final _scrollController = ScrollController();
 
+  bool _stickToBottom = true;
   bool _loading = false;
   bool _hasMore = true;
   int? _oldestTimestamp;
@@ -82,7 +84,19 @@ class _SelfChatScreenState extends State<SelfChatScreen> {
   }
 
   void _onListScroll() {
-    isChatScrolledToBottom(_scrollController);
+    final atBottom = isChatScrolledToBottom(_scrollController);
+    if (atBottom == _stickToBottom) return;
+    setState(() => _stickToBottom = atBottom);
+  }
+
+  void _jumpToBottom() {
+    _stickToBottom = true;
+    scheduleScrollChatToBottom(
+      _messages,
+      animated: true,
+      isMounted: () => mounted,
+    );
+    setState(() {});
   }
 
   Future<void> _loadInitialMessages() async {
@@ -128,6 +142,7 @@ class _SelfChatScreenState extends State<SelfChatScreen> {
   }
 
   void _scheduleScrollToBottomAfterSend() {
+    _stickToBottom = true;
     scheduleScrollChatToBottom(_messages, isMounted: () => mounted);
   }
 
@@ -581,7 +596,10 @@ class _SelfChatScreenState extends State<SelfChatScreen> {
         ),
       ),
       body: SafeArea(
-        child: Chat(
+        child: JumpToBottomFabOverlay(
+          visible: !_stickToBottom && _messages.messages.isNotEmpty,
+          onPressed: _jumpToBottom,
+          child: Chat(
           chatController: _messages,
           currentUserId: widget.userId,
           theme: ChatTheme.fromThemeData(Theme.of(context)),
@@ -671,6 +689,7 @@ class _SelfChatScreenState extends State<SelfChatScreen> {
               );
             },
           ),
+        ),
         ),
       ),
     );

--- a/lib/screens/widgets/jump_to_bottom_fab.dart
+++ b/lib/screens/widgets/jump_to_bottom_fab.dart
@@ -1,0 +1,49 @@
+import 'package:flutter/material.dart';
+
+/// Overlays a small jump-to-bottom FAB above [child] (e.g. chat list).
+class JumpToBottomFabOverlay extends StatelessWidget {
+  const JumpToBottomFabOverlay({
+    required this.visible,
+    required this.onPressed,
+    required this.child,
+    this.bottom = 80,
+    super.key,
+  });
+
+  final bool visible;
+  final VoidCallback onPressed;
+  final Widget child;
+  final double bottom;
+
+  static const _duration = Duration(milliseconds: 200);
+
+  @override
+  Widget build(BuildContext context) {
+    return Stack(
+      clipBehavior: Clip.none,
+      children: [
+        child,
+        Positioned(
+          right: 16,
+          bottom: bottom,
+          child: IgnorePointer(
+            ignoring: !visible,
+            child: AnimatedOpacity(
+              opacity: visible ? 1 : 0,
+              duration: _duration,
+              child: AnimatedScale(
+                scale: visible ? 1 : 0.8,
+                duration: _duration,
+                child: FloatingActionButton.small(
+                  onPressed: onPressed,
+                  tooltip: 'Jump to bottom',
+                  child: const Icon(Icons.keyboard_arrow_down),
+                ),
+              ),
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+}


### PR DESCRIPTION
- Introduced JumpToBottomFabOverlay to provide a floating action button for quickly scrolling to the bottom of chat lists.
- Updated chat screens (ChatScreen, DecoyChatScreen, GroupChatScreen, SelfChatScreen) to integrate the new jump-to-bottom feature.
- Enhanced scroll tracking logic to manage visibility of the jump-to-bottom button based on scroll position.