### PR TITLE
feat: implement message draft functionality across chat screens

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -2958,6 +2958,7 @@ class _HomeScreenState extends State<HomeScreen> with WidgetsBindingObserver {
       if (widget.decoyMode) {
         return DecoyChatScreen(
           key: ValueKey('decoy_group_${group.id}'),
+          conversationId: group.id,
           title: group.name,
           avatarName: group.name,
           avatarBase64: group.avatarBase64,
@@ -2983,6 +2984,7 @@ class _HomeScreenState extends State<HomeScreen> with WidgetsBindingObserver {
         final contact = selectedContact!;
         return DecoyChatScreen(
           key: ValueKey('decoy_dm_${contact.id}'),
+          conversationId: contact.id,
           title: contact.displayName,
           avatarName: contact.displayName,
           avatarBase64: contact.avatarBase64,

--- a/lib/models/conversation_draft.dart
+++ b/lib/models/conversation_draft.dart
@@ -1,0 +1,24 @@
+import 'package:prysm/models/reply_preview_data.dart';
+
+class ConversationDraft {
+  const ConversationDraft({
+    this.text = '',
+    this.reply,
+  });
+
+  final String text;
+  final ReplyPreviewData? reply;
+
+  bool get isEmpty => text.isEmpty && reply == null;
+
+  ConversationDraft copyWith({
+    String? text,
+    ReplyPreviewData? reply,
+    bool clearReply = false,
+  }) {
+    return ConversationDraft(
+      text: text ?? this.text,
+      reply: clearReply ? null : (reply ?? this.reply),
+    );
+  }
+}

--- a/lib/screens/chat.dart
+++ b/lib/screens/chat.dart
@@ -10,6 +10,8 @@ import 'package:flutter_chat_ui/flutter_chat_ui.dart';
 import 'package:flutter_chat_core/flutter_chat_core.dart';
 import 'package:path_provider/path_provider.dart';
 import 'package:url_launcher/url_launcher.dart';
+import 'package:prysm/models/reply_preview_data.dart';
+import 'package:prysm/services/message_draft_store.dart';
 import 'package:prysm/services/call/call_manager.dart';
 import 'package:prysm/transport/transport_preference.dart';
 import 'package:prysm/transport/transport_provider.dart';
@@ -137,6 +139,7 @@ class _ChatScreenState extends State<ChatScreen> {
 
   Set<String> selectedMessageIds = {};
   Message? _replyToMessage;
+  ReplyPreviewData? _replyDraft;
   final Map<String, double> _dragOffsets = {};
 
   Key _chatKey = UniqueKey();
@@ -175,6 +178,47 @@ class _ChatScreenState extends State<ChatScreen> {
       isMounted: () => mounted,
     );
     setState(() {});
+  }
+
+  String get _draftKey => 'dm:${widget.peerId}';
+
+  String? get _replyToMessageId => _replyToMessage?.id ?? _replyDraft?.messageId;
+
+  void _persistReplyDraft() {
+    final data = _replyToMessage != null
+        ? replyPreviewFromMessage(_replyToMessage!)
+        : _replyDraft;
+    MessageDraftStore.instance.setReply(_draftKey, data);
+  }
+
+  void _restoreReplyDraft() {
+    final stored = MessageDraftStore.instance.get(_draftKey).reply;
+    if (stored == null) return;
+    Message? found;
+    for (final message in _messages.messages) {
+      if (message.id == stored.messageId) {
+        found = message;
+        break;
+      }
+    }
+    setState(() {
+      _replyToMessage = found;
+      _replyDraft = found == null ? stored : null;
+    });
+  }
+
+  void _clearReplyState() {
+    _replyToMessage = null;
+    _replyDraft = null;
+    MessageDraftStore.instance.setReply(_draftKey, null);
+  }
+
+  void _setReplyToMessage(Message message) {
+    setState(() {
+      _replyToMessage = message;
+      _replyDraft = null;
+    });
+    _persistReplyDraft();
   }
 
   void _scheduleScrollToBottomIfNeeded({bool animated = false}) {
@@ -349,6 +393,7 @@ class _ChatScreenState extends State<ChatScreen> {
             .listen(_applyReadReceiptUpdate);
 
     await _loadInitialMessages();
+    _restoreReplyDraft();
     await _markInboundAsRead();
 
     if (mounted && _messages.messages.isNotEmpty) {
@@ -580,6 +625,7 @@ class _ChatScreenState extends State<ChatScreen> {
   void resetChatState() {
     _messages = InMemoryChatController();
     _replyToMessage = null;
+    _replyDraft = null;
     _messageCache.clear();
     _oldestTimestamp = null;
     _oldestMessageId = null;
@@ -1099,7 +1145,7 @@ class _ChatScreenState extends State<ChatScreen> {
   void _handleSendText(String text) async {
     if (!mounted) return;
 
-    var replyToId = _replyToMessage?.id;
+    var replyToId = _replyToMessageId;
 
     // ✅ Generate ID and show UI IMMEDIATELY
     final messageId = const Uuid().v4();
@@ -1118,7 +1164,9 @@ class _ChatScreenState extends State<ChatScreen> {
         index: _messages.messages.length,
       );
       _replyToMessage = null;
+      _replyDraft = null;
     });
+    MessageDraftStore.instance.setReply(_draftKey, null);
     _scheduleScrollToBottomAfterSend();
 
     // ✅ NOW send in background (non-blocking)
@@ -1140,7 +1188,7 @@ class _ChatScreenState extends State<ChatScreen> {
   Future<void> _sendFile(Uint8List bytes, String fileName, String type, {bool viewOnce = false}) async {
     if (!mounted) return;
 
-    var replyToId = _replyToMessage?.id;
+    var replyToId = _replyToMessageId;
 
     // ✅ Generate ID and show UI IMMEDIATELY
     final messageId = const Uuid().v4();
@@ -1179,7 +1227,9 @@ class _ChatScreenState extends State<ChatScreen> {
         );
       }
       _replyToMessage = null;
+      _replyDraft = null;
     });
+    MessageDraftStore.instance.setReply(_draftKey, null);
     _scheduleScrollToBottomAfterSend();
 
     // ✅ NOW send in background
@@ -1260,7 +1310,7 @@ class _ChatScreenState extends State<ChatScreen> {
     if (!mounted) return;
 
     final messageId = const Uuid().v4();
-    final replyToId = _replyToMessage?.id;
+    final replyToId = _replyToMessageId;
 
     // Save to cache so we can play back our own sent voice messages
     final cacheDir = await getTemporaryDirectory();
@@ -1288,7 +1338,9 @@ class _ChatScreenState extends State<ChatScreen> {
         index: _messages.messages.length,
       );
       _replyToMessage = null;
+      _replyDraft = null;
     });
+    MessageDraftStore.instance.setReply(_draftKey, null);
     _scheduleScrollToBottomAfterSend();
 
     _chatService
@@ -1397,6 +1449,7 @@ class _ChatScreenState extends State<ChatScreen> {
               _messages = InMemoryChatController();
               _chatKey = UniqueKey();
             });
+            MessageDraftStore.instance.setReply(_draftKey, null);
             _loadInitialMessages();
           },
           onDeleteContact: () async {
@@ -1406,8 +1459,8 @@ class _ChatScreenState extends State<ChatScreen> {
             setState(() {
               _messages = InMemoryChatController();
               _chatKey = UniqueKey();
-              _replyToMessage = null;
             });
+            MessageDraftStore.instance.setReply(_draftKey, null);
             widget.clearChat();
           },
           onPreferencesChanged: widget.reloadUsers,
@@ -1427,8 +1480,10 @@ class _ChatScreenState extends State<ChatScreen> {
   }
 
   Widget _buildReplyPreview() {
-    if (_replyToMessage == null) return const SizedBox.shrink();
-    final data = replyPreviewFromMessage(_replyToMessage!);
+    final data = _replyToMessage != null
+        ? replyPreviewFromMessage(_replyToMessage!)
+        : _replyDraft;
+    if (data == null) return const SizedBox.shrink();
     return DecoratedBox(
       decoration: BoxDecoration(
         color: Theme.of(context).colorScheme.surfaceContainerHigh,
@@ -1453,7 +1508,9 @@ class _ChatScreenState extends State<ChatScreen> {
             IconButton(
               icon: const Icon(Icons.close),
               visualDensity: VisualDensity.compact,
-              onPressed: () => setState(() => _replyToMessage = null),
+              onPressed: () {
+                setState(_clearReplyState);
+              },
             ),
           ],
         ),
@@ -1518,7 +1575,7 @@ class _ChatScreenState extends State<ChatScreen> {
         title: const Text('Reply'),
         onTap: () {
           Navigator.pop(context);
-          setState(() => _replyToMessage = message);
+          _setReplyToMessage(message);
         },
       ),
       ListTile(
@@ -1906,12 +1963,18 @@ class _ChatScreenState extends State<ChatScreen> {
                                 });
                               },
                               onHorizontalDragEnd: (details) {
+                                final shouldReply =
+                                    (_dragOffsets[message.id] ?? 0) > 50;
                                 setState(() {
-                                  if ((_dragOffsets[message.id] ?? 0) > 50) {
+                                  if (shouldReply) {
                                     _replyToMessage = message;
+                                    _replyDraft = null;
                                   }
                                   _dragOffsets[message.id] = 0;
                                 });
+                                if (shouldReply) {
+                                  _persistReplyDraft();
+                                }
                               },
                               onLongPressStart: (details) {
                                 if (selectedMessageIds.isNotEmpty) {
@@ -1993,7 +2056,8 @@ class _ChatScreenState extends State<ChatScreen> {
 
                   composerBuilder: (context) {
                     return PrysmChatComposerOverlay(
-                      replyPreview: _replyToMessage != null
+                      draftKey: _draftKey,
+                      replyPreview: _replyToMessage != null || _replyDraft != null
                           ? _buildReplyPreview()
                           : null,
                       typingTypistNames: _typingTypistNames(),

--- a/lib/screens/decoy_chat_screen.dart
+++ b/lib/screens/decoy_chat_screen.dart
@@ -8,6 +8,7 @@ import 'package:uuid/uuid.dart';
 
 /// Read-only-looking chat for panic decoy sessions. Messages stay in memory only.
 class DecoyChatScreen extends StatefulWidget {
+  final String conversationId;
   final String title;
   final String? avatarName;
   final String? avatarBase64;
@@ -16,6 +17,7 @@ class DecoyChatScreen extends StatefulWidget {
   final VoidCallback? onCloseChat;
 
   const DecoyChatScreen({
+    required this.conversationId,
     required this.title,
     this.avatarName,
     this.avatarBase64,
@@ -139,6 +141,7 @@ class _DecoyChatScreenState extends State<DecoyChatScreen> {
             ),
           ),
           MessageComposer(
+            draftKey: 'decoy:${widget.conversationId}',
             onSendText: _handleSend,
             onSendImage: () {},
             onSendFile: () {},

--- a/lib/screens/group_chat.dart
+++ b/lib/screens/group_chat.dart
@@ -15,6 +15,8 @@ import 'package:prysm/constants/group_constants.dart';
 import 'package:prysm/database/message_reactions.dart';
 import 'package:prysm/database/messages.dart';
 import 'package:prysm/models/contact.dart';
+import 'package:prysm/models/reply_preview_data.dart';
+import 'package:prysm/services/message_draft_store.dart';
 import 'package:prysm/models/group.dart';
 import 'package:prysm/screens/group_settings_screen.dart';
 import 'package:prysm/screens/widgets/jump_to_bottom_fab.dart';
@@ -122,6 +124,7 @@ class _GroupChatScreenState extends State<GroupChatScreen> {
   Timer? _highlightTimer;
 
   Message? _replyToMessage;
+  ReplyPreviewData? _replyDraft;
   final Set<String> selectedMessageIds = {};
   final Map<String, double> _dragOffsets = {};
   late TypingIndicatorService _typingService;
@@ -150,6 +153,47 @@ class _GroupChatScreenState extends State<GroupChatScreen> {
       isMounted: () => mounted,
     );
     setState(() {});
+  }
+
+  String get _draftKey => 'group:${widget.group.id}';
+
+  String? get _replyToMessageId => _replyToMessage?.id ?? _replyDraft?.messageId;
+
+  void _persistReplyDraft() {
+    final data = _replyToMessage != null
+        ? replyPreviewFromMessage(_replyToMessage!)
+        : _replyDraft;
+    MessageDraftStore.instance.setReply(_draftKey, data);
+  }
+
+  void _restoreReplyDraft() {
+    final stored = MessageDraftStore.instance.get(_draftKey).reply;
+    if (stored == null) return;
+    Message? found;
+    for (final message in _messages.messages) {
+      if (message.id == stored.messageId) {
+        found = message;
+        break;
+      }
+    }
+    setState(() {
+      _replyToMessage = found;
+      _replyDraft = found == null ? stored : null;
+    });
+  }
+
+  void _clearReplyState() {
+    _replyToMessage = null;
+    _replyDraft = null;
+    MessageDraftStore.instance.setReply(_draftKey, null);
+  }
+
+  void _setReplyToMessage(Message message) {
+    setState(() {
+      _replyToMessage = message;
+      _replyDraft = null;
+    });
+    _persistReplyDraft();
   }
 
   void _scheduleScrollToBottomIfNeeded({bool animated = false}) {
@@ -212,6 +256,8 @@ class _GroupChatScreenState extends State<GroupChatScreen> {
     if (oldWidget.group.id != widget.group.id) {
       _teardown();
       _messages = InMemoryChatController();
+      _replyToMessage = null;
+      _replyDraft = null;
       _senderNames.clear();
       _memberCount = 0;
       _loading = false;
@@ -300,6 +346,7 @@ class _GroupChatScreenState extends State<GroupChatScreen> {
             .listen(_applyReadReceiptUpdate);
 
     await _loadMoreMessages();
+    _restoreReplyDraft();
     await _markInboundAsRead();
     _chatService.startPolling();
     _chatService.startSendQueue();
@@ -338,11 +385,13 @@ class _GroupChatScreenState extends State<GroupChatScreen> {
   }
 
   Widget _buildReplyPreview() {
-    if (_replyToMessage == null) return const SizedBox.shrink();
-    final data = replyPreviewFromMessage(_replyToMessage!);
-    final authorName = _replyToMessage!.authorId == widget.userId
+    final data = _replyToMessage != null
+        ? replyPreviewFromMessage(_replyToMessage!)
+        : _replyDraft;
+    if (data == null) return const SizedBox.shrink();
+    final authorName = data.authorId == widget.userId
         ? 'You'
-        : _senderNames[_replyToMessage!.authorId];
+        : _senderNames[data.authorId];
     return DecoratedBox(
       decoration: BoxDecoration(
         color: Theme.of(context).colorScheme.surfaceContainerHigh,
@@ -368,7 +417,7 @@ class _GroupChatScreenState extends State<GroupChatScreen> {
             IconButton(
               icon: const Icon(Icons.close),
               visualDensity: VisualDensity.compact,
-              onPressed: () => setState(() => _replyToMessage = null),
+              onPressed: () => setState(_clearReplyState),
             ),
           ],
         ),
@@ -413,7 +462,7 @@ class _GroupChatScreenState extends State<GroupChatScreen> {
           title: const Text('Reply'),
           onTap: () {
             Navigator.pop(context);
-            setState(() => _replyToMessage = message);
+            _setReplyToMessage(message);
           },
         ),
         ListTile(
@@ -1013,7 +1062,7 @@ class _GroupChatScreenState extends State<GroupChatScreen> {
 
   void _handleSendText(String text) async {
     final messageId = const Uuid().v4();
-    final replyToId = _replyToMessage?.id;
+    final replyToId = _replyToMessageId;
     setState(() {
       _messages.insertMessage(
         messageWithPendingStatus(
@@ -1028,7 +1077,9 @@ class _GroupChatScreenState extends State<GroupChatScreen> {
         index: _messages.messages.length,
       );
       _replyToMessage = null;
+      _replyDraft = null;
     });
+    MessageDraftStore.instance.setReply(_draftKey, null);
     _scheduleScrollToBottomAfterSend();
     final sentId = await _chatService.sendTextMessage(
       text,
@@ -1045,7 +1096,7 @@ class _GroupChatScreenState extends State<GroupChatScreen> {
 
   void _sendFile(Uint8List bytes, String fileName, String type, {bool viewOnce = false}) async {
     final messageId = const Uuid().v4();
-    final replyToId = _replyToMessage?.id;
+    final replyToId = _replyToMessageId;
     setState(() {
       if (type == 'file') {
         _messages.insertMessage(
@@ -1080,7 +1131,9 @@ class _GroupChatScreenState extends State<GroupChatScreen> {
         );
       }
       _replyToMessage = null;
+      _replyDraft = null;
     });
+    MessageDraftStore.instance.setReply(_draftKey, null);
     _scheduleScrollToBottomAfterSend();
 
     final sentId = await _chatService.sendFileMessage(
@@ -1134,7 +1187,7 @@ class _GroupChatScreenState extends State<GroupChatScreen> {
 
   Future<void> _handleSendVoice(Uint8List bytes, int durationMs) async {
     final messageId = const Uuid().v4();
-    final replyToId = _replyToMessage?.id;
+    final replyToId = _replyToMessageId;
     final cacheDir = await getTemporaryDirectory();
     final cachePath = '${cacheDir.path}/group_voice_cache_$messageId.wav';
     await File(cachePath).writeAsBytes(bytes);
@@ -1159,7 +1212,9 @@ class _GroupChatScreenState extends State<GroupChatScreen> {
         index: _messages.messages.length,
       );
       _replyToMessage = null;
+      _replyDraft = null;
     });
+    MessageDraftStore.instance.setReply(_draftKey, null);
     _scheduleScrollToBottomAfterSend();
 
     await _chatService.sendFileMessage(
@@ -1742,12 +1797,18 @@ class _GroupChatScreenState extends State<GroupChatScreen> {
                             });
                           },
                           onHorizontalDragEnd: (details) {
+                            final shouldReply =
+                                (_dragOffsets[message.id] ?? 0) > 50;
                             setState(() {
-                              if ((_dragOffsets[message.id] ?? 0) > 50) {
+                              if (shouldReply) {
                                 _replyToMessage = message;
+                                _replyDraft = null;
                               }
                               _dragOffsets[message.id] = 0;
                             });
+                            if (shouldReply) {
+                              _persistReplyDraft();
+                            }
                           },
                           child: Transform.translate(
                             offset: Offset(
@@ -1821,7 +1882,8 @@ class _GroupChatScreenState extends State<GroupChatScreen> {
                   fileMessageBuilder: _groupFileMessageBuilder,
             composerBuilder: (context) {
               return PrysmChatComposerOverlay(
-                replyPreview: _replyToMessage != null
+                draftKey: _draftKey,
+                replyPreview: _replyToMessage != null || _replyDraft != null
                     ? _buildReplyPreview()
                     : null,
                 typingTypistNames: _typingTypistNames(),

--- a/lib/screens/message_composer.dart
+++ b/lib/screens/message_composer.dart
@@ -6,6 +6,7 @@ import 'package:emoji_picker_flutter/emoji_picker_flutter.dart';
 import 'package:record/record.dart';
 import 'package:permission_handler/permission_handler.dart';
 import 'package:path_provider/path_provider.dart';
+import 'package:prysm/services/message_draft_store.dart';
 import 'package:prysm/util/waveform_extractor.dart';
 
 class MessageComposer extends StatefulWidget {
@@ -15,6 +16,7 @@ class MessageComposer extends StatefulWidget {
   final Function(Uint8List bytes, int durationMs)? onSendVoice;
   final ValueChanged<bool>? onTypingChanged;
   final VoidCallback? onLayoutChanged;
+  final String? draftKey;
 
   const MessageComposer({
     super.key,
@@ -24,6 +26,7 @@ class MessageComposer extends StatefulWidget {
     this.onSendVoice,
     this.onTypingChanged,
     this.onLayoutChanged,
+    this.draftKey,
   });
 
   @override
@@ -43,8 +46,39 @@ class MessageComposerState extends State<MessageComposer> {
   String? _recordPath;
 
   @override
+  void initState() {
+    super.initState();
+    _loadDraft();
+  }
+
+  @override
+  void didUpdateWidget(covariant MessageComposer oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (oldWidget.draftKey != widget.draftKey) {
+      _persistDraft(oldWidget.draftKey);
+      _loadDraft();
+    }
+  }
+
+  void _loadDraft() {
+    final key = widget.draftKey;
+    if (key == null || key.isEmpty) return;
+    final text = MessageDraftStore.instance.get(key).text;
+    if (text.isEmpty) return;
+    _textController.text = text;
+    currentText = text;
+  }
+
+  void _persistDraft([String? keyOverride]) {
+    final key = keyOverride ?? widget.draftKey;
+    if (key == null || key.isEmpty) return;
+    MessageDraftStore.instance.setText(key, _textController.text);
+  }
+
+  @override
   void dispose() {
     widget.onTypingChanged?.call(false);
+    _persistDraft();
     _textController.dispose();
     _recordTimer?.cancel();
     _recorder.dispose();
@@ -69,6 +103,7 @@ class MessageComposerState extends State<MessageComposer> {
       currentText = '';
       showEmojiPicker = false;
     });
+    _persistDraft();
     WidgetsBinding.instance.addPostFrameCallback((_) => _notifyLayoutChanged());
   }
 
@@ -87,6 +122,7 @@ class MessageComposerState extends State<MessageComposer> {
     setState(() {
       currentText = newText;
     });
+    _persistDraft();
     _notifyTypingFromText(newText);
   }
 
@@ -274,6 +310,7 @@ class MessageComposerState extends State<MessageComposer> {
             controller: _textController,
             onChanged: (text) {
               setState(() => currentText = text);
+              _persistDraft();
               _notifyTypingFromText(text);
             },
             onSubmitted: (_) => _handleSend(),

--- a/lib/screens/self_chat_screen.dart
+++ b/lib/screens/self_chat_screen.dart
@@ -682,6 +682,7 @@ class _SelfChatScreenState extends State<SelfChatScreen> {
             textMessageBuilder: _textMessageBuilder,
             composerBuilder: (context) {
               return PrysmChatComposerOverlay(
+                draftKey: 'self:${widget.userId}',
                 onSendText: _handleSendText,
                 onSendImage: _handleSendImage,
                 onSendFile: _handleSendFile,

--- a/lib/screens/widgets/prysm_chat_composer_overlay.dart
+++ b/lib/screens/widgets/prysm_chat_composer_overlay.dart
@@ -15,6 +15,7 @@ class PrysmChatComposerOverlay extends StatefulWidget {
   final VoidCallback onSendFile;
   final void Function(Uint8List bytes, int durationMs)? onSendVoice;
   final ValueChanged<bool>? onTypingChanged;
+  final String? draftKey;
 
   const PrysmChatComposerOverlay({
     super.key,
@@ -25,6 +26,7 @@ class PrysmChatComposerOverlay extends StatefulWidget {
     required this.onSendFile,
     this.onSendVoice,
     this.onTypingChanged,
+    this.draftKey,
   });
 
   @override
@@ -76,6 +78,7 @@ class _PrysmChatComposerOverlayState extends State<PrysmChatComposerOverlay> {
             if (widget.replyPreview != null) widget.replyPreview!,
             TypingIndicatorBar(typistNames: widget.typingTypistNames),
             MessageComposer(
+              draftKey: widget.draftKey,
               onSendText: widget.onSendText,
               onSendImage: widget.onSendImage,
               onSendFile: widget.onSendFile,

--- a/lib/services/message_draft_store.dart
+++ b/lib/services/message_draft_store.dart
@@ -1,0 +1,43 @@
+import 'package:prysm/models/conversation_draft.dart';
+import 'package:prysm/models/reply_preview_data.dart';
+
+/// In-memory per-conversation drafts (lost when the app process exits).
+class MessageDraftStore {
+  MessageDraftStore._();
+
+  static final MessageDraftStore instance = MessageDraftStore._();
+
+  final Map<String, ConversationDraft> _drafts = {};
+
+  ConversationDraft get(String key) => _drafts[key] ?? const ConversationDraft();
+
+  void setText(String key, String text) {
+    final existing = get(key);
+    final updated = existing.copyWith(text: text);
+    _upsertOrRemove(key, updated);
+  }
+
+  void setReply(String key, ReplyPreviewData? reply) {
+    final existing = get(key);
+    final updated = reply == null
+        ? existing.copyWith(clearReply: true)
+        : existing.copyWith(reply: reply);
+    _upsertOrRemove(key, updated);
+  }
+
+  void clear(String key) {
+    _drafts.remove(key);
+  }
+
+  void clearAll() {
+    _drafts.clear();
+  }
+
+  void _upsertOrRemove(String key, ConversationDraft draft) {
+    if (draft.isEmpty) {
+      _drafts.remove(key);
+      return;
+    }
+    _drafts[key] = draft;
+  }
+}

--- a/test/message_draft_store_test.dart
+++ b/test/message_draft_store_test.dart
@@ -1,0 +1,62 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:prysm/models/reply_preview_data.dart';
+import 'package:prysm/services/message_draft_store.dart';
+
+void main() {
+  setUp(MessageDraftStore.instance.clearAll);
+
+  test('empty store returns empty draft', () {
+    expect(MessageDraftStore.instance.get('dm:peer.onion').isEmpty, isTrue);
+  });
+
+  test('setText upserts text', () {
+    MessageDraftStore.instance.setText('dm:peer.onion', 'hello');
+    expect(MessageDraftStore.instance.get('dm:peer.onion').text, 'hello');
+  });
+
+  test('setReply upserts reply', () {
+    const reply = ReplyPreviewData(
+      messageId: 'msg-1',
+      authorId: 'peer.onion',
+      label: 'Hi',
+      kind: ReplyPreviewKind.text,
+    );
+    MessageDraftStore.instance.setReply('dm:peer.onion', reply);
+    expect(MessageDraftStore.instance.get('dm:peer.onion').reply, reply);
+  });
+
+  test('setText and setReply are independent', () {
+    const reply = ReplyPreviewData(
+      messageId: 'msg-1',
+      authorId: 'peer.onion',
+      label: 'Hi',
+      kind: ReplyPreviewKind.text,
+    );
+    MessageDraftStore.instance.setText('dm:peer.onion', 'draft');
+    MessageDraftStore.instance.setReply('dm:peer.onion', reply);
+
+    final draft = MessageDraftStore.instance.get('dm:peer.onion');
+    expect(draft.text, 'draft');
+    expect(draft.reply, reply);
+  });
+
+  test('key removed when text and reply are empty', () {
+    MessageDraftStore.instance.setText('dm:peer.onion', 'hello');
+    MessageDraftStore.instance.setText('dm:peer.onion', '');
+    expect(MessageDraftStore.instance.get('dm:peer.onion').isEmpty, isTrue);
+  });
+
+  test('clear removes draft', () {
+    MessageDraftStore.instance.setText('dm:peer.onion', 'hello');
+    MessageDraftStore.instance.clear('dm:peer.onion');
+    expect(MessageDraftStore.instance.get('dm:peer.onion').isEmpty, isTrue);
+  });
+
+  test('clearAll removes all drafts', () {
+    MessageDraftStore.instance.setText('dm:a.onion', 'one');
+    MessageDraftStore.instance.setText('dm:b.onion', 'two');
+    MessageDraftStore.instance.clearAll();
+    expect(MessageDraftStore.instance.get('dm:a.onion').isEmpty, isTrue);
+    expect(MessageDraftStore.instance.get('dm:b.onion').isEmpty, isTrue);
+  });
+}


### PR DESCRIPTION
- Added MessageDraftStore to manage in-memory conversation drafts, allowing users to save and restore message text and reply previews.
- Updated ChatScreen, GroupChatScreen, DecoyChatScreen, and SelfChatScreen to integrate draft functionality, enabling persistence of user input across sessions.
- Enhanced MessageComposer to load and persist drafts based on conversation context.
- Added tests for MessageDraftStore to ensure correct behavior of draft management.