### PR TITLE
fix: Fixed app label and executable name appearing as lowercase prysm…

### DIFF
--- a/linux/CMakeLists.txt
+++ b/linux/CMakeLists.txt
@@ -4,7 +4,7 @@ project(runner LANGUAGES CXX)
 
 # The name of the executable created for the application. Change this to change
 # the on-disk name of your application.
-set(BINARY_NAME "prysm")
+set(BINARY_NAME "Prysm")
 # The unique GTK application identifier for this application. See:
 # https://wiki.gnome.org/HowDoI/ChooseApplicationID
 set(APPLICATION_ID "com.xmreur.prysm")

--- a/linux/runner/my_application.cc
+++ b/linux/runner/my_application.cc
@@ -48,11 +48,11 @@ static void my_application_activate(GApplication* application) {
   if (use_header_bar) {
     GtkHeaderBar* header_bar = GTK_HEADER_BAR(gtk_header_bar_new());
     gtk_widget_show(GTK_WIDGET(header_bar));
-    gtk_header_bar_set_title(header_bar, "prysm");
+    gtk_header_bar_set_title(header_bar, "Prysm");
     gtk_header_bar_set_show_close_button(header_bar, TRUE);
     gtk_window_set_titlebar(window, GTK_WIDGET(header_bar));
   } else {
-    gtk_window_set_title(window, "prysm");
+    gtk_window_set_title(window, "Prysm");
   }
 
   gtk_window_set_default_size(window, 1280, 720);

--- a/windows/CMakeLists.txt
+++ b/windows/CMakeLists.txt
@@ -4,7 +4,7 @@ project(prysm LANGUAGES CXX)
 
 # The name of the executable created for the application. Change this to change
 # the on-disk name of your application.
-set(BINARY_NAME "prysm")
+set(BINARY_NAME "Prysm")
 
 # Explicitly opt in to modern CMake behaviors to avoid warnings with recent
 # versions of CMake.

--- a/windows/runner/main.cpp
+++ b/windows/runner/main.cpp
@@ -27,7 +27,7 @@ int APIENTRY wWinMain(_In_ HINSTANCE instance, _In_opt_ HINSTANCE prev,
   FlutterWindow window(project);
   Win32Window::Point origin(10, 10);
   Win32Window::Size size(1280, 720);
-  if (!window.Create(L"prysm", origin, size)) {
+  if (!window.Create(L"Prysm", origin, size)) {
     return EXIT_FAILURE;
   }
   window.SetQuitOnClose(true);


### PR DESCRIPTION
… instead of Prysm on desktop