### PR TITLE
feat: implement file drop support and refactor attachment handling

### DIFF
--- a/lib/screens/chat.dart
+++ b/lib/screens/chat.dart
@@ -32,7 +32,8 @@ import 'package:prysm/screens/widgets/file_attachment_bubble.dart';
 import 'package:prysm/screens/widgets/linked_message_text.dart';
 import 'package:prysm/screens/widgets/voice_message_bubble.dart';
 import 'package:prysm/screens/widgets/image_message_bubble.dart';
-import 'package:prysm/screens/widgets/image_send_preview_screen.dart';
+import 'package:prysm/screens/widgets/prysm_chat_drop_target.dart';
+import 'package:prysm/util/chat_attachment_ingress.dart';
 import 'package:prysm/screens/widgets/quoted_reply_preview.dart';
 import 'package:prysm/screens/widgets/quoted_reply_preview_loader.dart';
 import 'package:prysm/util/reply_preview_label.dart';
@@ -74,7 +75,6 @@ import 'package:file_picker/file_picker.dart';
 import 'package:prysm/models/contact.dart';
 
 import 'package:uuid/uuid.dart';
-import 'package:flutter_image_compress/flutter_image_compress.dart';
 
 class ChatScreen extends StatefulWidget {
   final String userId;
@@ -1264,33 +1264,16 @@ class _ChatScreenState extends State<ChatScreen> {
     );
     if (pickedFile == null) return;
 
-    Uint8List bytes = await pickedFile.readAsBytes();
-
-    if (bytes.length > 500 * 1024) {
-      try {
-        final compressed = await FlutterImageCompress.compressWithList(
-          bytes,
-          minHeight: 1080,
-          minWidth: 1080,
-          quality: 70,
-        );
-        bytes = compressed;
-      } catch (e) {
-        print("Compression failed: $e");
-        if (mounted) {
-          ScaffoldMessenger.of(context).showSnackBar(
-            const SnackBar(content: Text('Image compression failed, sending original.')),
-          );
-        }
-      }
-    }
-
+    final bytes = await pickedFile.readAsBytes();
     if (!mounted) return;
 
-    final viewOnce = await ImageSendPreviewScreen.open(context, bytes);
-    if (viewOnce == null || !mounted) return;
-
-    _sendFile(bytes, pickedFile.name, "image", viewOnce: viewOnce);
+    await ChatAttachmentIngress.sendLocalAttachment(
+      context: context,
+      bytes: bytes,
+      fileName: pickedFile.name,
+      sendFile: _sendFile,
+      forceImageFlow: true,
+    );
   }
 
   Future<void> _handleSendFile() async {
@@ -1298,7 +1281,34 @@ class _ChatScreenState extends State<ChatScreen> {
     if (result == null || result.files.isEmpty) return;
 
     final file = result.files.first;
-    _sendFile(file.bytes!, file.name, "file");
+    if (file.bytes == null) return;
+    if (!mounted) return;
+
+    await ChatAttachmentIngress.sendLocalAttachment(
+      context: context,
+      bytes: file.bytes!,
+      fileName: file.name,
+      sendFile: _sendFile,
+    );
+  }
+
+  Future<void> _handleDroppedFile(String path, String name) async {
+    try {
+      final bytes = await File(path).readAsBytes();
+      if (!mounted) return;
+      await ChatAttachmentIngress.sendLocalAttachment(
+        context: context,
+        bytes: bytes,
+        fileName: name,
+        sendFile: _sendFile,
+      );
+    } catch (e) {
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(content: Text('Could not read dropped file: $e')),
+        );
+      }
+    }
   }
 
   void _handleSend(dynamic message) {
@@ -1876,7 +1886,10 @@ class _ChatScreenState extends State<ChatScreen> {
         shadowColor: Colors.black.withValues(alpha: 0.1),
       ),
       body: SafeArea(
-        child: JumpToBottomFabOverlay(
+        child: PrysmChatDropTarget(
+          enabled: !_isPeerBlocked,
+          onFileDropped: _handleDroppedFile,
+          child: JumpToBottomFabOverlay(
           visible: !_stickToBottom &&
               _messages.messages.isNotEmpty &&
               selectedMessageIds.isEmpty,
@@ -2122,6 +2135,7 @@ class _ChatScreenState extends State<ChatScreen> {
                     );
                   },
                 ),
+        ),
         ),
         ),
       ),

