### PR TITLE
feat: implement blocking functionality across chat and profile screens

### DIFF
--- a/lib/database/blocked_users_db.dart
+++ b/lib/database/blocked_users_db.dart
@@ -1,0 +1,69 @@
+import 'package:prysm/util/db_helper.dart';
+import 'package:sqflite_common_ffi/sqflite_ffi.dart';
+
+class BlockedUser {
+  final String userId;
+  final int blockedAt;
+
+  const BlockedUser({required this.userId, required this.blockedAt});
+
+  factory BlockedUser.fromMap(Map<String, dynamic> map) {
+    return BlockedUser(
+      userId: map['userId'] as String,
+      blockedAt: map['blockedAt'] as int,
+    );
+  }
+}
+
+class BlockedUsersDb {
+  BlockedUsersDb._();
+
+  static Future<void> createTable(Database db) async {
+    await db.execute('''
+      CREATE TABLE blocked_users (
+        userId TEXT PRIMARY KEY,
+        blockedAt INTEGER NOT NULL
+      )
+    ''');
+  }
+
+  static Future<void> block(String userId, int blockedAt) async {
+    final db = await DBHelper.database;
+    await db.insert(
+      'blocked_users',
+      {'userId': userId, 'blockedAt': blockedAt},
+      conflictAlgorithm: ConflictAlgorithm.replace,
+    );
+  }
+
+  static Future<void> unblock(String userId) async {
+    final db = await DBHelper.database;
+    await db.delete(
+      'blocked_users',
+      where: 'userId = ?',
+      whereArgs: [userId],
+    );
+  }
+
+  static Future<bool> isBlocked(String userId) async {
+    final db = await DBHelper.database;
+    final rows = await db.query(
+      'blocked_users',
+      where: 'userId = ?',
+      whereArgs: [userId],
+      limit: 1,
+    );
+    return rows.isNotEmpty;
+  }
+
+  static Future<List<BlockedUser>> getAll() async {
+    final db = await DBHelper.database;
+    final rows = await db.query('blocked_users', orderBy: 'blockedAt DESC');
+    return rows.map(BlockedUser.fromMap).toList();
+  }
+
+  static Future<Set<String>> getBlockedIds() async {
+    final all = await getAll();
+    return all.map((u) => u.userId).toSet();
+  }
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -21,6 +21,7 @@ import 'package:prysm/services/unlock_lockout_service.dart';
 import 'package:prysm/screens/settings_screen.dart';
 import 'package:prysm/server/PrysmServer.dart';
 import 'package:prysm/services/battery_saver_service.dart';
+import 'package:prysm/services/block_service.dart';
 import 'package:prysm/services/notification_mute_service.dart';
 import 'package:prysm/services/active_conversation_tracker.dart';
 import 'package:prysm/services/notification_open_chat_resolver.dart';
@@ -70,6 +71,7 @@ import 'package:prysm/screens/onboarding/onboarding_screen.dart';
 import 'package:prysm/services/contact_add_service.dart';
 import 'package:prysm/util/qr_platform.dart';
 import 'package:prysm/util/tor_connection_notifier.dart';
+import 'package:prysm/util/local_onion_address.dart';
 import 'package:prysm/util/network_reachability.dart';
 import 'package:prysm/services/read_receipt_service.dart';
 import 'package:prysm/services/sync_coordinator.dart';
@@ -148,12 +150,15 @@ void main() async {
   await PeerTransportRegistry.instance.load();
   await BatterySaverService.instance.init();
   await NotificationMuteService.instance.init();
+  await BlockService.instance.init();
 
   final keyManager = KeyManager();
 
   // Start early so Tor peers can connect during bootstrap / unlock screen.
   final messageServer = PrysmServer(port: 12345, keyManager: keyManager);
   messageServer.start();
+  LocalOnionAddress.provider =
+      () => PrysmServer.instance?.localOnionAddress;
 
   runApp(MyApp(keyManager: keyManager));
 
@@ -850,6 +855,7 @@ class _HomeScreenState extends State<HomeScreen> with WidgetsBindingObserver {
   Map<String, ConversationPreferences> _conversationPrefs = {};
   Map<String, List<DecoyMessage>> _decoyMessages = {};
   bool _viewingArchived = false;
+  bool _viewingBlocked = false;
 
   Timer? _refreshTimer;
   Timer? _loadUsersDebounce;
@@ -873,9 +879,42 @@ class _HomeScreenState extends State<HomeScreen> with WidgetsBindingObserver {
       )
       .length;
 
+  int get _blockedCount => conversations
+      .where(
+        (c) =>
+            c is DirectConversation &&
+            BlockService.instance.isBlocked(c.id),
+      )
+      .length;
+
+  int get _sidebarFooterCount {
+    if (_viewingArchived || _viewingBlocked || _searchQuery.isNotEmpty) {
+      return 0;
+    }
+    var count = 0;
+    if (_archivedCount > 0) count++;
+    if (_blockedCount > 0) count++;
+    return count;
+  }
+
   List<Conversation> get _filteredConversations {
     return conversations.where((c) {
+      final blocked =
+          c is DirectConversation && BlockService.instance.isBlocked(c.id);
       final archived = _conversationPrefs[c.id]?.isArchived ?? false;
+
+      if (_viewingBlocked) {
+        if (!blocked) return false;
+        if (_searchQuery.isNotEmpty) {
+          final name = c.contact.displayName.toLowerCase();
+          return name.contains(_searchQuery) ||
+              c.id.toLowerCase().contains(_searchQuery);
+        }
+        return true;
+      }
+
+      if (blocked) return false;
+
       if (_searchQuery.isNotEmpty) {
         if (!c.displayName.toLowerCase().contains(_searchQuery)) return false;
         return _viewingArchived ? archived : true;
@@ -1780,7 +1819,7 @@ class _HomeScreenState extends State<HomeScreen> with WidgetsBindingObserver {
   }
 
   bool get _showSelfChatInSidebar {
-    if (widget.decoyMode || _viewingArchived) return false;
+    if (widget.decoyMode || _viewingArchived || _viewingBlocked) return false;
     if (_searchQuery.isEmpty) return true;
     return 'chat with myself'.contains(_searchQuery);
   }
@@ -1938,6 +1977,31 @@ class _HomeScreenState extends State<HomeScreen> with WidgetsBindingObserver {
                 ],
               ),
             ),
+          if (_viewingBlocked)
+            Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+              child: Row(
+                children: [
+                  IconButton(
+                    icon: const Icon(Icons.arrow_back),
+                    tooltip: 'Back to chats',
+                    onPressed: () => setState(() {
+                      _viewingBlocked = false;
+                      _searchQuery = '';
+                    }),
+                  ),
+                  const Expanded(
+                    child: Text(
+                      'Blocked',
+                      style: TextStyle(
+                        fontWeight: FontWeight.w600,
+                        fontSize: 16,
+                      ),
+                    ),
+                  ),
+                ],
+              ),
+            ),
           const SizedBox(height: 8),
           // Search bar
           Padding(
@@ -1960,7 +2024,9 @@ class _HomeScreenState extends State<HomeScreen> with WidgetsBindingObserver {
                 decoration: InputDecoration(
                   hintText: _viewingArchived
                       ? 'Search archived...'
-                      : 'Search chats...',
+                      : _viewingBlocked
+                          ? 'Search blocked...'
+                          : 'Search chats...',
                   hintStyle: const TextStyle(fontSize: 14),
                   prefixIcon: const Icon(Icons.search, size: 20),
                   border: InputBorder.none,
@@ -1978,44 +2044,65 @@ class _HomeScreenState extends State<HomeScreen> with WidgetsBindingObserver {
           Expanded(
             child: ListView.builder(
               padding: const EdgeInsets.symmetric(vertical: 8),
-              itemCount: _filteredConversations.length +
-                  (!_viewingArchived && _searchQuery.isEmpty && _archivedCount > 0
-                      ? 1
-                      : 0),
+              itemCount: _filteredConversations.length + _sidebarFooterCount,
               itemBuilder: (_, index) {
-                final showArchivedEntry = !_viewingArchived &&
-                    _searchQuery.isEmpty &&
-                    _archivedCount > 0;
-                if (showArchivedEntry && index == _filteredConversations.length) {
+                if (index >= _filteredConversations.length) {
+                  final footerIndex = index - _filteredConversations.length;
+                  final showArchivedFooter = _archivedCount > 0;
+                  if (showArchivedFooter && footerIndex == 0) {
+                    return Padding(
+                      padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 2),
+                      child: ListTile(
+                        leading: Icon(
+                          Icons.archive_outlined,
+                          color: Theme.of(context).colorScheme.primary,
+                        ),
+                        title: const Text('Archived'),
+                        subtitle: Row(
+                          mainAxisSize: MainAxisSize.min,
+                          children: [
+                            Text('$_archivedCount'),
+                            if (_archivedUnreadCount > 0) ...[
+                              const SizedBox(width: 8),
+                              Container(
+                                width: 8,
+                                height: 8,
+                                decoration: BoxDecoration(
+                                  color: Theme.of(context).colorScheme.primary,
+                                  shape: BoxShape.circle,
+                                ),
+                              ),
+                            ],
+                          ],
+                        ),
+                        shape: RoundedRectangleBorder(
+                          borderRadius: BorderRadius.circular(12),
+                        ),
+                        onTap: () => setState(() {
+                          _viewingArchived = true;
+                          _viewingBlocked = false;
+                        }),
+                      ),
+                    );
+                  }
                   return Padding(
                     padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 2),
                     child: ListTile(
                       leading: Icon(
-                        Icons.archive_outlined,
+                        Icons.block_outlined,
                         color: Theme.of(context).colorScheme.primary,
                       ),
-                      title: const Text('Archived'),
-                      subtitle: Row(
-                        mainAxisSize: MainAxisSize.min,
-                        children: [
-                          Text('$_archivedCount'),
-                          if (_archivedUnreadCount > 0) ...[
-                            const SizedBox(width: 8),
-                            Container(
-                              width: 8,
-                              height: 8,
-                              decoration: BoxDecoration(
-                                color: Theme.of(context).colorScheme.primary,
-                                shape: BoxShape.circle,
-                              ),
-                            ),
-                          ],
-                        ],
+                      title: const Text('Blocked'),
+                      subtitle: Text(
+                        '$_blockedCount contact${_blockedCount == 1 ? '' : 's'}',
                       ),
                       shape: RoundedRectangleBorder(
                         borderRadius: BorderRadius.circular(12),
                       ),
-                      onTap: () => setState(() => _viewingArchived = true),
+                      onTap: () => setState(() {
+                        _viewingBlocked = true;
+                        _viewingArchived = false;
+                      }),
                     ),
                   );
                 }
@@ -2034,8 +2121,18 @@ class _HomeScreenState extends State<HomeScreen> with WidgetsBindingObserver {
 
                 if (conv is DirectConversation) {
                   final contact = conv.contact;
-                  leading = ContactAvatar(name: contact.displayName, avatarBase64: contact.avatarBase64);
-                  subtitle = preview != null ? '$preview · $timeLabel' : timeLabel;
+                  final isBlockedContact =
+                      BlockService.instance.isBlocked(conv.id);
+                  leading = ContactAvatar(
+                    name: contact.displayName,
+                    avatarBase64: contact.avatarBase64,
+                  );
+                  if (isBlockedContact) {
+                    subtitle = timeLabel;
+                  } else {
+                    subtitle =
+                        preview != null ? '$preview · $timeLabel' : timeLabel;
+                  }
                 } else {
                   final group = (conv as GroupConversation).group;
                   leading = ContactAvatar(
@@ -2048,7 +2145,9 @@ class _HomeScreenState extends State<HomeScreen> with WidgetsBindingObserver {
                 }
 
                 Widget? trailing;
-                if (unreadCount > 0) {
+                final isBlockedContact = conv is DirectConversation &&
+                    BlockService.instance.isBlocked(conv.id);
+                if (unreadCount > 0 && !isBlockedContact) {
                   trailing = CircleAvatar(
                     radius: 11,
                     backgroundColor: Theme.of(context).colorScheme.primary,
@@ -2060,7 +2159,13 @@ class _HomeScreenState extends State<HomeScreen> with WidgetsBindingObserver {
                       ),
                     ),
                   );
-                } else if (isPinned && !_viewingArchived) {
+                } else if (isBlockedContact && _viewingBlocked) {
+                  trailing = Icon(
+                    Icons.block,
+                    size: 18,
+                    color: Theme.of(context).hintColor,
+                  );
+                } else if (isPinned && !_viewingArchived && !_viewingBlocked) {
                   trailing = Icon(
                     Icons.push_pin,
                     size: 18,
@@ -2086,7 +2191,10 @@ class _HomeScreenState extends State<HomeScreen> with WidgetsBindingObserver {
                             overflow: TextOverflow.ellipsis,
                           ),
                         ),
-                        if (isArchived && !_viewingArchived && _searchQuery.isNotEmpty)
+                        if (isArchived &&
+                            !_viewingArchived &&
+                            !_viewingBlocked &&
+                            _searchQuery.isNotEmpty)
                           Padding(
                             padding: const EdgeInsets.only(left: 4),
                             child: Icon(

--- a/lib/screens/blocked_contacts_screen.dart
+++ b/lib/screens/blocked_contacts_screen.dart
@@ -1,0 +1,164 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:prysm/models/contact.dart';
+import 'package:prysm/services/block_service.dart';
+import 'package:prysm/util/db_helper.dart';
+import 'package:prysm/util/onion_id_codec.dart';
+import 'package:prysm/screens/widgets/contact_avatar.dart';
+
+class BlockedContactsScreen extends StatefulWidget {
+  final VoidCallback onClose;
+  final void Function(String peerId)? onOpenChat;
+
+  const BlockedContactsScreen({
+    required this.onClose,
+    this.onOpenChat,
+    super.key,
+  });
+
+  @override
+  State<BlockedContactsScreen> createState() => _BlockedContactsScreenState();
+}
+
+class _BlockedContactsScreenState extends State<BlockedContactsScreen> {
+  final Map<String, Contact> _contactsById = {};
+  List<String> _blockedIds = [];
+  bool _loading = true;
+
+  @override
+  void initState() {
+    super.initState();
+    unawaited(_load());
+  }
+
+  Future<void> _load() async {
+    final blockedIds = BlockService.instance.blockedIds.toList()
+      ..sort((a, b) {
+        final aAt = BlockService.instance.blockedAt(a) ?? 0;
+        final bAt = BlockService.instance.blockedAt(b) ?? 0;
+        return bAt.compareTo(aAt);
+      });
+
+    final contacts = <String, Contact>{};
+    for (final peerId in blockedIds) {
+      final user = await DBHelper.getUserById(peerId);
+      if (user != null) {
+        contacts[peerId] = Contact(
+          id: peerId,
+          name: (user['name'] as String?) ?? peerId,
+          avatarUrl: '',
+          avatarBase64: user['avatarBase64'] as String?,
+          customName: user['customName'] as String?,
+          identityJson: (user['identityJson'] as String?) ??
+              (user['publicKeyPem'] as String?) ??
+              '',
+        );
+      }
+    }
+
+    if (!mounted) return;
+    setState(() {
+      _blockedIds = blockedIds;
+      _contactsById
+        ..clear()
+        ..addAll(contacts);
+      _loading = false;
+    });
+  }
+
+  String _shortOnion(String onion) {
+    try {
+      final encoded = encodeOnionToBase58(onion);
+      if (encoded.length <= 12) return encoded;
+      return '${encoded.substring(0, 6)}…${encoded.substring(encoded.length - 4)}';
+    } catch (_) {
+      if (onion.length <= 12) return onion;
+      return '${onion.substring(0, 6)}…';
+    }
+  }
+
+  Future<void> _confirmUnblock(String peerId) async {
+    final confirmed = await showDialog<bool>(
+      context: context,
+      builder: (context) => AlertDialog(
+        title: const Text('Unblock contact'),
+        content: const Text(
+          'This contact will be able to message and call you again.',
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.of(context).pop(false),
+            child: const Text('Cancel'),
+          ),
+          TextButton(
+            onPressed: () => Navigator.of(context).pop(true),
+            child: const Text('Unblock'),
+          ),
+        ],
+      ),
+    );
+    if (confirmed != true || !mounted) return;
+
+    await BlockService.instance.unblock(peerId);
+    await _load();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Blocked contacts'),
+        leading: IconButton(
+          icon: const Icon(Icons.arrow_back),
+          onPressed: widget.onClose,
+        ),
+      ),
+      body: _loading
+          ? const Center(child: CircularProgressIndicator())
+          : _blockedIds.isEmpty
+              ? Center(
+                  child: Text(
+                    'No blocked contacts',
+                    style: TextStyle(color: Theme.of(context).hintColor),
+                  ),
+                )
+              : ListView.separated(
+                  padding: const EdgeInsets.symmetric(vertical: 8),
+                  itemCount: _blockedIds.length,
+                  separatorBuilder: (context, index) =>
+                      const Divider(height: 1),
+                  itemBuilder: (context, index) {
+                    final peerId = _blockedIds[index];
+                    final contact = _contactsById[peerId];
+                    final displayName = contact?.displayName ?? _shortOnion(peerId);
+
+                    return ListTile(
+                      leading: ContactAvatar(
+                        name: displayName,
+                        avatarBase64: contact?.avatarBase64,
+                      ),
+                      title: Text(displayName),
+                      subtitle: Text(
+                        _shortOnion(peerId),
+                        style: const TextStyle(
+                          fontFamily: 'monospace',
+                          fontSize: 12,
+                        ),
+                      ),
+                      trailing: TextButton(
+                        onPressed: () => _confirmUnblock(peerId),
+                        child: const Text('Unblock'),
+                      ),
+                      onTap: () async {
+                        if (contact == null || widget.onOpenChat == null) {
+                          return;
+                        }
+                        widget.onOpenChat!(peerId);
+                      },
+                    );
+                  },
+                ),
+    );
+  }
+}

--- a/lib/screens/chat.dart
+++ b/lib/screens/chat.dart
@@ -12,6 +12,7 @@ import 'package:path_provider/path_provider.dart';
 import 'package:url_launcher/url_launcher.dart';
 import 'package:prysm/models/reply_preview_data.dart';
 import 'package:prysm/services/message_draft_store.dart';
+import 'package:prysm/services/block_service.dart';
 import 'package:prysm/services/call/call_manager.dart';
 import 'package:prysm/transport/transport_preference.dart';
 import 'package:prysm/transport/transport_provider.dart';
@@ -296,6 +297,7 @@ class _ChatScreenState extends State<ChatScreen> {
   }
 
   void _initPeerPresence() {
+    if (_isPeerBlocked) return;
     if (!_isNetworkAvailable) {
       _applyOfflinePresence();
     } else {
@@ -576,6 +578,7 @@ class _ChatScreenState extends State<ChatScreen> {
   Future<void> _refreshPeerProfile({
     TransportPreference preference = TransportPreference.wsPreferred,
   }) async {
+    if (_isPeerBlocked) return;
     if (!_isNetworkAvailable) return;
     try {
       final body = await TransportProvider.getProfileOrFallback(
@@ -1389,7 +1392,10 @@ class _ChatScreenState extends State<ChatScreen> {
     }
   }
 
+  bool get _isPeerBlocked => BlockService.instance.isBlocked(widget.peerId);
+
   bool get _canStartCall {
+    if (_isPeerBlocked) return false;
     if (TorRuntimeGate.blocked) return false;
     if (!TransportProvider.isConfigured) return false;
     if (!TransportProvider.instance.isRealtimeConnected(widget.peerId)) {
@@ -1467,6 +1473,16 @@ class _ChatScreenState extends State<ChatScreen> {
           onArchived: () {
             Navigator.of(context).pop();
             widget.clearChat();
+          },
+          onBlocked: () {
+            widget.reloadUsers();
+            Navigator.of(context).pop();
+            widget.clearChat();
+          },
+          onUnblocked: () {
+            widget.reloadUsers();
+            unawaited(_refreshPeerProfile());
+            _initPeerPresence();
           },
         ),
       ),
@@ -1748,7 +1764,9 @@ class _ChatScreenState extends State<ChatScreen> {
                             fontWeight: FontWeight.w600,
                           ),
                         ),
-                        subtitle: const Text('View profile'),
+                        subtitle: Text(
+                          _isPeerBlocked ? 'Blocked · View profile' : 'View profile',
+                        ),
                         onTap: () {
                           Navigator.pop(context);
                           _openChatProfile();
@@ -1781,7 +1799,16 @@ class _ChatScreenState extends State<ChatScreen> {
                     ),
                   ),
                   const SizedBox(height: 2),
-                  if (_peerOnline == null)
+                  if (_isPeerBlocked)
+                    Text(
+                      'Blocked',
+                      style: TextStyle(
+                        color: Theme.of(context).hintColor,
+                        fontSize: 12,
+                        fontWeight: FontWeight.w500,
+                      ),
+                    )
+                  else if (_peerOnline == null)
                     Text(
                       'Checking...',
                       style: TextStyle(
@@ -2055,6 +2082,32 @@ class _ChatScreenState extends State<ChatScreen> {
                   textMessageBuilder: textMessageBuilder,
 
                   composerBuilder: (context) {
+                    if (_isPeerBlocked) {
+                      return Positioned(
+                        left: 0,
+                        right: 0,
+                        bottom: 0,
+                        child: Container(
+                          padding: const EdgeInsets.symmetric(
+                            horizontal: 16,
+                            vertical: 14,
+                          ),
+                          decoration: BoxDecoration(
+                            color: Theme.of(context).colorScheme.surfaceContainerHighest,
+                            border: Border(
+                              top: BorderSide(
+                                color: Theme.of(context).dividerColor,
+                              ),
+                            ),
+                          ),
+                          child: Text(
+                            'Unblock to send messages',
+                            textAlign: TextAlign.center,
+                            style: TextStyle(color: Theme.of(context).hintColor),
+                          ),
+                        ),
+                      );
+                    }
                     return PrysmChatComposerOverlay(
                       draftKey: _draftKey,
                       replyPreview: _replyToMessage != null || _replyDraft != null

--- a/lib/screens/chat_profile_screen.dart
+++ b/lib/screens/chat_profile_screen.dart
@@ -2,11 +2,13 @@ import 'dart:convert';
 import 'package:bs58/bs58.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
+import 'package:prysm/services/block_service.dart';
 import 'package:prysm/services/notification_mute_service.dart';
 import '../models/contact.dart';
 import '../util/db_helper.dart';
 import '../util/key_manager.dart';
 import 'chat_media_gallery_screen.dart';
+import 'widgets/block_user_tile.dart';
 import 'widgets/contact_avatar.dart';
 import 'widgets/conversation_prefs_tiles.dart';
 import 'widgets/notification_mute_tile.dart';
@@ -21,6 +23,8 @@ class ChatProfileScreen extends StatefulWidget {
   final Function() onDeleteContact;
   final VoidCallback onPreferencesChanged;
   final VoidCallback? onArchived;
+  final VoidCallback? onBlocked;
+  final VoidCallback? onUnblocked;
   final String userId;
   final KeyManager keyManager;
 
@@ -34,6 +38,8 @@ class ChatProfileScreen extends StatefulWidget {
     required this.onDeleteContact,
     required this.onPreferencesChanged,
     this.onArchived,
+    this.onBlocked,
+    this.onUnblocked,
     required this.userId,
     required this.keyManager,
     super.key,
@@ -45,6 +51,8 @@ class ChatProfileScreen extends StatefulWidget {
 
 class _ChatProfileScreenState extends State<ChatProfileScreen> {
   late TextEditingController _nameController;
+
+  bool get _isBlocked => BlockService.instance.isBlocked(widget.peer.id);
 
   @override
   void initState() {
@@ -164,11 +172,12 @@ class _ChatProfileScreenState extends State<ChatProfileScreen> {
           onPressed: widget.onClose,
         ),
         actions: [
-          IconButton(
-            icon: const Icon(Icons.save_outlined),
-            onPressed: _saveName,
-            tooltip: 'Save',
-          ),
+          if (!_isBlocked)
+            IconButton(
+              icon: const Icon(Icons.save_outlined),
+              onPressed: _saveName,
+              tooltip: 'Save',
+            ),
         ],
         elevation: 2,
         shadowColor: Colors.black.withValues(alpha: 0.1),
@@ -194,72 +203,100 @@ class _ChatProfileScreenState extends State<ChatProfileScreen> {
                 ),
                 child: Column(
                   children: [
-                    Stack(
-                      children: [
-                        ContactAvatar(
-                          name: widget.peer.displayName,
-                          radius: 50,
-                          avatarBase64: widget.peer.avatarBase64,
-                        ),
-                      ],
+                    ContactAvatar(
+                      name: widget.peer.displayName,
+                      radius: 50,
+                      avatarBase64: widget.peer.avatarBase64,
                     ),
                     const SizedBox(height: 20),
-                    TextField(
-                      controller: _nameController,
-                      decoration: const InputDecoration(
-                        labelText: 'Display Name',
-                        border: OutlineInputBorder(),
-                      ),
-                      textAlign: TextAlign.center,
-                      style: const TextStyle(
-                        fontSize: 24,
-                        fontWeight: FontWeight.bold,
-                      ),
-                    ),
-                    const SizedBox(height: 8),
-                    if (widget.isOnline == null)
+                    if (_isBlocked) ...[
                       Text(
-                        'Checking...',
-                        style: TextStyle(
-                          fontSize: 16,
-                          fontWeight: FontWeight.w500,
-                          color: Theme.of(context).hintColor,
+                        widget.peer.displayName,
+                        textAlign: TextAlign.center,
+                        style: const TextStyle(
+                          fontSize: 24,
+                          fontWeight: FontWeight.bold,
                         ),
-                      )
-                    else
+                      ),
+                      const SizedBox(height: 8),
                       Row(
                         mainAxisAlignment: MainAxisAlignment.center,
                         children: [
-                          Container(
-                            width: 10,
-                            height: 10,
-                            decoration: BoxDecoration(
-                              shape: BoxShape.circle,
-                              color: widget.isOnline!
-                                  ? Colors.green
-                                  : Theme.of(context)
-                                      .colorScheme
-                                      .onSurface
-                                      .withAlpha(100),
-                            ),
+                          Icon(
+                            Icons.block,
+                            size: 16,
+                            color: Theme.of(context).hintColor,
                           ),
-                          const SizedBox(width: 8),
+                          const SizedBox(width: 6),
                           Text(
-                            widget.isOnline! ? 'Online' : 'Offline',
+                            'Blocked',
                             style: TextStyle(
                               fontSize: 16,
                               fontWeight: FontWeight.w500,
-                              color: widget.isOnline!
-                                  ? Colors.green
-                                  : Theme.of(context).hintColor,
+                              color: Theme.of(context).hintColor,
                             ),
                           ),
                         ],
                       ),
+                    ] else ...[
+                      TextField(
+                        controller: _nameController,
+                        decoration: const InputDecoration(
+                          labelText: 'Display Name',
+                          border: OutlineInputBorder(),
+                        ),
+                        textAlign: TextAlign.center,
+                        style: const TextStyle(
+                          fontSize: 24,
+                          fontWeight: FontWeight.bold,
+                        ),
+                      ),
+                      const SizedBox(height: 8),
+                      if (widget.isOnline == null)
+                        Text(
+                          'Checking...',
+                          style: TextStyle(
+                            fontSize: 16,
+                            fontWeight: FontWeight.w500,
+                            color: Theme.of(context).hintColor,
+                          ),
+                        )
+                      else
+                        Row(
+                          mainAxisAlignment: MainAxisAlignment.center,
+                          children: [
+                            Container(
+                              width: 10,
+                              height: 10,
+                              decoration: BoxDecoration(
+                                shape: BoxShape.circle,
+                                color: widget.isOnline!
+                                    ? Colors.green
+                                    : Theme.of(context)
+                                        .colorScheme
+                                        .onSurface
+                                        .withAlpha(100),
+                              ),
+                            ),
+                            const SizedBox(width: 8),
+                            Text(
+                              widget.isOnline! ? 'Online' : 'Offline',
+                              style: TextStyle(
+                                fontSize: 16,
+                                fontWeight: FontWeight.w500,
+                                color: widget.isOnline!
+                                    ? Colors.green
+                                    : Theme.of(context).hintColor,
+                              ),
+                            ),
+                          ],
+                        ),
+                    ],
                   ],
                 ),
               ),
               const SizedBox(height: 20),
+              if (!_isBlocked) ...[
               // Profile details
               Container(
                 decoration: BoxDecoration(
@@ -368,6 +405,32 @@ class _ChatProfileScreenState extends State<ChatProfileScreen> {
                   target: MuteTarget.user,
                   id: widget.peer.id,
                   label: widget.peer.displayName,
+                ),
+              ),
+              const SizedBox(height: 20),
+              ],
+              Container(
+                decoration: BoxDecoration(
+                  color: Theme.of(context).cardColor,
+                  borderRadius: BorderRadius.circular(20),
+                  boxShadow: [
+                    BoxShadow(
+                      color: Colors.black.withValues(alpha: 0.05),
+                      blurRadius: 10,
+                      offset: const Offset(0, 4),
+                    ),
+                  ],
+                ),
+                child: BlockUserTile(
+                  peerId: widget.peer.id,
+                  onBlocked: () {
+                    widget.onBlocked?.call();
+                    setState(() {});
+                  },
+                  onUnblocked: () {
+                    widget.onUnblocked?.call();
+                    setState(() {});
+                  },
                 ),
               ),
               const SizedBox(height: 20),

--- a/lib/screens/settings_screen.dart
+++ b/lib/screens/settings_screen.dart
@@ -20,6 +20,7 @@ import 'package:prysm/models/unlock_type.dart';
 import 'package:prysm/services/biometric_unlock_service.dart';
 import 'package:prysm/screens/widgets/change_passcode_flow.dart';
 import 'privacy_settings_screen.dart';
+import 'blocked_contacts_screen.dart';
 import 'package:flutter/foundation.dart';
 
 class SettingsScreen extends StatefulWidget {
@@ -711,6 +712,21 @@ class _SettingsScreenState extends State<SettingsScreen> {
                     const Divider(height: 1),
                   ],
                 ],
+                _buildNavigationTile(
+                  'Blocked contacts',
+                  Icons.block_outlined,
+                  () {
+                    Navigator.push(
+                      context,
+                      MaterialPageRoute(
+                        builder: (context) => BlockedContactsScreen(
+                          onClose: () => Navigator.of(context).pop(),
+                        ),
+                      ),
+                    );
+                  },
+                ),
+                const Divider(height: 1),
                 _buildNavigationTile(
                   'Advanced Privacy',
                   Icons.privacy_tip_outlined,

--- a/lib/screens/widgets/block_user_tile.dart
+++ b/lib/screens/widgets/block_user_tile.dart
@@ -1,0 +1,98 @@
+import 'package:flutter/material.dart';
+import 'package:prysm/services/block_service.dart';
+
+class BlockUserTile extends StatefulWidget {
+  final String peerId;
+  final VoidCallback? onBlocked;
+  final VoidCallback? onUnblocked;
+
+  const BlockUserTile({
+    required this.peerId,
+    this.onBlocked,
+    this.onUnblocked,
+    super.key,
+  });
+
+  @override
+  State<BlockUserTile> createState() => _BlockUserTileState();
+}
+
+class _BlockUserTileState extends State<BlockUserTile> {
+  void _refresh() => setState(() {});
+
+  Future<void> _confirmBlock() async {
+    final confirmed = await showDialog<bool>(
+      context: context,
+      builder: (context) => AlertDialog(
+        title: const Text('Block contact'),
+        content: const Text(
+          'You will no longer receive messages, calls, or profile updates from this contact.',
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.of(context).pop(false),
+            child: const Text('Cancel'),
+          ),
+          TextButton(
+            onPressed: () => Navigator.of(context).pop(true),
+            child: const Text('Block', style: TextStyle(color: Colors.red)),
+          ),
+        ],
+      ),
+    );
+    if (confirmed != true || !mounted) return;
+
+    await BlockService.instance.block(widget.peerId);
+    widget.onBlocked?.call();
+    _refresh();
+  }
+
+  Future<void> _confirmUnblock() async {
+    final confirmed = await showDialog<bool>(
+      context: context,
+      builder: (context) => AlertDialog(
+        title: const Text('Unblock contact'),
+        content: const Text(
+          'This contact will be able to message and call you again.',
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.of(context).pop(false),
+            child: const Text('Cancel'),
+          ),
+          TextButton(
+            onPressed: () => Navigator.of(context).pop(true),
+            child: const Text('Unblock'),
+          ),
+        ],
+      ),
+    );
+    if (confirmed != true || !mounted) return;
+
+    await BlockService.instance.unblock(widget.peerId);
+    widget.onUnblocked?.call();
+    _refresh();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final blocked = BlockService.instance.isBlocked(widget.peerId);
+
+    return ListTile(
+      leading: Icon(
+        blocked ? Icons.block : Icons.block_outlined,
+        color: blocked ? Colors.red : null,
+      ),
+      title: Text(
+        blocked ? 'Unblock contact' : 'Block contact',
+        style: TextStyle(color: blocked ? Colors.red : null),
+      ),
+      subtitle: Text(
+        blocked
+            ? 'Tap to allow messages and calls again'
+            : 'Stop messages, calls, and profile updates',
+      ),
+      onTap: blocked ? _confirmUnblock : _confirmBlock,
+    );
+  }
+}

--- a/lib/server/PrysmServer.dart
+++ b/lib/server/PrysmServer.dart
@@ -11,7 +11,9 @@ import 'package:prysm/transport/ws_frame_router.dart';
 import 'package:prysm/util/db_helper.dart';
 import 'package:prysm/util/key_manager.dart';
 import 'package:prysm/util/peer_profile_cache.dart';
+import 'package:prysm/util/profile_http_uri.dart';
 import 'package:prysm/util/tor_delivery.dart';
+import 'package:prysm/services/block_service.dart';
 import 'package:prysm/services/settings_service.dart';
 import 'package:shelf/shelf.dart';
 import 'package:shelf/shelf_io.dart' as io;
@@ -86,7 +88,12 @@ class PrysmServer {
       }
 
       if (request.method == 'GET' && request.url.path == 'profile') {
-        return _toResponse(await _router.buildProfile());
+        return _toResponse(
+          await _router.buildProfile(
+            requesterOnion: request.url.queryParameters['requester'],
+            requireRequester: true,
+          ),
+        );
       }
 
       if (request.method == 'POST' && request.url.path == 'sync-hint') {
@@ -189,6 +196,7 @@ class PrysmServer {
   }
 
   void _fetchSenderProfile(String senderId) {
+    if (BlockService.instance.isBlocked(senderId)) return;
     if (!PeerProfileCache.instance.shouldFetch(senderId)) return;
 
     Zone.current.fork(
@@ -211,7 +219,11 @@ class PrysmServer {
                     proxyPort: 9050,
                   );
                   try {
-                    final uri = Uri.parse('http://$senderId:80/profile');
+                    final requester = localOnionAddress;
+                    final uri = ProfileHttpUri.build(
+                      senderId,
+                      requesterOnion: requester,
+                    );
                     final response = await torClient
                         .get(uri, {})
                         .timeout(const Duration(seconds: 20));

--- a/lib/server/inbound_message_router.dart
+++ b/lib/server/inbound_message_router.dart
@@ -3,6 +3,7 @@ import 'dart:async';
 import 'package:flutter/material.dart';
 import 'package:prysm/constants/group_constants.dart';
 import 'package:prysm/database/messages.dart';
+import 'package:prysm/services/block_service.dart';
 import 'package:prysm/services/group_service.dart';
 import 'package:prysm/services/message_modify_service.dart';
 import 'package:prysm/services/notification_mute_service.dart';
@@ -72,7 +73,22 @@ class InboundMessageRouter {
     );
   }
 
-  Future<InboundHandleResult> buildProfile() async {
+  Future<InboundHandleResult> buildProfile({
+    String? requesterOnion,
+    bool requireRequester = false,
+  }) async {
+    if (_shouldRedactProfileForRequester(
+      requesterOnion,
+      requireRequester: requireRequester,
+    )) {
+      return InboundHandleResult.ok({
+        'identityJson': '',
+        'publicKeyPem': '',
+        'username': '',
+        'avatar': '',
+      });
+    }
+
     final broadcastName = settings.username;
     final username =
         (broadcastName != null &&
@@ -113,6 +129,10 @@ class InboundMessageRouter {
     }
 
     final senderId = data['senderId'] as String;
+    if (BlockService.instance.isBlocked(senderId)) {
+      return InboundHandleResult.forbidden('Unknown sender');
+    }
+
     final contact = await DBHelper.getUserById(senderId);
     if (contact == null) {
       return InboundHandleResult.forbidden('Unknown sender');
@@ -200,6 +220,10 @@ class InboundMessageRouter {
   /// Async processing after [validateMessage] returns null.
   Future<InboundHandleResult> processMessage(Map<String, dynamic> data) async {
     print('InboundMessageRouter: Received ${data['type']} from ${data['senderId']}');
+
+    if (_isBlockedDm(data)) {
+      return InboundHandleResult.ok({'status': 'received', 'id': data['id']});
+    }
 
     final type = data['type'] as String;
 
@@ -494,5 +518,26 @@ class InboundMessageRouter {
 
   bool _hasValidFileMetadata(dynamic data) {
     return data['fileName'] is String && data['fileSize'] is int;
+  }
+
+  bool _isBlockedDm(Map<String, dynamic> data) {
+    if (data['groupId'] != null) return false;
+    return BlockService.instance.isBlocked(data['senderId'] as String);
+  }
+
+  bool _shouldRedactProfileForRequester(
+    String? requesterOnion, {
+    bool requireRequester = false,
+  }) {
+    if (requireRequester &&
+        (requesterOnion == null || requesterOnion.isEmpty)) {
+      return true;
+    }
+    if (requesterOnion != null &&
+        requesterOnion.isNotEmpty &&
+        BlockService.instance.isBlocked(requesterOnion)) {
+      return true;
+    }
+    return false;
   }
 }

--- a/lib/services/block_service.dart
+++ b/lib/services/block_service.dart
@@ -1,0 +1,42 @@
+import 'package:prysm/database/blocked_users_db.dart';
+import 'package:prysm/services/call/call_manager.dart';
+
+class BlockService {
+  BlockService._();
+  static final BlockService instance = BlockService._();
+
+  final Set<String> _blockedIds = {};
+  final Map<String, int> _blockedAt = {};
+
+  Future<void> init() async {
+    _blockedIds.clear();
+    _blockedAt.clear();
+    final all = await BlockedUsersDb.getAll();
+    for (final user in all) {
+      _blockedIds.add(user.userId);
+      _blockedAt[user.userId] = user.blockedAt;
+    }
+  }
+
+  bool isBlocked(String userId) => _blockedIds.contains(userId);
+
+  Set<String> get blockedIds => Set.unmodifiable(_blockedIds);
+
+  int? blockedAt(String userId) => _blockedAt[userId];
+
+  Future<void> block(String userId) async {
+    if (_blockedIds.contains(userId)) return;
+    final now = DateTime.now().millisecondsSinceEpoch;
+    await BlockedUsersDb.block(userId, now);
+    _blockedIds.add(userId);
+    _blockedAt[userId] = now;
+    await CallManager.endCallWithPeer(userId, reason: 'declined');
+  }
+
+  Future<void> unblock(String userId) async {
+    if (!_blockedIds.contains(userId)) return;
+    await BlockedUsersDb.unblock(userId);
+    _blockedIds.remove(userId);
+    _blockedAt.remove(userId);
+  }
+}

--- a/lib/services/call/call_manager.dart
+++ b/lib/services/call/call_manager.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 import 'dart:math';
 
 import 'package:flutter/foundation.dart';
+import 'package:prysm/services/block_service.dart';
 import 'package:prysm/services/call/audio_engine.dart';
 import 'package:prysm/services/call/call_session.dart';
 import 'package:prysm/services/call/opus_codec.dart';
@@ -98,6 +99,24 @@ class CallManager extends ChangeNotifier {
     CallForegroundSession.resetState();
   }
 
+  /// Ends an active call with [peerOnion] if one is in progress.
+  static Future<void> endCallWithPeer(
+    String peerOnion, {
+    String reason = 'declined',
+  }) async {
+    final mgr = _instance;
+    if (mgr == null || mgr._shuttingDown) return;
+    if (!mgr._snapshot.isInCall || mgr._snapshot.peerOnion != peerOnion) {
+      return;
+    }
+    final callId = mgr._snapshot.callId;
+    if (callId != null) {
+      await mgr._sendEnd(peerOnion, callId, reason: reason);
+    }
+    await mgr._teardown();
+    mgr._setSnapshot(const CallSnapshot(state: CallState.idle));
+  }
+
   final KeyManager _keyManager;
   CallTransport? _transport;
   CallKeyResolver? _keyResolver;
@@ -141,6 +160,7 @@ class CallManager extends ChangeNotifier {
 
   Future<void> startCall(String peerOnion) async {
     if (_shuttingDown || _snapshot.isInCall) return;
+    if (BlockService.instance.isBlocked(peerOnion)) return;
 
     _setSnapshot(
       CallSnapshot(
@@ -338,6 +358,14 @@ class CallManager extends ChangeNotifier {
   }
 
   Future<void> _handleOffer(CallSignalEvent event) async {
+    if (BlockService.instance.isBlocked(event.peerOnion)) {
+      final callId = event.callId;
+      if (callId != null) {
+        await _sendEnd(event.peerOnion, callId, reason: 'declined');
+      }
+      return;
+    }
+
     if (_snapshot.isInCall) {
       final callId = event.callId;
       if (callId != null) {

--- a/lib/services/chat_service.dart
+++ b/lib/services/chat_service.dart
@@ -7,6 +7,7 @@ import 'package:prysm/constants/group_constants.dart';
 import 'package:prysm/crypto/crypto.dart';
 import 'package:prysm/database/messages.dart';
 import 'package:prysm/transport/transport_provider.dart';
+import 'package:prysm/services/block_service.dart';
 import 'package:prysm/util/battery_saver_policy.dart';
 import 'package:prysm/util/db_helper.dart';
 import 'package:prysm/util/inbound_message_notifier.dart';
@@ -169,6 +170,7 @@ class ChatService {
     String? replyToId,
     String? messageId,
   }) async {
+    if (BlockService.instance.isBlocked(peerId)) return null;
     if (peerIdentity == null) return null;
 
     final timestamp = DateTime.now().millisecondsSinceEpoch;
@@ -227,6 +229,7 @@ class ChatService {
     String? messageId,
     bool viewOnce = false,
   }) async {
+    if (BlockService.instance.isBlocked(peerId)) return null;
     if (peerIdentity == null) return null;
 
     final payload = await _encryptFilePayload(bytes);
@@ -363,6 +366,7 @@ class ChatService {
 
   Future<void> _processSendQueue() async {
     if (_isSending || _disposed || TorRuntimeGate.blocked) return;
+    if (BlockService.instance.isBlocked(peerId)) return;
     _isSending = true;
 
     int consecutiveFailures = 0;
@@ -455,6 +459,7 @@ class ChatService {
     int? fileSize,
     bool viewOnce = false,
   }) async {
+    if (BlockService.instance.isBlocked(peerId)) return false;
     if (TorRuntimeGate.blocked) return false;
 
     final isLargeMedia = type == 'file' || type == 'image' || type == 'audio';

--- a/lib/services/contact_add_service.dart
+++ b/lib/services/contact_add_service.dart
@@ -4,6 +4,7 @@ import 'dart:convert';
 import 'package:prysm/crypto/crypto.dart';
 import 'package:prysm/models/contact.dart';
 import 'package:prysm/transport/transport_provider.dart';
+import 'package:prysm/services/block_service.dart';
 import 'package:prysm/util/db_helper.dart';
 
 class ContactAddService {
@@ -15,6 +16,10 @@ class ContactAddService {
     required String displayName,
     String? expectedFingerprint,
   }) async {
+    if (BlockService.instance.isBlocked(onionId)) {
+      print('Cannot add blocked contact $onionId');
+      return false;
+    }
     String? identityJson;
     String? avatarBase64;
     String fetchedName = displayName;

--- a/lib/services/ws_inbound_dispatcher.dart
+++ b/lib/services/ws_inbound_dispatcher.dart
@@ -3,6 +3,7 @@ import 'dart:async';
 import 'package:flutter/foundation.dart';
 import 'package:prysm/server/inbound_message_router.dart';
 import 'package:prysm/server/PrysmServer.dart';
+import 'package:prysm/services/block_service.dart';
 import 'package:prysm/services/call/call_signaling_notifier.dart';
 import 'package:prysm/util/typing_indicator_notifier.dart';
 import 'package:prysm/transport/ws_protocol.dart';
@@ -59,6 +60,7 @@ class WsInboundDispatcher {
     if (op is! String) return;
 
     if (WsFrame.isCallOp(op)) {
+      if (BlockService.instance.isBlocked(peerOnion)) return;
       final payload = frame['payload'];
       if (payload is Map<String, dynamic>) {
         CallSignalingNotifier.active.applyInbound(peerOnion, op, payload);
@@ -67,6 +69,7 @@ class WsInboundDispatcher {
     }
 
     if (WsFrame.isTypingOp(op)) {
+      if (BlockService.instance.isBlocked(peerOnion)) return;
       final payload = frame['payload'];
       if (payload is Map<String, dynamic>) {
         TypingIndicatorNotifier.instance.applyInbound(payload);

--- a/lib/transport/tor_http_transport.dart
+++ b/lib/transport/tor_http_transport.dart
@@ -4,6 +4,8 @@ import 'dart:convert';
 import 'package:flutter/foundation.dart';
 import 'package:prysm/client/TorHttpClient.dart';
 import 'package:prysm/transport/outbound_transport.dart';
+import 'package:prysm/util/local_onion_address.dart';
+import 'package:prysm/util/profile_http_uri.dart';
 import 'package:prysm/util/tor_delivery.dart';
 import 'package:prysm/util/tor_runtime_gate.dart';
 import 'package:prysm/util/tor_service.dart';
@@ -63,9 +65,12 @@ class TorHttpTransport implements OutboundTransport {
     return runForPeer(peerOnion, () async {
       final client = _client();
       try {
-        final response = await client
-            .get(Uri.parse('http://$peerOnion:80/profile'), {})
-            .timeout(timeout);
+        final requester = LocalOnionAddress.value;
+        final uri = ProfileHttpUri.build(
+          peerOnion,
+          requesterOnion: requester,
+        );
+        final response = await client.get(uri, {}).timeout(timeout);
         return client.readUtf8Body(response);
       } finally {
         await client.close();

--- a/lib/transport/transport_provider.dart
+++ b/lib/transport/transport_provider.dart
@@ -9,6 +9,8 @@ import 'package:prysm/transport/peer_transport_registry.dart';
 import 'package:prysm/transport/tor_http_transport.dart';
 import 'package:prysm/transport/tor_websocket_transport.dart';
 import 'package:prysm/transport/transport_preference.dart';
+import 'package:prysm/util/local_onion_address.dart';
+import 'package:prysm/util/profile_http_uri.dart';
 import 'package:prysm/util/tor_delivery.dart';
 import 'package:prysm/util/tor_service.dart';
 
@@ -267,7 +269,11 @@ class TransportProvider implements OutboundTransport {
           proxyPort: socksPort,
         );
         try {
-          final uri = Uri.parse('http://$peerOnion:80/profile');
+          final requester = LocalOnionAddress.value;
+          final uri = ProfileHttpUri.build(
+            peerOnion,
+            requesterOnion: requester,
+          );
           final response = await torClient.get(uri, {}).timeout(timeout);
           return torClient.readUtf8Body(response);
         } finally {

--- a/lib/transport/ws_frame_router.dart
+++ b/lib/transport/ws_frame_router.dart
@@ -3,6 +3,7 @@ import 'dart:async';
 import 'package:flutter/foundation.dart';
 import 'package:prysm/server/inbound_message_router.dart';
 import 'package:prysm/server/PrysmServer.dart';
+import 'package:prysm/services/block_service.dart';
 import 'package:prysm/services/call/call_signaling_notifier.dart';
 import 'package:prysm/transport/ws_protocol.dart';
 import 'package:prysm/util/typing_indicator_notifier.dart';
@@ -27,6 +28,11 @@ class WsFrameRouter {
     }
 
     if (WsFrame.isCallOp(frame.op)) {
+      if (peerOnion != null &&
+          peerOnion.isNotEmpty &&
+          BlockService.instance.isBlocked(peerOnion)) {
+        return [];
+      }
       final payload = frame.payload;
       if (payload != null &&
           peerOnion != null &&
@@ -43,7 +49,7 @@ class WsFrameRouter {
     if (frame.op == 'get_profile') {
       final router = _router;
       if (router == null) return [];
-      final result = await router.buildProfile();
+      final result = await router.buildProfile(requesterOnion: peerOnion);
       return [
         WsFrame.response(
           op: 'profile',
@@ -71,6 +77,11 @@ class WsFrameRouter {
     }
 
     if (frame.op == 'typing_update') {
+      if (peerOnion != null &&
+          peerOnion.isNotEmpty &&
+          BlockService.instance.isBlocked(peerOnion)) {
+        return [];
+      }
       final payload = frame.payload;
       if (payload != null) {
         TypingIndicatorNotifier.instance.applyInbound(payload);

--- a/lib/util/db_helper.dart
+++ b/lib/util/db_helper.dart
@@ -1,5 +1,6 @@
 
 import 'package:prysm/crypto/ratchet/session_store.dart';
+import 'package:prysm/database/blocked_users_db.dart';
 import 'package:prysm/database/conversation_preferences_db.dart';
 import 'package:prysm/util/group_sender_index_store.dart';
 import 'package:prysm/util/sqflite_platform.dart';
@@ -36,7 +37,7 @@ class DBHelper {
   static Future<Database> _initDB() async {
     final docDir = await getApplicationDocumentsDirectory();
     final path = join(docDir.path, 'prysm', 'chat_app.db');
-    return await openDatabase(path, version: 7, onCreate: _createDB, onUpgrade: _onUpgrade);
+    return await openDatabase(path, version: 8, onCreate: _createDB, onUpgrade: _onUpgrade);
   }
 
   static Future _createDB(Database db, int version) async {
@@ -54,6 +55,7 @@ class DBHelper {
     await db.execute('CREATE INDEX idx_users_name ON users(name)');
     await _createGroupTables(db);
     await ConversationPreferencesDb.createTable(db);
+    await BlockedUsersDb.createTable(db);
     await _createCryptoTables(db);
   }
 
@@ -122,6 +124,9 @@ class DBHelper {
     }
     if (oldVersion < 7) {
       await _createCryptoTables(db);
+    }
+    if (oldVersion < 8) {
+      await BlockedUsersDb.createTable(db);
     }
   }
 

--- a/lib/util/local_onion_address.dart
+++ b/lib/util/local_onion_address.dart
@@ -1,0 +1,8 @@
+/// Local hidden-service onion, set after Tor bootstrap.
+class LocalOnionAddress {
+  LocalOnionAddress._();
+
+  static String? Function()? provider;
+
+  static String? get value => provider?.call();
+}

--- a/lib/util/profile_http_uri.dart
+++ b/lib/util/profile_http_uri.dart
@@ -1,0 +1,18 @@
+/// Builds Tor hidden-service profile URLs with optional requester identity.
+class ProfileHttpUri {
+  ProfileHttpUri._();
+
+  static Uri build(String peerOnion, {String? requesterOnion}) {
+    final query = <String, String>{};
+    if (requesterOnion != null && requesterOnion.isNotEmpty) {
+      query['requester'] = requesterOnion;
+    }
+    return Uri(
+      scheme: 'http',
+      host: peerOnion,
+      port: 80,
+      path: '/profile',
+      queryParameters: query.isEmpty ? null : query,
+    );
+  }
+}

--- a/test/block_service_test.dart
+++ b/test/block_service_test.dart
@@ -1,0 +1,55 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:prysm/database/blocked_users_db.dart';
+import 'package:prysm/services/block_service.dart';
+import 'package:prysm/util/db_helper.dart';
+import 'package:sqflite_common_ffi/sqflite_ffi.dart';
+
+void main() {
+  setUpAll(() {
+    sqfliteFfiInit();
+    databaseFactory = databaseFactoryFfi;
+  });
+
+  setUp(() async {
+    final db = await databaseFactory.openDatabase(
+      '${inMemoryDatabasePath}_${DateTime.now().microsecondsSinceEpoch}',
+      options: OpenDatabaseOptions(
+        version: 1,
+        onCreate: (db, _) async {
+          await BlockedUsersDb.createTable(db);
+        },
+      ),
+    );
+    DBHelper.setDatabaseForTest(db);
+    await BlockService.instance.init();
+  });
+
+  tearDown(() {
+    DBHelper.setDatabaseForTest(null);
+  });
+
+  test('block and unblock update cache and database', () async {
+    expect(BlockService.instance.isBlocked('peer.onion'), isFalse);
+
+    await BlockService.instance.block('peer.onion');
+    expect(BlockService.instance.isBlocked('peer.onion'), isTrue);
+    expect(BlockService.instance.blockedIds, contains('peer.onion'));
+    expect(BlockService.instance.blockedAt('peer.onion'), isNotNull);
+
+    expect(await BlockedUsersDb.isBlocked('peer.onion'), isTrue);
+
+    await BlockService.instance.unblock('peer.onion');
+    expect(BlockService.instance.isBlocked('peer.onion'), isFalse);
+    expect(await BlockedUsersDb.isBlocked('peer.onion'), isFalse);
+  });
+
+  test('init reloads blocked users from database', () async {
+    await BlockedUsersDb.block('a.onion', 100);
+    await BlockedUsersDb.block('b.onion', 200);
+
+    await BlockService.instance.init();
+
+    expect(BlockService.instance.blockedIds, containsAll(['a.onion', 'b.onion']));
+    expect(BlockService.instance.blockedAt('b.onion'), 200);
+  });
+}

--- a/test/call_manager_test.dart
+++ b/test/call_manager_test.dart
@@ -4,6 +4,8 @@ import 'dart:typed_data';
 import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:prysm/crypto/identity.dart';
+import 'package:prysm/database/blocked_users_db.dart';
+import 'package:prysm/services/block_service.dart';
 import 'package:prysm/services/call/audio_engine.dart';
 import 'package:prysm/services/call/call_foreground_session.dart';
 import 'package:prysm/services/call/call_manager.dart';
@@ -11,6 +13,8 @@ import 'package:prysm/services/call/call_session.dart';
 import 'package:prysm/services/call/call_signaling_notifier.dart';
 import 'package:prysm/services/call/call_transport.dart';
 import 'package:prysm/util/key_manager.dart';
+import 'package:prysm/util/db_helper.dart';
+import 'package:sqflite_common_ffi/sqflite_ffi.dart';
 
 // Manual verification (not automated):
 // 1. Android active call: start call, press Home, verify bidirectional audio ~60s.
@@ -30,7 +34,24 @@ void main() {
   late IdentityPublicKeys peerKeys;
   late IdentityPublicKeys localKeys;
 
+  setUpAll(() {
+    sqfliteFfiInit();
+    databaseFactory = databaseFactoryFfi;
+  });
+
   setUp(() async {
+    final db = await databaseFactory.openDatabase(
+      '${inMemoryDatabasePath}_call_manager_${DateTime.now().microsecondsSinceEpoch}',
+      options: OpenDatabaseOptions(
+        version: 1,
+        onCreate: (db, _) async {
+          await BlockedUsersDb.createTable(db);
+        },
+      ),
+    );
+    DBHelper.setDatabaseForTest(db);
+    await BlockService.instance.init();
+
     final local = await IdentityKeyPair.generate();
     final peer = await IdentityKeyPair.generate();
     keyManager = KeyManager.fromIdentity(local);
@@ -65,6 +86,7 @@ void main() {
   tearDown(() {
     CallSignalingNotifier.testInstance = null;
     CallManager.resetForTest();
+    DBHelper.setDatabaseForTest(null);
   });
 
   test('answer received while offer send is pending activates call', () async {
@@ -240,6 +262,29 @@ void main() {
       transport.sentFrames.where((f) => f.op == 'call_end'),
       isNotEmpty,
     );
+  });
+
+  test('incoming offer from blocked peer is declined without ringing', () async {
+    await BlockService.instance.block('blocked.onion');
+
+    final caller = CallSession.createOutbound(
+      callId: 'blocked-offer',
+      sessionId: 3,
+      peerOnion: 'local.onion',
+    );
+    notifier.applyInbound('blocked.onion', 'call_offer', {
+      'callId': caller.callId,
+      'sessionId': caller.sessionId,
+      'wrappedKey': await caller.wrapKeyForPeer(
+        localKeys,
+        keyManager,
+      ),
+    });
+
+    await Future<void>.delayed(Duration.zero);
+    expect(manager.snapshot.state, CallState.idle);
+    final endFrame = transport.sentFrames.firstWhere((f) => f.op == 'call_end');
+    expect(endFrame.payload['reason'], 'declined');
   });
 }
 

--- a/test/inbound_block_test.dart
+++ b/test/inbound_block_test.dart
@@ -1,0 +1,92 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:prysm/database/blocked_users_db.dart';
+import 'package:prysm/server/inbound_message_router.dart';
+import 'package:prysm/services/block_service.dart';
+import 'package:prysm/services/settings_service.dart';
+import 'package:prysm/util/db_helper.dart';
+import 'package:prysm/util/key_manager.dart';
+import 'package:sqflite_common_ffi/sqflite_ffi.dart';
+
+void main() {
+  late InboundMessageRouter router;
+
+  setUpAll(() {
+    sqfliteFfiInit();
+    databaseFactory = databaseFactoryFfi;
+  });
+
+  setUp(() async {
+    final db = await databaseFactory.openDatabase(
+      '${inMemoryDatabasePath}_${DateTime.now().microsecondsSinceEpoch}',
+      options: OpenDatabaseOptions(
+        version: 1,
+        onCreate: (db, _) async {
+          await BlockedUsersDb.createTable(db);
+        },
+      ),
+    );
+    DBHelper.setDatabaseForTest(db);
+    await BlockService.instance.init();
+    await BlockService.instance.block('blocked.onion');
+
+    router = InboundMessageRouter(
+      keyManager: KeyManager(),
+      settings: SettingsService(),
+      localOnionAddress: () => 'local.onion',
+    );
+  });
+
+  tearDown(() {
+    DBHelper.setDatabaseForTest(null);
+  });
+
+  test('processMessage acks but drops DM from blocked sender', () async {
+    final result = await router.processMessage({
+      'id': 'msg-1',
+      'senderId': 'blocked.onion',
+      'receiverId': 'local.onion',
+      'message': 'cipher',
+      'type': 'text',
+      'timestamp': 1,
+    });
+
+    expect(result.statusCode, 200);
+    expect(result.jsonBody?['status'], 'received');
+    expect(result.jsonBody?['id'], 'msg-1');
+  });
+
+  test('buildProfile redacts info for blocked requester', () async {
+    final result = await router.buildProfile(requesterOnion: 'blocked.onion');
+
+    expect(result.statusCode, 200);
+    expect(result.jsonBody?['username'], '');
+    expect(result.jsonBody?['avatar'], '');
+    expect(result.jsonBody?['identityJson'], '');
+    expect(result.jsonBody?['publicKeyPem'], '');
+  });
+
+  test('buildProfile returns data for non-blocked requester', () async {
+    final result = await router.buildProfile(requesterOnion: 'friend.onion');
+
+    expect(result.statusCode, 200);
+    expect(result.jsonBody?.containsKey('username'), isTrue);
+  });
+
+  test('buildProfile redacts when HTTP requester is required but missing', () async {
+    final result = await router.buildProfile(requireRequester: true);
+
+    expect(result.statusCode, 200);
+    expect(result.jsonBody?['username'], '');
+    expect(result.jsonBody?['avatar'], '');
+  });
+
+  test('handleSyncHint rejects blocked sender', () async {
+    final result = await router.handleSyncHint({
+      'senderId': 'blocked.onion',
+      'receiverId': 'local.onion',
+      'timestamp': DateTime.now().millisecondsSinceEpoch,
+    });
+
+    expect(result.statusCode, 403);
+  });
+}

--- a/test/profile_http_uri_test.dart
+++ b/test/profile_http_uri_test.dart
@@ -1,0 +1,22 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:prysm/util/profile_http_uri.dart';
+
+void main() {
+  test('build includes requester query parameter when provided', () {
+    final uri = ProfileHttpUri.build(
+      'peer.onion',
+      requesterOnion: 'me.onion',
+    );
+
+    expect(uri.toString(), contains('peer.onion'));
+    expect(uri.path, '/profile');
+    expect(uri.queryParameters['requester'], 'me.onion');
+  });
+
+  test('build omits query when requester is absent', () {
+    final uri = ProfileHttpUri.build('peer.onion');
+
+    expect(uri.path, '/profile');
+    expect(uri.queryParameters, isEmpty);
+  });
+}


### PR DESCRIPTION
- Integrated BlockService to manage blocked users, preventing interactions with blocked contacts.
- Updated ChatScreen, ChatProfileScreen, and HomeScreen to reflect blocked status and restrict actions accordingly.
- Enhanced UI to provide feedback when viewing blocked contacts and added navigation to a blocked contacts screen in settings.
- Implemented database changes to support blocked users and updated relevant services to handle blocking logic.
- Added tests to ensure correct behavior of blocking functionality and interactions with blocked peers.