### PR TITLE
fix: handle pending message deletion before send completes

### DIFF
--- a/lib/database/messages.dart
+++ b/lib/database/messages.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/foundation.dart';
 import 'package:prysm/database/message_reactions.dart';
 import 'package:prysm/database/message_read_receipts.dart';
 import 'package:prysm/database/self_messages_db.dart';
@@ -89,6 +90,12 @@ class MessagesDb {
       _database = null;
       _opening = null;
     }
+  }
+
+  @visibleForTesting
+  static void setDatabaseForTest(Database? db) {
+    _database = db;
+    _opening = null;
   }
 
   static Future<void> _createV2(Database db) async {

--- a/lib/screens/chat.dart
+++ b/lib/screens/chat.dart
@@ -63,6 +63,7 @@ import 'package:prysm/database/message_read_receipts.dart';
 import 'package:prysm/screens/widgets/message_status_icon.dart';
 import 'package:prysm/screens/widgets/read_receipt_details_sheet.dart';
 import 'package:prysm/util/message_status_mapper.dart';
+import 'package:prysm/util/pending_message_db_helper.dart';
 import 'package:prysm/util/outbound_read_status_refresh.dart';
 import 'package:prysm/util/read_receipt_refresh_notifier.dart';
 import 'package:prysm/util/message_content_wiper.dart';
@@ -1848,7 +1849,27 @@ class _ChatScreenState extends State<ChatScreen> {
     );
   }
 