--- a/lib/screens/group_chat.dart
+++ b/lib/screens/group_chat.dart
@@ -8,7 +8,6 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_chat_core/flutter_chat_core.dart';
 import 'package:flutter_chat_ui/flutter_chat_ui.dart';
-import 'package:flutter_image_compress/flutter_image_compress.dart';
 import 'package:image_picker/image_picker.dart';
 import 'package:path_provider/path_provider.dart';
 import 'package:prysm/constants/group_constants.dart';
@@ -30,7 +29,8 @@ import 'package:prysm/screens/widgets/file_attachment_bubble.dart';
 import 'package:prysm/screens/widgets/linked_message_text.dart';
 import 'package:prysm/screens/widgets/voice_message_bubble.dart';
 import 'package:prysm/screens/widgets/image_message_bubble.dart';
-import 'package:prysm/screens/widgets/image_send_preview_screen.dart';
+import 'package:prysm/screens/widgets/prysm_chat_drop_target.dart';
+import 'package:prysm/util/chat_attachment_ingress.dart';
 import 'package:prysm/screens/widgets/quoted_reply_preview.dart';
 import 'package:prysm/screens/widgets/quoted_reply_preview_loader.dart';
 import 'package:prysm/util/reply_preview_label.dart';
@@ -1157,24 +1157,16 @@ class _GroupChatScreenState extends State<GroupChatScreen> {
     final pickedFile = await picker.pickImage(source: ImageSource.gallery);
     if (pickedFile == null) return;
 
-    var bytes = await pickedFile.readAsBytes();
-    if (bytes.length > 500 * 1024) {
-      try {
-        bytes = await FlutterImageCompress.compressWithList(
-          bytes,
-          minHeight: 1080,
-          minWidth: 1080,
-          quality: 70,
-        );
-      } catch (_) {}
-    }
-
+    final bytes = await pickedFile.readAsBytes();
     if (!mounted) return;
 
-    final viewOnce = await ImageSendPreviewScreen.open(context, bytes);
-    if (viewOnce == null || !mounted) return;
-
-    _sendFile(bytes, pickedFile.name, 'image', viewOnce: viewOnce);
+    await ChatAttachmentIngress.sendLocalAttachment(
+      context: context,
+      bytes: bytes,
+      fileName: pickedFile.name,
+      sendFile: _sendFile,
+      forceImageFlow: true,
+    );
   }
 
   Future<void> _handleSendFile() async {
@@ -1182,7 +1174,33 @@ class _GroupChatScreenState extends State<GroupChatScreen> {
     if (result == null || result.files.isEmpty) return;
     final file = result.files.first;
     if (file.bytes == null) return;
-    _sendFile(file.bytes!, file.name, 'file');
+    if (!mounted) return;
+
+    await ChatAttachmentIngress.sendLocalAttachment(
+      context: context,
+      bytes: file.bytes!,
+      fileName: file.name,
+      sendFile: _sendFile,
+    );
+  }
+
+  Future<void> _handleDroppedFile(String path, String name) async {
+    try {
+      final bytes = await File(path).readAsBytes();
+      if (!mounted) return;
+      await ChatAttachmentIngress.sendLocalAttachment(
+        context: context,
+        bytes: bytes,
+        fileName: name,
+        sendFile: _sendFile,
+      );
+    } catch (e) {
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(content: Text('Could not read dropped file: $e')),
+        );
+      }
+    }
   }
 
   Future<void> _handleSendVoice(Uint8List bytes, int durationMs) async {
@@ -1692,7 +1710,9 @@ class _GroupChatScreenState extends State<GroupChatScreen> {
         shadowColor: Colors.black.withValues(alpha: 0.1),
       ),
       body: SafeArea(
-        child: JumpToBottomFabOverlay(
+        child: PrysmChatDropTarget(
+          onFileDropped: _handleDroppedFile,
+          child: JumpToBottomFabOverlay(
           visible: !_stickToBottom &&
               _messages.messages.isNotEmpty &&
               selectedMessageIds.isEmpty,
@@ -1895,6 +1915,7 @@ class _GroupChatScreenState extends State<GroupChatScreen> {
               );
             },
           ),
+        ),
         ),
         ),
       ),

