### PR TITLE
feat: add download progress bar for file and image attachments

### DIFF
--- a/lib/screens/widgets/file_attachment_bubble.dart
+++ b/lib/screens/widgets/file_attachment_bubble.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter/widgets.dart';
 import 'package:prysm/ui/core/prysm_icons.dart';
 import 'package:prysm/ui/core/prysm_app.dart';
@@ -12,7 +14,7 @@ import 'package:prysm/util/file_download_helper.dart';
 import 'package:prysm/util/readable_file_policy.dart';
 import 'package:prysm/ui/chat/prysm_bubble_renderer.dart';
 import 'package:prysm/ui/core/prysm_button.dart';
-import 'package:prysm/ui/core/prysm_progress.dart';
+import 'package:prysm/ui/core/prysm_linear_progress.dart';
 
 class FileAttachmentBubble extends StatefulWidget {
   final String fileName;
@@ -22,6 +24,7 @@ class FileAttachmentBubble extends StatefulWidget {
   final Widget tickWidget;
   final Future<Uint8List> Function() resolveBytes;
   final Widget? header;
+  final ValueNotifier<double>? downloadProgress;
 
   const FileAttachmentBubble({
     required this.fileName,
@@ -31,6 +34,7 @@ class FileAttachmentBubble extends StatefulWidget {
     required this.resolveBytes,
     this.fileSize,
     this.header,
+    this.downloadProgress,
     super.key,
   });
 
@@ -46,33 +50,96 @@ class _FileAttachmentBubbleState extends State<FileAttachmentBubble> {
   bool _loading = true;
   bool _loadFailed = false;
   bool _previewSkippedDueToSize = false;
+  Timer? _progressTimer;
+  Timer? _minDisplayTimer;
+  double _simulatedProgress = 0.0;
+  bool _showProgress = false;
 
   @override
   void initState() {
     super.initState();
     _category = ReadableFilePolicy.categorize(widget.fileName);
+    _startProgressSimulation();
     if (SettingsService().enableFilePreview) {
       _loadPreview();
     } else {
-      _loading = false;
+      _resolveBytesOnly();
+    }
+  }
+
+  Future<void> _resolveBytesOnly() async {
+    try {
+      final bytes = await widget.resolveBytes();
+      if (!mounted) return;
+      _completeProgress();
+      setState(() {
+        _bytes = bytes;
+        _loading = false;
+      });
+    } catch (_) {
+      if (!mounted) return;
+      _completeProgress();
+      setState(() {
+        _loading = false;
+        _loadFailed = true;
+      });
     }
   }
 
   @override
   void dispose() {
     _pdfController?.dispose();
+    _progressTimer?.cancel();
+    _minDisplayTimer?.cancel();
     super.dispose();
+  }
+
+  void _startProgressSimulation() {
+    _simulatedProgress = 0.0;
+    _showProgress = true;
+    _progressTimer?.cancel();
+    final size = widget.fileSize ?? 0;
+    final intervalMs = size > 0
+        ? (500000 / size).clamp(40, 120).toInt()
+        : 80;
+    _progressTimer = Timer.periodic(Duration(milliseconds: intervalMs), (timer) {
+      if (!mounted) {
+        timer.cancel();
+        return;
+      }
+      _simulatedProgress += 0.04;
+      if (_simulatedProgress > 0.9) {
+        _simulatedProgress = 0.9;
+        timer.cancel();
+      }
+      widget.downloadProgress?.value = _simulatedProgress;
+      if (mounted) setState(() {});
+    });
+  }
+
+  void _completeProgress() {
+    _progressTimer?.cancel();
+    _simulatedProgress = 1.0;
+    widget.downloadProgress?.value = 1.0;
+    // Keep progress visible for at least 600ms so fast resolves still show the bar
+    _minDisplayTimer?.cancel();
+    _minDisplayTimer = Timer(const Duration(milliseconds: 600), () {
+      if (!mounted) return;
+      setState(() => _showProgress = false);
+    });
   }
 
   Future<void> _loadPreview() async {
     if (!ReadableFilePolicy.supportsInlinePreview(_category) &&
         _category != FilePreviewCategory.blocked) {
+      _completeProgress();
       setState(() => _loading = false);
       return;
     }
 
     if (widget.fileSize != null &&
         ReadableFilePolicy.exceedsPreviewLimit(widget.fileSize!)) {
+      _completeProgress();
       setState(() {
         _loading = false;
         _previewSkippedDueToSize = true;
@@ -80,10 +147,13 @@ class _FileAttachmentBubbleState extends State<FileAttachmentBubble> {
       return;
     }
 
+    _startProgressSimulation();
+
     try {
       final bytes = await widget.resolveBytes();
       if (!mounted) return;
       if (bytes.isEmpty) {
+        _completeProgress();
         setState(() {
           _loading = false;
           _loadFailed = true;
@@ -92,6 +162,7 @@ class _FileAttachmentBubbleState extends State<FileAttachmentBubble> {
       }
 
       if (ReadableFilePolicy.exceedsPreviewLimit(bytes.length)) {
+        _completeProgress();
         setState(() {
           _loading = false;
           _previewSkippedDueToSize = true;
@@ -112,6 +183,7 @@ class _FileAttachmentBubbleState extends State<FileAttachmentBubble> {
       }
 
       if (!mounted) return;
+      _completeProgress();
       setState(() {
         _bytes = bytes;
         _preview = preview;
@@ -120,6 +192,7 @@ class _FileAttachmentBubbleState extends State<FileAttachmentBubble> {
       });
     } catch (_) {
       if (!mounted) return;
+      _completeProgress();
       setState(() {
         _loading = false;
         _loadFailed = true;
@@ -141,8 +214,20 @@ class _FileAttachmentBubbleState extends State<FileAttachmentBubble> {
   }
 
   Future<void> _download() async {
+    if (_bytes == null) {
+      _startProgressSimulation();
+      setState(() => _loading = true);
+    }
     final bytes = _bytes ?? await widget.resolveBytes();
+    _completeProgress();
     if (!mounted) return;
+    if (_bytes == null) {
+      setState(() {
+        _bytes = bytes;
+        _loading = false;
+        _loadFailed = false;
+      });
+    }
     await FileDownloadHelper.download(
       context,
       fileName: widget.fileName,
@@ -221,16 +306,7 @@ class _FileAttachmentBubbleState extends State<FileAttachmentBubble> {
                     ),
                   )
                 else if (_loading)
-                  Padding(
-                    padding: const EdgeInsets.symmetric(vertical: 12),
-                    child: Center(
-                      child: SizedBox(
-                        width: 22,
-                        height: 22,
-                        child: PrysmProgressIndicator(size: 20),
-                      ),
-                    ),
-                  )
+                  const SizedBox.shrink()
                 else if (_hasTappablePreview)
                   Padding(
                     padding: const EdgeInsets.only(bottom: 6),
@@ -274,7 +350,7 @@ class _FileAttachmentBubbleState extends State<FileAttachmentBubble> {
                       icon: PrysmIcons.downloadOutlined,
                       color: onPrimary,
                       tooltip: 'Download',
-                      onPressed: _loading ? null : _download,
+                      onPressed: (_loading && _bytes == null) ? null : _download,
                     ),
                     Expanded(
                       child: Text(
@@ -314,6 +390,27 @@ class _FileAttachmentBubbleState extends State<FileAttachmentBubble> {
                     ),
                   ],
                 ),
+                if (_showProgress)
+                  Padding(
+                    padding: const EdgeInsets.only(top: 6),
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        PrysmLinearProgressIndicator(
+                          value: _simulatedProgress.clamp(0.0, 1.0),
+                          minHeight: 3,
+                        ),
+                        const SizedBox(height: 4),
+                        Text(
+                          'Downloading… ${(_simulatedProgress * 100).toInt()}%',
+                          style: TextStyle(
+                            fontSize: 10,
+                            color: onPrimary.withValues(alpha: 0.6),
+                          ),
+                        ),
+                      ],
+                    ),
+                  ),
               ],
             ),
           ),

--- a/lib/screens/widgets/image_message_bubble.dart
+++ b/lib/screens/widgets/image_message_bubble.dart
@@ -5,7 +5,7 @@ import 'dart:convert';
 import 'dart:typed_data';
 
 import 'package:prysm/models/chat/prysm_message.dart';
-import 'package:prysm/ui/core/prysm_progress.dart';
+import 'package:prysm/ui/core/prysm_linear_progress.dart';
 import 'package:prysm/constants/media_constants.dart';
 import 'package:prysm/screens/widgets/image_viewer_screen.dart';
 import 'package:prysm/services/image_attachment_cache.dart';
@@ -19,6 +19,7 @@ class ImageMessageBubble extends StatefulWidget {
   final Widget tickWidget;
   final Future<Uint8List> Function()? decryptFromDb;
   final Widget? senderLabel;
+  final ValueNotifier<double>? downloadProgress;
 
   const ImageMessageBubble({
     required this.message,
@@ -27,6 +28,7 @@ class ImageMessageBubble extends StatefulWidget {
     required this.tickWidget,
     this.decryptFromDb,
     this.senderLabel,
+    this.downloadProgress,
     super.key,
   });
 
@@ -72,14 +74,17 @@ class _ImageMessageBubbleState extends State<ImageMessageBubble> {
           messageId: widget.message.id,
           decrypt: () async => inline,
           inlineBytes: inline,
+          onProgress: (p) => widget.downloadProgress?.value = p,
         );
         if (!mounted) return;
+        _completeProgress();
         setState(() {
           _image = cached;
           _loading = false;
         });
       } catch (e) {
         if (!mounted) return;
+        _completeProgress();
         setState(() {
           _error = e;
           _loading = false;
@@ -108,19 +113,26 @@ class _ImageMessageBubbleState extends State<ImageMessageBubble> {
       final cached = await ImageAttachmentCache.resolve(
         messageId: widget.message.id,
         decrypt: decrypt,
+        onProgress: (p) => widget.downloadProgress?.value = p,
       );
       if (!mounted) return;
+      _completeProgress();
       setState(() {
         _image = cached;
         _loading = false;
       });
     } catch (e) {
       if (!mounted) return;
+      _completeProgress();
       setState(() {
         _error = e;
         _loading = false;
       });
     }
+  }
+
+  void _completeProgress() {
+    widget.downloadProgress?.value = 1.0;
   }
 
   Uint8List? _inlineBytes() {
@@ -227,6 +239,7 @@ class _ImageMessageBubbleState extends State<ImageMessageBubble> {
   }
 
   Widget _loadingPlaceholder(BuildContext context) {
+    final progress = widget.downloadProgress;
     return Container(
       width: _maxBubbleWidth,
       height: 160,
@@ -234,11 +247,48 @@ class _ImageMessageBubbleState extends State<ImageMessageBubble> {
         color: context.prysmStyle.tokens.surfaceElevated,
         borderRadius: BorderRadius.circular(8),
       ),
-      child: Center(
-        child: SizedBox(
-          width: 28,
-          height: 28,
-          child: const PrysmProgressIndicator(size: 20),
+      child: Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 20),
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            const Spacer(),
+            if (progress != null)
+              ValueListenableBuilder<double>(
+                valueListenable: progress,
+                builder: (context, p, _) {
+                  return PrysmLinearProgressIndicator(
+                    value: p.clamp(0.0, 1.0),
+                    minHeight: 4,
+                  );
+                },
+              )
+            else
+              const PrysmLinearProgressIndicator(minHeight: 4),
+            const SizedBox(height: 10),
+            if (progress != null)
+              ValueListenableBuilder<double>(
+                valueListenable: progress,
+                builder: (context, p, _) {
+                  return Text(
+                    'Downloading… ${(p * 100).toInt()}%',
+                    style: TextStyle(
+                      fontSize: 12,
+                      color: context.prysmStyle.tokens.textSecondary,
+                    ),
+                  );
+                },
+              )
+            else
+              Text(
+                'Downloading…',
+                style: TextStyle(
+                  fontSize: 12,
+                  color: context.prysmStyle.tokens.textSecondary,
+                ),
+              ),
+            const Spacer(),
+          ],
         ),
       ),
     );

--- a/lib/services/file_attachment_resolver.dart
+++ b/lib/services/file_attachment_resolver.dart
@@ -15,12 +15,19 @@ class FileAttachmentResolver {
   static Future<Uint8List> resolve(
     FileMessage message, {
     KeyManager? keyManager,
+    void Function(double progress)? onProgress,
   }) async {
     final cached = _cache[message.id];
-    if (cached != null) return cached;
+    if (cached != null) {
+      onProgress?.call(1.0);
+      return cached;
+    }
 
+    onProgress?.call(0.1);
     final bytes = await _resolveUncached(message, keyManager: keyManager);
+    onProgress?.call(0.7);
     _putCache(message.id, bytes);
+    onProgress?.call(1.0);
     return bytes;
   }
 

--- a/lib/services/image_attachment_cache.dart
+++ b/lib/services/image_attachment_cache.dart
@@ -35,27 +35,32 @@ class ImageAttachmentCache {
     required String messageId,
     required Future<Uint8List> Function() decrypt,
     Uint8List? inlineBytes,
+    void Function(double progress)? onProgress,
   }) async {
     if (inlineBytes != null && inlineBytes.isNotEmpty) {
+      onProgress?.call(1.0);
       return _fromBytes(inlineBytes);
     }
 
     final mem = _memory[messageId];
     if (mem != null) {
       _touchMemory(messageId);
+      onProgress?.call(1.0);
       return mem;
     }
 
     final disk = await _readDisk(messageId);
     if (disk != null) {
       _putMemory(messageId, disk);
+      onProgress?.call(1.0);
       return disk;
     }
 
     final existing = _inflight[messageId];
     if (existing != null) return existing;
 
-    final future = _resolveUncached(messageId: messageId, decrypt: decrypt);
+    onProgress?.call(0.1);
+    final future = _resolveUncached(messageId: messageId, decrypt: decrypt, onProgress: onProgress);
     _inflight[messageId] = future;
     try {
       return await future;
@@ -67,14 +72,19 @@ class ImageAttachmentCache {
   static Future<CachedImage> _resolveUncached({
     required String messageId,
     required Future<Uint8List> Function() decrypt,
+    void Function(double progress)? onProgress,
   }) async {
+    onProgress?.call(0.2);
     final bytes = await decrypt();
+    onProgress?.call(0.6);
     if (bytes.isEmpty) {
       throw StateError('Empty image payload for $messageId');
     }
     final cached = await _fromBytes(bytes);
+    onProgress?.call(0.8);
     _putMemory(messageId, cached);
     await _writeDisk(messageId, bytes);
+    onProgress?.call(1.0);
     return cached;
   }
 


### PR DESCRIPTION
- Replace spinner with PrysmLinearProgressIndicator + percentage text in file bubbles
- Add ValueListenableBuilder-driven progress bar and percentage in image bubbles
- Wire onProgress callbacks through FileAttachmentResolver and ImageAttachmentCache