+  Future<void> _deletePendingMessage(Message message) async {
+    final id = message.id;
+    await PendingMessageDbHelper.removeOutboundPendingForWireId(id);
+    _chatService.cancelPendingSend(id);
+    await MessageContentWiper.wipeLocalArtifacts(wireId: id);
+    await MessagesDb.deleteMessageById(id);
+    await MessageReactionsDb.deleteReactionsForMessage(id);
+    _messageCache.remove(id);
+    if (!mounted) return;
+    setState(() {
+      _messages.removeMessage(message);
+      selectedMessageIds.remove(id);
+    });
+  }
+
   Future<void> _deleteMessage(Message message) async {
+    if (message.authorId == widget.userId && isOutboundPending(message)) {
+      await _deletePendingMessage(message);
+      return;
+    }
+
     if (canDeleteForEveryone(message, widget.userId)) {
       await _modifyService.deleteMessage(targetMessageId: message.id);
       await MessageReactionsDb.deleteReactionsForMessage(message.id);
@@ -1910,6 +1931,10 @@ class _ChatScreenState extends State<ChatScreen> {
     final ids = List<String>.from(selectedMessageIds);
     for (final id in ids) {
       final message = _messages.messages.firstWhere((msg) => msg.id == id);
+      if (message.authorId == widget.userId && isOutboundPending(message)) {
+        await _deletePendingMessage(message);
+        continue;
+      }
       if (canDeleteForEveryone(message, widget.userId)) {
         await _modifyService.deleteMessage(targetMessageId: id);
         await MessageReactionsDb.deleteReactionsForMessage(id);

--- a/lib/services/chat_service.dart
+++ b/lib/services/chat_service.dart
@@ -48,6 +48,7 @@ class ChatService {
   int? _newestTimestamp;
   final Set<String> _seenMessageIds = {};
   final Set<String> _inFlightSends = {};
+  final Set<String> _cancelledSends = {};
   StreamSubscription<InboundMessageEvent>? _inboundSub;
 
   ChatService({
@@ -203,6 +204,14 @@ class ChatService {
       replyToId: replyToId,
     );
 
+    // If the user deleted the message while the send was in flight, do not
+    // mark it as sent or re-queue it.
+    final stored = await MessagesDb.getMessageById(id);
+    if (stored.isEmpty || stored.first['deletedAt'] != null) {
+      await PendingMessageDbHelper.removeOutboundPendingForWireId(id);
+      return id;
+    }
+
     if (success) {
       await _markAsSent(id);
       _notifyPeerReachable();
@@ -261,6 +270,14 @@ class ChatService {
       replyToId: replyToId,
       viewOnce: viewOnce,
     );
+
+    // If the user deleted the message while the send was in flight, do not
+    // mark it as sent or re-queue it.
+    final stored = await MessagesDb.getMessageById(id);
+    if (stored.isEmpty || stored.first['deletedAt'] != null) {
+      await PendingMessageDbHelper.removeOutboundPendingForWireId(id);
+      return id;
+    }
 
     if (success) {
       await _markAsSent(id);
@@ -379,7 +396,7 @@ class ChatService {
             await PendingMessageDbHelper.getPendingMessages(receiverId: peerId);
         if (pending.isEmpty) break;
 
-        final List<String> sentIds = [];
+        final List<String> removeIds = [];
         var sentAny = false;
 
         for (final msg in pending) {
@@ -391,10 +408,21 @@ class ChatService {
           }
 
           final msgId = msg['id'] as String;
+
+          // Skip messages that were deleted while queued. This prevents a
+          // pending message from being delivered after the user deletes it.
+          final stored = await MessagesDb.getMessageById(msgId);
+          if (stored.isEmpty ||
+              stored.first['deletedAt'] != null ||
+              _cancelledSends.contains(msgId)) {
+            removeIds.add(msgId);
+            continue;
+          }
+
           final retries = _retryCounts[msgId] ?? 0;
 
           if (retries >= _maxRetries) {
-            sentIds.add(msgId);
+            removeIds.add(msgId);
             _retryCounts.remove(msgId);
             if (!_disposed) {
               _messageStatusController.add(MessageStatusUpdate(msgId, 'failed'));
@@ -413,7 +441,7 @@ class ChatService {
           );
 
           if (success) {
-            sentIds.add(msgId);
+            removeIds.add(msgId);
             _retryCounts.remove(msgId);
             await _markAsSent(msgId);
             if (!_disposed) {
@@ -428,8 +456,8 @@ class ChatService {
           }
         }
 
-        if (sentIds.isNotEmpty) {
-          await PendingMessageDbHelper.removeMessages(sentIds);
+        if (removeIds.isNotEmpty) {
+          await PendingMessageDbHelper.removeMessages(removeIds);
         }
 
         final remaining =
@@ -658,7 +686,7 @@ class ChatService {
         }
         final msgId = msg['id'] as String;
         final stored = await MessagesDb.getMessageById(msgId);
-        if (stored.isNotEmpty && stored.first['deletedAt'] != null) {
+        if (stored.isEmpty || stored.first['deletedAt'] != null) {
           await PendingMessageDbHelper.removeOutboundPendingForWireId(msgId);
           continue;
         }
@@ -720,6 +748,7 @@ class ChatService {
       await PendingMessageDbHelper.removeOutboundPendingForWireId(messageId);
       return;
     }
+    if (_cancelledSends.contains(messageId)) return;
 
     if (_inFlightSends.contains(messageId)) return;
 
@@ -775,6 +804,13 @@ class ChatService {
     if (processQueue) {
       _processSendQueue();
     }
+  }
+
+  /// Cancel any future send attempt for [messageId] within this service.
+  /// Already queued rows should still be removed by the caller; this only
+  /// prevents in-flight sends started after the call from completing.
+  void cancelPendingSend(String messageId) {
+    _cancelledSends.add(messageId);
   }
 
   void _notifyPeerReachable() {

--- a/lib/util/message_status_mapper.dart
+++ b/lib/util/message_status_mapper.dart
@@ -175,9 +175,10 @@ Message messageWithDeliveryUpdate(
     );
   }
   if (status == 'failed') {
-    return message.copyWith(
-      metadata: {...?message.metadata, 'failed': true},
-    );
+    final meta = <String, Object?>{...?message.metadata};
+    meta.remove('deliveryStatus');
+    meta['failed'] = true;
+    return message.copyWith(metadata: meta);
   }
   return message;
 }

--- a/test/chat_service_pending_delete_test.dart
+++ b/test/chat_service_pending_delete_test.dart
@@ -1,0 +1,162 @@
+import 'dart:convert';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:prysm/crypto/identity.dart';
+import 'package:prysm/database/messages.dart';
+import 'package:prysm/services/chat_service.dart';
+import 'package:prysm/util/db_helper.dart';
+import 'package:prysm/util/key_manager.dart';
+import 'package:prysm/util/pending_message_db_helper.dart';
+import 'package:sqflite_common_ffi/sqflite_ffi.dart';
+
+Future<Database> _openPendingDb() async {
+  final db = await databaseFactory.openDatabase(inMemoryDatabasePath);
+  await db.execute('DROP TABLE IF EXISTS pending_messages');
+  await db.execute('''
+    CREATE TABLE pending_messages(
+      id TEXT PRIMARY KEY,
+      senderId TEXT,
+      receiverId TEXT,
+      message TEXT,
+      type TEXT,
+      fileName TEXT,
+      fileSize INTEGER,
+      timestamp INTEGER,
+      status TEXT,
+      replyTo TEXT,
+      viewOnce INTEGER DEFAULT 0,
+      groupId TEXT,
+      targetMemberId TEXT
+    )
+  ''');
+  return db;
+}
+
+Future<Database> _openDbHelperDb() async {
+  final db = await databaseFactory.openDatabase(inMemoryDatabasePath);
+  await db.execute('DROP TABLE IF EXISTS users');
+  await db.execute('''
+    CREATE TABLE users (
+      id TEXT PRIMARY KEY,
+      name TEXT,
+      avatarUrl TEXT,
+      avatarBase64 TEXT,
+      customName TEXT,
+      publicKeyPem TEXT,
+      identityJson TEXT
+    )
+  ''');
+  return db;
+}
+
+Future<Database> _openMessagesDb() async {
+  final db = await databaseFactory.openDatabase(inMemoryDatabasePath);
+  await db.execute('DROP TABLE IF EXISTS messages');
+  await db.execute('''
+    CREATE TABLE messages(
+      id TEXT PRIMARY KEY,
+      senderId TEXT NOT NULL,
+      receiverId TEXT NOT NULL,
+      message TEXT,
+      type TEXT,
+      fileName TEXT,
+      fileSize INTEGER,
+      timestamp INTEGER NOT NULL,
+      status TEXT DEFAULT 'sent',
+      replyTo TEXT,
+      readAt INTEGER,
+      viewOnce INTEGER DEFAULT 0,
+      viewed INTEGER DEFAULT 0,
+      groupId TEXT,
+      deletedAt INTEGER,
+      editedAt INTEGER
+    )
+  ''');
+  return db;
+}
+
+void main() {
+  setUpAll(() {
+    TestWidgetsFlutterBinding.ensureInitialized();
+    sqfliteFfiInit();
+    databaseFactory = databaseFactoryFfi;
+  });
+
+  late Database pendingDb;
+  late Database dbHelperDb;
+  late Database messagesDb;
+  late KeyManager keyManager;
+  late IdentityKeyPair peerIdentity;
+
+  setUp(() async {
+    pendingDb = await _openPendingDb();
+    PendingMessageDbHelper.setDatabaseForTest(pendingDb);
+
+    dbHelperDb = await _openDbHelperDb();
+    DBHelper.setDatabaseForTest(dbHelperDb);
+
+    messagesDb = await _openMessagesDb();
+    MessagesDb.setDatabaseForTest(messagesDb);
+
+    peerIdentity = await IdentityKeyPair.generate();
+    keyManager = KeyManager.fromIdentity(await IdentityKeyPair.generate());
+
+    final identityJson = jsonEncode(await peerIdentity.toPublicJson());
+    await DBHelper.insertOrUpdateUser({
+      'id': 'peer.onion',
+      'name': 'Peer',
+      'identityJson': identityJson,
+      'publicKeyPem': identityJson,
+    });
+  });
+
+  tearDown(() async {
+    await pendingDb.close();
+    PendingMessageDbHelper.setDatabaseForTest(null);
+
+    await dbHelperDb.close();
+    DBHelper.setDatabaseForTest(null);
+
+    await messagesDb.close();
+    MessagesDb.setDatabaseForTest(null);
+  });
+
+  test('processPendingForPeer removes deleted messages from queue', () async {
+    const wireId = 'msg-1';
+    const senderId = 'me.onion';
+    const receiverId = 'peer.onion';
+
+    await MessagesDb.insertMessage({
+      'id': wireId,
+      'senderId': senderId,
+      'receiverId': receiverId,
+      'message': 'self-cipher',
+      'type': 'text',
+      'status': 'pending',
+      'timestamp': 1,
+    });
+
+    await PendingMessageDbHelper.insertPendingMessage({
+      'id': wireId,
+      'senderId': senderId,
+      'receiverId': receiverId,
+      'message': 'peer-cipher',
+      'type': 'text',
+      'timestamp': 1,
+      'status': 'pending',
+    });
+
+    await MessagesDb.deleteMessageById(wireId);
+
+    await ChatService.processPendingForPeer(
+      userId: senderId,
+      peerId: receiverId,
+      keyManager: keyManager,
+    );
+
+    final remaining = await PendingMessageDbHelper.getPendingMessages(
+      receiverId: receiverId,
+    );
+    expect(remaining, isEmpty);
+  });
+}

--- a/test/message_status_mapper_test.dart
+++ b/test/message_status_mapper_test.dart
@@ -127,6 +127,41 @@ void main() {
     expect(sent.seenAt, isNull);
   });
 
+  test('isOutboundPending detects undelivered outbound messages', () {
+    final base = TextMessage(
+      authorId: 'me',
+      createdAt: DateTime.now(),
+      id: '1',
+      text: 'hi',
+    );
+
+    expect(isOutboundPending(base), isTrue);
+
+    final pending = messageWithPendingStatus(base);
+    expect(isOutboundPending(pending), isTrue);
+
+    final sent = messageWithDeliveryUpdate(
+      pending,
+      status: 'sent',
+      readReceiptsEnabled: true,
+    );
+    expect(isOutboundPending(sent), isFalse);
+
+    final read = messageWithDeliveryUpdate(
+      sent,
+      status: 'read',
+      readReceiptsEnabled: true,
+    );
+    expect(isOutboundPending(read), isFalse);
+
+    final failed = messageWithDeliveryUpdate(
+      pending,
+      status: 'failed',
+      readReceiptsEnabled: true,
+    );
+    expect(isOutboundPending(failed), isFalse);
+  });
+
   test('outboundTickState maps pending, delivered, and read', () {
     final base = TextMessage(
       authorId: 'me',


### PR DESCRIPTION
- Skip send completion for messages deleted while in-flight
- Prevent queued retries from resurrecting deleted messages
- Add cancelPendingSend to ChatService to short-circuit future sends
- Remove deliveryStatus metadata on failed status for correct icon mapping
- Add isOutboundPending check before proceeding with deletion
- Add @visibleForTesting setter for MessagesDb database injection