--- a/lib/screens/self_chat_screen.dart
+++ b/lib/screens/self_chat_screen.dart
@@ -6,7 +6,6 @@ import 'package:file_picker/file_picker.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_chat_core/flutter_chat_core.dart';
 import 'package:flutter_chat_ui/flutter_chat_ui.dart';
-import 'package:flutter_image_compress/flutter_image_compress.dart';
 import 'package:image_picker/image_picker.dart';
 import 'package:path_provider/path_provider.dart';
 import 'package:prysm/crypto/wire.dart';
@@ -15,14 +14,15 @@ import 'package:prysm/screens/widgets/contact_avatar.dart';
 import 'package:prysm/screens/widgets/deleted_message_bubble.dart';
 import 'package:prysm/screens/widgets/file_attachment_bubble.dart';
 import 'package:prysm/screens/widgets/image_message_bubble.dart';
-import 'package:prysm/screens/widgets/image_send_preview_screen.dart';
 import 'package:prysm/screens/widgets/linked_message_text.dart';
 import 'package:prysm/screens/widgets/jump_to_bottom_fab.dart';
 import 'package:prysm/screens/widgets/prysm_chat_composer_overlay.dart';
+import 'package:prysm/screens/widgets/prysm_chat_drop_target.dart';
 import 'package:prysm/screens/widgets/voice_message_bubble.dart';
 import 'package:prysm/services/file_attachment_resolver.dart';
 import 'package:prysm/services/image_attachment_cache.dart';
 import 'package:prysm/services/self_chat_service.dart';
+import 'package:prysm/util/chat_attachment_ingress.dart';
 import 'package:prysm/util/chat_scroll.dart';
 import 'package:prysm/util/key_manager.dart';
 import 'package:prysm/util/message_modify_policy.dart';
@@ -226,33 +226,16 @@ class _SelfChatScreenState extends State<SelfChatScreen> {
     );
     if (pickedFile == null) return;
 
-    var bytes = await pickedFile.readAsBytes();
-
-    if (bytes.length > 500 * 1024) {
-      try {
-        bytes = await FlutterImageCompress.compressWithList(
-          bytes,
-          minHeight: 1080,
-          minWidth: 1080,
-          quality: 70,
-        );
-      } catch (e) {
-        if (mounted) {
-          ScaffoldMessenger.of(context).showSnackBar(
-            const SnackBar(
-              content: Text('Image compression failed, sending original.'),
-            ),
-          );
-        }
-      }
-    }
-
+    final bytes = await pickedFile.readAsBytes();
     if (!mounted) return;
 
-    final viewOnce = await ImageSendPreviewScreen.open(context, bytes);
-    if (viewOnce == null || !mounted) return;
-
-    await _sendFile(bytes, pickedFile.name, 'image', viewOnce: viewOnce);
+    await ChatAttachmentIngress.sendLocalAttachment(
+      context: context,
+      bytes: bytes,
+      fileName: pickedFile.name,
+      sendFile: _sendFile,
+      forceImageFlow: true,
+    );
   }
 
   Future<void> _handleSendFile() async {
@@ -261,7 +244,33 @@ class _SelfChatScreenState extends State<SelfChatScreen> {
 
     final file = result.files.first;
     if (file.bytes == null) return;
-    await _sendFile(file.bytes!, file.name, 'file');
+    if (!mounted) return;
+
+    await ChatAttachmentIngress.sendLocalAttachment(
+      context: context,
+      bytes: file.bytes!,
+      fileName: file.name,
+      sendFile: _sendFile,
+    );
+  }
+
+  Future<void> _handleDroppedFile(String path, String name) async {
+    try {
+      final bytes = await File(path).readAsBytes();
+      if (!mounted) return;
+      await ChatAttachmentIngress.sendLocalAttachment(
+        context: context,
+        bytes: bytes,
+        fileName: name,
+        sendFile: _sendFile,
+      );
+    } catch (e) {
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(content: Text('Could not read dropped file: $e')),
+        );
+      }
+    }
   }
 
   Future<void> _handleSendVoice(Uint8List bytes, int durationMs) async {
@@ -596,7 +605,9 @@ class _SelfChatScreenState extends State<SelfChatScreen> {
         ),
       ),
       body: SafeArea(
-        child: JumpToBottomFabOverlay(
+        child: PrysmChatDropTarget(
+          onFileDropped: _handleDroppedFile,
+          child: JumpToBottomFabOverlay(
           visible: !_stickToBottom && _messages.messages.isNotEmpty,
           onPressed: _jumpToBottom,
           child: Chat(
@@ -690,6 +701,7 @@ class _SelfChatScreenState extends State<SelfChatScreen> {
               );
             },
           ),
+        ),
         ),
         ),
       ),

