### PR TITLE
fix(group): resolve own sender identity from keystore

### DIFF
--- a/lib/screens/group_chat.dart
+++ b/lib/screens/group_chat.dart
@@ -721,9 +721,10 @@ class _GroupChatScreenState extends State<GroupChatScreen> {
     required String wire,
     required String transportSenderId,
   }) async {
-    final senderKeys = await loadPeerIdentityFromDb(
+    final senderKeys = await loadGroupSenderIdentity(
       widget.keyManager,
       transportSenderId,
+      localUserId: widget.userId,
     );
     if (senderKeys == null) {
       throw ArgumentError('Unknown sender identity');

--- a/lib/services/detached_chat_bridge.dart
+++ b/lib/services/detached_chat_bridge.dart
@@ -191,6 +191,7 @@ class DetachedChatBridge {
                   wire: wireStr,
                   transportSenderId: authorId,
                   keyManager: keyManager,
+                  localUserId: userId,
                 )
               : await GroupCryptoV2.decryptText(groupKey, wireStr);
           result.add(
@@ -256,10 +257,12 @@ class DetachedChatBridge {
     required String wire,
     required String transportSenderId,
     required KeyManager keyManager,
+    required String localUserId,
   }) async {
-    final senderKeys = await loadPeerIdentityFromDb(
+    final senderKeys = await loadGroupSenderIdentity(
       keyManager,
       transportSenderId,
+      localUserId: localUserId,
     );
     if (senderKeys == null) {
       throw ArgumentError('Unknown sender identity');

--- a/lib/util/peer_identity_loader.dart
+++ b/lib/util/peer_identity_loader.dart
@@ -16,3 +16,29 @@ Future<IdentityPublicKeys?> loadPeerIdentityFromDb(
     return null;
   }
 }
+
+/// Resolves the public keys that signed a group message.
+///
+/// The local user's own row in `users` carries a placeholder identity, so for
+/// [localUserId] the keystore identity — the key that actually produced the
+/// signature — is authoritative instead of the peer store.
+Future<IdentityPublicKeys?> loadGroupSenderIdentity(
+  KeyManager keyManager,
+  String senderId, {
+  required String localUserId,
+}) async {
+  if (senderId != localUserId) {
+    return loadPeerIdentityFromDb(keyManager, senderId);
+  }
+  try {
+    final identity = keyManager.identity;
+    final publicJson = await identity.toPublicJson();
+    return IdentityPublicKeys(
+      signPublic: await identity.signPublicKey,
+      agreePublic: await identity.agreePublicKey,
+      fingerprint: IdentityKeyPair.fingerprintFromPublicJson(publicJson),
+    );
+  } catch (_) {
+    return null;
+  }
+}

--- a/test/group_sender_identity_test.dart
+++ b/test/group_sender_identity_test.dart
@@ -1,0 +1,119 @@
+import 'dart:convert';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:prysm/crypto/group_crypto.dart';
+import 'package:prysm/crypto/identity.dart';
+import 'package:prysm/util/db_helper.dart';
+import 'package:prysm/util/key_manager.dart';
+import 'package:prysm/util/peer_identity_loader.dart';
+import 'package:sqflite_common_ffi/sqflite_ffi.dart';
+
+Future<Database> _openTestDb() async {
+  return databaseFactory.openDatabase(
+    inMemoryDatabasePath,
+    options: OpenDatabaseOptions(
+      version: 1,
+      onCreate: (db, version) async {
+        await db.execute('''
+          CREATE TABLE users (
+            id TEXT PRIMARY KEY,
+            name TEXT,
+            avatarUrl TEXT,
+            avatarBase64 TEXT,
+            customName TEXT,
+            publicKeyPem TEXT,
+            identityJson TEXT
+          )
+        ''');
+      },
+    ),
+  );
+}
+
+void main() {
+  setUpAll(() {
+    TestWidgetsFlutterBinding.ensureInitialized();
+    sqfliteFfiInit();
+    databaseFactory = databaseFactoryFfi;
+  });
+
+  group('loadGroupSenderIdentity', () {
+    const localUserId = 'me.onion';
+    const peerId = 'peer.onion';
+    const groupId = 'group-1';
+
+    late Database db;
+    late KeyManager keyManager;
+
+    setUp(() async {
+      db = await _openTestDb();
+      DBHelper.setDatabaseForTest(db);
+      keyManager = KeyManager.fromIdentity(await IdentityKeyPair.generate());
+      // The app stores a placeholder identity for the local user's own row.
+      await DBHelper.insertOrUpdateUser({
+        'id': localUserId,
+        'name': 'me',
+        'avatarUrl': '',
+        'identityJson': 'NONE',
+        'publicKeyPem': 'NONE',
+      });
+    });
+
+    tearDown(() async {
+      await db.close();
+      DBHelper.setDatabaseForTest(null);
+    });
+
+    test('own group message decrypts despite placeholder identity row',
+        () async {
+      final groupKey = GroupCryptoV2.generateGroupKey();
+      const plaintext = 'my own group message';
+      final wire = await GroupCryptoV2.encryptWithSenderKey(
+        epochKey: groupKey,
+        groupId: groupId,
+        senderId: localUserId,
+        messageIndex: 1,
+        plaintext: plaintext,
+        sender: keyManager.identity,
+      );
+
+      final senderKeys = await loadGroupSenderIdentity(
+        keyManager,
+        localUserId,
+        localUserId: localUserId,
+      );
+      expect(senderKeys, isNotNull);
+
+      final decrypted = await GroupCryptoV2.decryptWithSenderKey(
+        epochKey: groupKey,
+        groupId: groupId,
+        wire: wire,
+        transportSenderId: localUserId,
+        senderKeys: senderKeys!,
+      );
+      expect(decrypted, plaintext);
+    });
+
+    test('peer identity still resolves from the user store', () async {
+      final peerIdentity = await IdentityKeyPair.generate();
+      final peerPublicJson = await peerIdentity.toPublicJson();
+      await DBHelper.insertOrUpdateUser({
+        'id': peerId,
+        'name': 'peer',
+        'avatarUrl': '',
+        'identityJson': jsonEncode(peerPublicJson),
+      });
+
+      final resolved = await loadGroupSenderIdentity(
+        keyManager,
+        peerId,
+        localUserId: localUserId,
+      );
+      expect(resolved, isNotNull);
+      expect(
+        resolved!.signPublic.bytes,
+        (await peerIdentity.signPublicKey).bytes,
+      );
+    });
+  });
+}


### PR DESCRIPTION
Own group messages showed "Cannot decrypt message" when reopening a chat. Group messages use the sender-key scheme, where the signature is verified against the sender's public key -- looked up in the `users` table. The local user's own row carries a placeholder identity (`identityJson: 'NONE'`), so signature verification failed for own messages only, while peers decrypted fine.

Resolve the signing keys from the keystore for the local user, since that is the key that actually produced the signature. Peer lookups are unchanged, and signature verification stays mandatory for every sender.

Sending was unaffected because outbound messages are appended in memory with the plaintext already available; the failure only surfaced once rows were re-read from the database.