--- a/lib/screens/widgets/prysm_chat_drop_target.dart
+++ b/lib/screens/widgets/prysm_chat_drop_target.dart
@@ -1,0 +1,95 @@
+import 'dart:io';
+
+import 'package:desktop_drop/desktop_drop.dart';
+import 'package:flutter/material.dart';
+import 'package:prysm/util/desktop_platform.dart';
+
+/// Desktop-only drop target for sending files into an open chat.
+class PrysmChatDropTarget extends StatefulWidget {
+  final bool enabled;
+  final Future<void> Function(String path, String name) onFileDropped;
+  final Widget child;
+
+  const PrysmChatDropTarget({
+    super.key,
+    this.enabled = true,
+    required this.onFileDropped,
+    required this.child,
+  });
+
+  @override
+  State<PrysmChatDropTarget> createState() => _PrysmChatDropTargetState();
+}
+
+class _PrysmChatDropTargetState extends State<PrysmChatDropTarget> {
+  bool _dragging = false;
+
+  @override
+  Widget build(BuildContext context) {
+    if (!isDesktopPlatform || !widget.enabled) {
+      return widget.child;
+    }
+
+    return DropTarget(
+      onDragEntered: (_) => setState(() => _dragging = true),
+      onDragExited: (_) => setState(() => _dragging = false),
+      onDragDone: (detail) async {
+        setState(() => _dragging = false);
+
+        if (detail.files.isEmpty) return;
+
+        if (detail.files.length > 1 && mounted) {
+          ScaffoldMessenger.of(context).showSnackBar(
+            const SnackBar(content: Text('Only one file at a time')),
+          );
+        }
+
+        final file = detail.files.first;
+        final path = file.path;
+        if (path.isEmpty) return;
+
+        final messenger = ScaffoldMessenger.of(context);
+        if (await FileSystemEntity.type(path) == FileSystemEntityType.directory) {
+          messenger.showSnackBar(
+            const SnackBar(content: Text('Folders can\'t be sent')),
+          );
+          return;
+        }
+
+        final name = file.name.isNotEmpty ? file.name : path.split(Platform.pathSeparator).last;
+        await widget.onFileDropped(path, name);
+      },
+      child: Stack(
+        fit: StackFit.expand,
+        children: [
+          widget.child,
+          if (_dragging)
+            IgnorePointer(
+              child: ColoredBox(
+                color: Theme.of(context).colorScheme.primary.withValues(alpha: 0.12),
+                child: Center(
+                  child: Column(
+                    mainAxisSize: MainAxisSize.min,
+                    children: [
+                      Icon(
+                        Icons.upload_file,
+                        size: 48,
+                        color: Theme.of(context).colorScheme.primary,
+                      ),
+                      const SizedBox(height: 12),
+                      Text(
+                        'Drop to send',
+                        style: Theme.of(context).textTheme.titleMedium?.copyWith(
+                              color: Theme.of(context).colorScheme.primary,
+                            ),
+                      ),
+                    ],
+                  ),
+                ),
+              ),
+            ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/util/chat_attachment_ingress.dart
+++ b/lib/util/chat_attachment_ingress.dart
@@ -1,0 +1,79 @@
+import 'dart:typed_data';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_image_compress/flutter_image_compress.dart';
+import 'package:path/path.dart' as p;
+import 'package:prysm/screens/widgets/image_send_preview_screen.dart';
+import 'package:prysm/util/readable_file_policy.dart';
+
+typedef SendFileCallback = void Function(
+  Uint8List bytes,
+  String fileName,
+  String type, {
+  bool viewOnce,
+});
+
+/// Shared routing for local attachment bytes (picker, drag-drop, etc.).
+class ChatAttachmentIngress {
+  ChatAttachmentIngress._();
+
+  static const _imageExtensions = {
+    'jpg',
+    'jpeg',
+    'png',
+    'gif',
+    'webp',
+    'bmp',
+    'heic',
+    'heif',
+    'tif',
+    'tiff',
+  };
+
+  static bool isImageFileName(String fileName) {
+    final ext = p.extension(fileName).toLowerCase().replaceFirst('.', '');
+    if (ext.isNotEmpty && _imageExtensions.contains(ext)) {
+      return true;
+    }
+    final mime = ReadableFilePolicy.mimeTypeFor(fileName)?.toLowerCase();
+    return mime != null && mime.startsWith('image/');
+  }
+
+  static Future<Uint8List> prepareImageBytes(Uint8List bytes) async {
+    if (bytes.length <= 500 * 1024) {
+      return bytes;
+    }
+
+    try {
+      return await FlutterImageCompress.compressWithList(
+        bytes,
+        minHeight: 1080,
+        minWidth: 1080,
+        quality: 70,
+      );
+    } catch (_) {
+      return bytes;
+    }
+  }
+
+  static Future<void> sendLocalAttachment({
+    required BuildContext context,
+    required Uint8List bytes,
+    required String fileName,
+    required SendFileCallback sendFile,
+    bool forceImageFlow = false,
+  }) async {
+    if (forceImageFlow || isImageFileName(fileName)) {
+      final prepared = await prepareImageBytes(bytes);
+      if (!context.mounted) return;
+
+      final viewOnce = await ImageSendPreviewScreen.open(context, prepared);
+      if (viewOnce == null || !context.mounted) return;
+
+      sendFile(prepared, fileName, 'image', viewOnce: viewOnce);
+      return;
+    }
+
+    sendFile(bytes, fileName, 'file');
+  }
+}

--- a/linux/flutter/generated_plugin_registrant.cc
+++ b/linux/flutter/generated_plugin_registrant.cc
@@ -7,6 +7,7 @@
 #include "generated_plugin_registrant.h"
 
 #include <audioplayers_linux/audioplayers_linux_plugin.h>
+#include <desktop_drop/desktop_drop_plugin.h>
 #include <emoji_picker_flutter/emoji_picker_flutter_plugin.h>
 #include <file_selector_linux/file_selector_plugin.h>
 #include <flutter_secure_storage_linux/flutter_secure_storage_linux_plugin.h>
@@ -23,6 +24,9 @@ void fl_register_plugins(FlPluginRegistry* registry) {
   g_autoptr(FlPluginRegistrar) audioplayers_linux_registrar =
       fl_plugin_registry_get_registrar_for_plugin(registry, "AudioplayersLinuxPlugin");
   audioplayers_linux_plugin_register_with_registrar(audioplayers_linux_registrar);
+  g_autoptr(FlPluginRegistrar) desktop_drop_registrar =
+      fl_plugin_registry_get_registrar_for_plugin(registry, "DesktopDropPlugin");
+  desktop_drop_plugin_register_with_registrar(desktop_drop_registrar);
   g_autoptr(FlPluginRegistrar) emoji_picker_flutter_registrar =
       fl_plugin_registry_get_registrar_for_plugin(registry, "EmojiPickerFlutterPlugin");
   emoji_picker_flutter_plugin_register_with_registrar(emoji_picker_flutter_registrar);

--- a/linux/flutter/generated_plugins.cmake
+++ b/linux/flutter/generated_plugins.cmake
@@ -4,6 +4,7 @@
 
 list(APPEND FLUTTER_PLUGIN_LIST
   audioplayers_linux
+  desktop_drop
   emoji_picker_flutter
   file_selector_linux
   flutter_secure_storage_linux

--- a/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -8,6 +8,7 @@ import Foundation
 import audio_session
 import audioplayers_darwin
 import battery_plus
+import desktop_drop
 import device_info_plus
 import emoji_picker_flutter
 import file_picker
@@ -39,6 +40,7 @@ func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
   AudioSessionPlugin.register(with: registry.registrar(forPlugin: "AudioSessionPlugin"))
   AudioplayersDarwinPlugin.register(with: registry.registrar(forPlugin: "AudioplayersDarwinPlugin"))
   BatteryPlusMacosPlugin.register(with: registry.registrar(forPlugin: "BatteryPlusMacosPlugin"))
+  DesktopDropPlugin.register(with: registry.registrar(forPlugin: "DesktopDropPlugin"))
   DeviceInfoPlusMacosPlugin.register(with: registry.registrar(forPlugin: "DeviceInfoPlusMacosPlugin"))
   EmojiPickerFlutterPlugin.register(with: registry.registrar(forPlugin: "EmojiPickerFlutterPlugin"))
   FilePickerPlugin.register(with: registry.registrar(forPlugin: "FilePickerPlugin"))

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -53,6 +53,7 @@ dependencies:
   flutter_secure_storage: ^9.2.4
   image_picker: ^1.2.0
   file_picker: ^10.3.3
+  desktop_drop: ^0.5.0
   mime: ^2.0.0
   shared_preferences: ^2.5.3
   flutter_background: ^1.3.0+1

--- a/test/chat_attachment_ingress_test.dart
+++ b/test/chat_attachment_ingress_test.dart
@@ -1,0 +1,30 @@
+import 'dart:typed_data';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:prysm/util/chat_attachment_ingress.dart';
+
+void main() {
+  group('ChatAttachmentIngress.isImageFileName', () {
+    test('returns true for common image extensions', () {
+      expect(ChatAttachmentIngress.isImageFileName('photo.png'), isTrue);
+      expect(ChatAttachmentIngress.isImageFileName('IMG.JPG'), isTrue);
+      expect(ChatAttachmentIngress.isImageFileName('pic.webp'), isTrue);
+      expect(ChatAttachmentIngress.isImageFileName('anim.gif'), isTrue);
+      expect(ChatAttachmentIngress.isImageFileName('scan.heic'), isTrue);
+    });
+
+    test('returns false for non-image files', () {
+      expect(ChatAttachmentIngress.isImageFileName('doc.pdf'), isFalse);
+      expect(ChatAttachmentIngress.isImageFileName('archive.zip'), isFalse);
+      expect(ChatAttachmentIngress.isImageFileName('notes.txt'), isFalse);
+    });
+  });
+
+  group('ChatAttachmentIngress.prepareImageBytes', () {
+    test('leaves small images unchanged', () async {
+      final bytes = Uint8List.fromList([0, 1, 2, 3]);
+      final prepared = await ChatAttachmentIngress.prepareImageBytes(bytes);
+      expect(prepared, bytes);
+    });
+  });
+}

--- a/windows/flutter/generated_plugin_registrant.cc
+++ b/windows/flutter/generated_plugin_registrant.cc
@@ -8,6 +8,7 @@
 
 #include <audioplayers_windows/audioplayers_windows_plugin.h>
 #include <battery_plus/battery_plus_windows_plugin.h>
+#include <desktop_drop/desktop_drop_plugin.h>
 #include <emoji_picker_flutter/emoji_picker_flutter_plugin_c_api.h>
 #include <file_selector_windows/file_selector_windows.h>
 #include <flutter_secure_storage_windows/flutter_secure_storage_windows_plugin.h>
@@ -28,6 +29,8 @@ void RegisterPlugins(flutter::PluginRegistry* registry) {
       registry->GetRegistrarForPlugin("AudioplayersWindowsPlugin"));
   BatteryPlusWindowsPluginRegisterWithRegistrar(
       registry->GetRegistrarForPlugin("BatteryPlusWindowsPlugin"));
+  DesktopDropPluginRegisterWithRegistrar(
+      registry->GetRegistrarForPlugin("DesktopDropPlugin"));
   EmojiPickerFlutterPluginCApiRegisterWithRegistrar(
       registry->GetRegistrarForPlugin("EmojiPickerFlutterPluginCApi"));
   FileSelectorWindowsRegisterWithRegistrar(

--- a/windows/flutter/generated_plugins.cmake
+++ b/windows/flutter/generated_plugins.cmake
@@ -5,6 +5,7 @@
 list(APPEND FLUTTER_PLUGIN_LIST
   audioplayers_windows
   battery_plus
+  desktop_drop
   emoji_picker_flutter
   file_selector_windows
   flutter_secure_storage_windows


### PR DESCRIPTION
- Added PrysmChatDropTarget widget for handling file drops in chat screens.
- Refactored file attachment logic in ChatScreen, GroupChatScreen, and SelfChatScreen to utilize ChatAttachmentIngress for consistent file processing.
- Removed image compression logic from chat screens, delegating it to ChatAttachmentIngress.
- Introduced ChatAttachmentIngress utility for managing local attachment bytes and image preparation.
- Updated pubspec.yaml to include desktop_drop dependency for drag-and-drop functionality.