### PR TITLE
feat(chat): schedule messages for later delivery

### DIFF
--- a/lib/database/message_schema_migrations.dart
+++ b/lib/database/message_schema_migrations.dart
@@ -11,7 +11,7 @@ class MessageSchemaMigrations {
   MessageSchemaMigrations._();
 
   /// Current schema version. Bump alongside a new _upgradeToVN step.
-  static const int dbVersion = 11;
+  static const int dbVersion = 12;
 
   static Future<void> onCreate(Database db, int version) async {
     await _createV2(db);
@@ -31,6 +31,7 @@ class MessageSchemaMigrations {
     if (oldVersion < 8) await _upgradeToV8(db);
     if (oldVersion < 9) await _upgradeToV9(db);
     if (oldVersion < 10) await _upgradeToV10(db);
+    if (oldVersion < 12) await _upgradeToV12(db);
   }
 
   static Future<void> migrateOversizedMessagePayloads(Database db) async {
@@ -124,6 +125,7 @@ class MessageSchemaMigrations {
     await createReactionsTable(db);
     await createReadReceiptsTable(db);
     await createSelfMessagesTable(db);
+    await createScheduledMessagesTable(db);
   }
 
   /// CHANGES: added readAt timestamp
@@ -231,6 +233,11 @@ class MessageSchemaMigrations {
     await createSelfMessagesTable(db);
   }
 
+  static Future<void> _upgradeToV12(Database db) async {
+    Logging.info('UPGRADING DB TO v12', 'MessagesDb');
+    await createScheduledMessagesTable(db);
+  }
+
   /// Owns message_reactions' schema; MessageReactionsDb.createTable delegates here.
   static Future<void> createReactionsTable(Database db) async {
     await db.execute('''
@@ -286,6 +293,29 @@ class MessageSchemaMigrations {
     ''');
     await db.execute(
       'CREATE INDEX IF NOT EXISTS idx_self_messages_ts ON self_messages(timestamp)',
+    );
+  }
+
+  /// Owns scheduled_messages' schema; ScheduledMessagesDb.createTable delegates
+  /// here. `body` holds the message text encrypted for self, so a pending
+  /// scheduled message is never stored as plaintext.
+  static Future<void> createScheduledMessagesTable(Database db) async {
+    await db.execute('''
+      CREATE TABLE IF NOT EXISTS scheduled_messages (
+        id TEXT PRIMARY KEY,
+        conversationId TEXT NOT NULL,
+        isGroup INTEGER NOT NULL DEFAULT 0,
+        body TEXT NOT NULL,
+        replyTo TEXT,
+        sendAt INTEGER NOT NULL,
+        createdAt INTEGER NOT NULL
+      )
+    ''');
+    await db.execute(
+      'CREATE INDEX IF NOT EXISTS idx_scheduled_send_at ON scheduled_messages(sendAt)',
+    );
+    await db.execute(
+      'CREATE INDEX IF NOT EXISTS idx_scheduled_conversation ON scheduled_messages(conversationId, sendAt)',
     );
   }
 }

--- a/lib/database/scheduled_messages_db.dart
+++ b/lib/database/scheduled_messages_db.dart
@@ -1,0 +1,108 @@
+import 'package:prysm/database/message_schema_migrations.dart';
+import 'package:prysm/database/messages.dart';
+import 'package:prysm/database/messages_database.dart';
+import 'package:sqflite/sqflite.dart';
+
+/// Rows for messages queued to be sent at a future time.
+///
+/// The `body` column is always ciphertext (encrypted for self); callers own
+/// encrypting before insert and decrypting after read, so this DAO never sees
+/// plaintext.
+class ScheduledMessagesDb {
+  ScheduledMessagesDb._();
+
+  static Database? _testDatabase;
+
+  static Future<Database> _db() async {
+    if (_testDatabase != null) return _testDatabase!;
+    return MessagesDb.database;
+  }
+
+  static void setDatabaseForTest(Database? db) {
+    _testDatabase = db;
+  }
+
+  static Future<void> createTable(Database db) =>
+      MessageSchemaMigrations.createScheduledMessagesTable(db);
+
+  static Future<void> insert(Map<String, dynamic> row) async {
+    await MessagesDatabase.mutex.protect(() async {
+      final db = await _db();
+      await db.insert(
+        'scheduled_messages',
+        row,
+        conflictAlgorithm: ConflictAlgorithm.replace,
+      );
+    });
+  }
+
+  /// Rows whose send time has arrived, oldest first.
+  static Future<List<Map<String, dynamic>>> getDue(int nowMs) async {
+    return MessagesDatabase.mutex.protect(() async {
+      final db = await _db();
+      return db.query(
+        'scheduled_messages',
+        where: 'sendAt <= ?',
+        whereArgs: [nowMs],
+        orderBy: 'sendAt ASC',
+      );
+    });
+  }
+
+  /// Earliest `sendAt` still queued, or null when the queue is empty.
+  static Future<int?> getNextSendAt() async {
+    return MessagesDatabase.mutex.protect(() async {
+      final db = await _db();
+      final rows = await db.rawQuery(
+        'SELECT MIN(sendAt) AS next FROM scheduled_messages',
+      );
+      final value = rows.first['next'];
+      if (value is int) return value;
+      return value == null ? null : int.tryParse('$value');
+    });
+  }
+
+  static Future<List<Map<String, dynamic>>> getForConversation(
+    String conversationId,
+  ) async {
+    return MessagesDatabase.mutex.protect(() async {
+      final db = await _db();
+      return db.query(
+        'scheduled_messages',
+        where: 'conversationId = ?',
+        whereArgs: [conversationId],
+        orderBy: 'sendAt ASC',
+      );
+    });
+  }
+
+  static Future<int> countForConversation(String conversationId) async {
+    return MessagesDatabase.mutex.protect(() async {
+      final db = await _db();
+      final rows = await db.rawQuery(
+        'SELECT COUNT(*) AS c FROM scheduled_messages WHERE conversationId = ?',
+        [conversationId],
+      );
+      final value = rows.first['c'];
+      return value is int ? value : int.tryParse('$value') ?? 0;
+    });
+  }
+
+  static Future<void> delete(String id) async {
+    await MessagesDatabase.mutex.protect(() async {
+      final db = await _db();
+      await db.delete('scheduled_messages', where: 'id = ?', whereArgs: [id]);
+    });
+  }
+
+  static Future<void> deleteForConversation(String conversationId) async {
+    await MessagesDatabase.mutex.protect(() async {
+      final db = await _db();
+      await db.delete(
+        'scheduled_messages',
+        where: 'conversationId = ?',
+        whereArgs: [conversationId],
+      );
+    });
+  }
+}

--- a/lib/models/scheduled_message.dart
+++ b/lib/models/scheduled_message.dart
@@ -1,0 +1,24 @@
+/// A message the user chose to send at a future time.
+///
+/// [body] is the decrypted text; rows on disk keep it encrypted for self.
+class ScheduledMessage {
+  const ScheduledMessage({
+    required this.id,
+    required this.conversationId,
+    required this.isGroup,
+    required this.body,
+    required this.sendAt,
+    required this.createdAt,
+    this.replyTo,
+  });
+
+  final String id;
+  final String conversationId;
+  final bool isGroup;
+  final String body;
+  final String? replyTo;
+  final DateTime sendAt;
+  final DateTime createdAt;
+
+  bool isDueAt(DateTime now) => !sendAt.isAfter(now);
+}

--- a/lib/screens/chat.dart
+++ b/lib/screens/chat.dart
@@ -19,6 +19,7 @@ import 'package:prysm/util/file_bytes_reader.dart';
 import 'package:prysm/util/logging.dart';
 import 'package:url_launcher/url_launcher.dart';
 import 'package:prysm/services/message_draft_store.dart';
+import 'package:prysm/services/scheduled_message_service.dart';
 import 'package:prysm/services/block_service.dart';
 import 'package:prysm/services/call/call_manager.dart';
 import 'package:prysm/transport/transport_preference.dart';
@@ -920,6 +921,26 @@ class _ChatScreenState extends State<ChatScreen> {
         });
   }
 
+  Future<bool> _scheduleText(String text, DateTime sendAt) async {
+    try {
+      await ScheduledMessageService(
+        userId: widget.userId,
+        keyManager: widget.keyManager,
+      ).schedule(
+        conversationId: widget.peerId,
+        isGroup: false,
+        text: text,
+        sendAt: sendAt,
+        replyToId: _controller.replyToMessageId,
+      );
+    } catch (e) {
+      if (mounted) showPrysmToast(context, 'Could not schedule message: $e');
+      return false;
+    }
+    _controller.clearReplyState();
+    return true;
+  }
+
   Future<void> _dispatchFile({
     required Uint8List bytes,
     required String fileName,
@@ -1662,6 +1683,8 @@ class _ChatScreenState extends State<ChatScreen> {
                 onSendImage: _handleSendImage,
                 onSendFile: _handleSendFile,
                 onSendVoice: _controller.sendVoice,
+                onScheduleText:
+                    widget.detachedClient == null ? _scheduleText : null,
                 onTypingChanged: _controller.onComposerTypingChanged,
               ),
           ],

--- a/lib/screens/chat_profile_screen.dart
+++ b/lib/screens/chat_profile_screen.dart
@@ -15,6 +15,7 @@ import 'widgets/block_user_tile.dart';
 import 'widgets/contact_avatar.dart';
 import 'widgets/conversation_prefs_tiles.dart';
 import 'widgets/notification_mute_tile.dart';
+import 'widgets/scheduled_messages_tile.dart';
 import 'package:prysm/ui/core/prysm_button.dart';
 import 'package:prysm/ui/prysm_scaffold.dart';
 import 'package:prysm/ui/core/prysm_list_row.dart';
@@ -365,10 +366,20 @@ class _ChatProfileScreenState extends State<ChatProfileScreen> {
                     ),
                   ],
                 ),
-                child: NotificationMuteTile(
-                  target: MuteTarget.user,
-                  id: widget.peer.id,
-                  label: widget.peer.displayName,
+                child: Column(
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    ScheduledMessagesTile(
+                      userId: widget.userId,
+                      keyManager: widget.keyManager,
+                      conversationId: widget.peer.id,
+                    ),
+                    NotificationMuteTile(
+                      target: MuteTarget.user,
+                      id: widget.peer.id,
+                      label: widget.peer.displayName,
+                    ),
+                  ],
                 ),
               ),
               const SizedBox(height: 20),

--- a/lib/screens/group_chat.dart
+++ b/lib/screens/group_chat.dart
@@ -49,6 +49,7 @@ import 'package:prysm/services/message_actions_service.dart';
 import 'package:prysm/services/message_view_mapper.dart';
 import 'package:prysm/services/reaction_service.dart';
 import 'package:prysm/services/read_receipt_service.dart';
+import 'package:prysm/services/scheduled_message_service.dart';
 import 'package:prysm/services/chat_screen_controller.dart';
 import 'package:prysm/services/settings_service.dart';
 import 'package:prysm/database/message_read_receipts.dart';
@@ -944,6 +945,26 @@ class _GroupChatScreenState extends State<GroupChatScreen> {
     widget.reloadConversations();
   }
 
+  Future<bool> _scheduleText(String text, DateTime sendAt) async {
+    try {
+      await ScheduledMessageService(
+        userId: widget.userId,
+        keyManager: widget.keyManager,
+      ).schedule(
+        conversationId: widget.group.id,
+        isGroup: true,
+        text: text,
+        sendAt: sendAt,
+        replyToId: _controller.replyToMessageId,
+      );
+    } catch (e) {
+      if (mounted) showPrysmToast(context, 'Could not schedule message: $e');
+      return false;
+    }
+    _controller.clearReplyState();
+    return true;
+  }
+
   Future<void> _dispatchFile({
     required Uint8List bytes,
     required String fileName,
@@ -1578,6 +1599,8 @@ class _GroupChatScreenState extends State<GroupChatScreen> {
               onSendImage: _handleSendImage,
               onSendFile: _handleSendFile,
               onSendVoice: _controller.sendVoice,
+              onScheduleText:
+                  widget.detachedClient == null ? _scheduleText : null,
               onTypingChanged: _controller.onComposerTypingChanged,
             ),
           ],

--- a/lib/screens/group_settings_screen.dart
+++ b/lib/screens/group_settings_screen.dart
@@ -18,6 +18,7 @@ import 'package:prysm/screens/widgets/contact_avatar.dart';
 import 'package:prysm/util/db_helper.dart';
 import 'package:prysm/screens/widgets/conversation_prefs_tiles.dart';
 import 'package:prysm/screens/widgets/notification_mute_tile.dart';
+import 'package:prysm/screens/widgets/scheduled_messages_tile.dart';
 import 'package:prysm/services/notification_mute_service.dart';
 import 'package:prysm/util/key_manager.dart';
 import 'package:prysm/ui/core/prysm_button.dart';
@@ -432,6 +433,11 @@ class _GroupSettingsScreenState extends State<GroupSettingsScreen> {
                   label: _groupName,
                 ),
                 const PrysmDivider(),
+                ScheduledMessagesTile(
+                  userId: widget.userId,
+                  keyManager: widget.keyManager,
+                  conversationId: widget.group.id,
+                ),
                 if (_isAdmin && _members.length < maxGroupMembers)
                   PrysmListRow(
                     leading: const Icon(PrysmIcons.personAddOutlined),

--- a/lib/screens/home/home_screen.dart
+++ b/lib/screens/home/home_screen.dart
@@ -1652,7 +1652,10 @@ class _HomeScreenState extends State<HomeScreen> with WidgetsBindingObserver {
     }
     WidgetsBinding.instance.removeObserver(this);
     _searchController.dispose();
-    widget.torConnectionController.shutdown();
+    // Deliberately no shutdown() here: the controller is owned by _MyAppState
+    // and outlives this widget, so a rebuild that remounts HomeScreen would
+    // kill a Tor process the new instance still needs. Real exit stops Tor via
+    // quitApp() and the `detached` lifecycle branch below.
     super.dispose();
   }
 

--- a/lib/screens/message_composer.dart
+++ b/lib/screens/message_composer.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/widgets.dart';
+import 'package:prysm/screens/widgets/schedule_message_sheet.dart';
 import 'package:prysm/ui/core/prysm_button.dart';
 import 'package:prysm/ui/core/prysm_icons.dart';
 import 'package:prysm/ui/core/prysm_list_row.dart';
@@ -17,6 +18,7 @@ import 'package:prysm/services/message_draft_store.dart';
 import 'package:prysm/theme/prysm_theme.dart';
 import 'package:prysm/theme/prysm_tokens.dart';
 import 'package:prysm/util/desktop_platform.dart';
+import 'package:prysm/util/schedule_time_format.dart';
 import 'package:prysm/util/waveform_extractor.dart';
 
 class MessageComposer extends StatefulWidget {
@@ -24,6 +26,11 @@ class MessageComposer extends StatefulWidget {
   final VoidCallback onSendImage;
   final VoidCallback onSendFile;
   final Function(Uint8List bytes, int durationMs)? onSendVoice;
+
+  /// Queues [text] for delivery at [sendAt]. Returning false keeps the draft in
+  /// the composer. Long-pressing send is inert when this is null.
+  final Future<bool> Function(String text, DateTime sendAt)? onScheduleText;
+
   final ValueChanged<bool>? onTypingChanged;
   final VoidCallback? onLayoutChanged;
   final String? draftKey;
@@ -34,6 +41,7 @@ class MessageComposer extends StatefulWidget {
     required this.onSendImage,
     required this.onSendFile,
     this.onSendVoice,
+    this.onScheduleText,
     this.onTypingChanged,
     this.onLayoutChanged,
     this.draftKey,
@@ -116,6 +124,24 @@ class MessageComposerState extends State<MessageComposer> {
     final text = currentText.trim();
     if (text.isEmpty) return;
     widget.onSendText(text);
+    _clearComposer();
+  }
+
+  Future<void> _handleSchedule() async {
+    final schedule = widget.onScheduleText;
+    if (schedule == null) return;
+    final text = currentText.trim();
+    if (text.isEmpty) return;
+
+    final sendAt = await showScheduleMessageSheet(context: context);
+    if (sendAt == null || !mounted) return;
+    if (!await schedule(text, sendAt) || !mounted) return;
+
+    _clearComposer();
+    showPrysmToast(context, 'Will send ${formatScheduleLabel(sendAt)}');
+  }
+
+  void _clearComposer() {
     widget.onTypingChanged?.call(false);
     _textController.clear();
     setState(() {
@@ -405,7 +431,12 @@ class MessageComposerState extends State<MessageComposer> {
                   key: const ValueKey('send'),
                   icon: PrysmIcons.send,
                   color: tokens.accent,
+                  tooltip: widget.onScheduleText == null
+                      ? null
+                      : 'Send. Hold to schedule',
                   onPressed: _handleSend,
+                  onLongPress:
+                      widget.onScheduleText == null ? null : _handleSchedule,
                 ),
         ),
       ],

--- a/lib/screens/widgets/schedule_message_sheet.dart
+++ b/lib/screens/widgets/schedule_message_sheet.dart
@@ -1,0 +1,301 @@
+import 'package:flutter/widgets.dart';
+import 'package:prysm/theme/prysm_style_scope.dart';
+import 'package:prysm/theme/prysm_tokens.dart';
+import 'package:prysm/ui/core/prysm_button.dart';
+import 'package:prysm/ui/core/prysm_divider.dart';
+import 'package:prysm/ui/core/prysm_list_row.dart';
+import 'package:prysm/util/schedule_time_format.dart';
+
+/// How far ahead a message can be scheduled.
+const scheduleHorizonDays = 60;
+
+/// Asks the user when a message should be sent, returning null if dismissed.
+///
+/// Material's showDatePicker/showTimePicker cannot be used: the app root is a
+/// WidgetsApp, so there is no MaterialLocalizations ancestor.
+Future<DateTime?> showScheduleMessageSheet({
+  required BuildContext context,
+  DateTime? initial,
+}) {
+  return showPrysmSheet<DateTime>(
+    context: context,
+    builder: (ctx) => _ScheduleSheet(initial: initial),
+  );
+}
+
+class _ScheduleSheet extends StatefulWidget {
+  const _ScheduleSheet({this.initial});
+
+  final DateTime? initial;
+
+  @override
+  State<_ScheduleSheet> createState() => _ScheduleSheetState();
+}
+
+class _ScheduleSheetState extends State<_ScheduleSheet> {
+  static const _itemExtent = 40.0;
+  static const _wheelHeight = 200.0;
+
+  late final DateTime _firstDay;
+  late final List<DateTime> _days;
+
+  late final FixedExtentScrollController _dayController;
+  late final FixedExtentScrollController _hourController;
+  late final FixedExtentScrollController _minuteController;
+  late final FixedExtentScrollController _periodController;
+
+  late int _dayIndex;
+  late int _hourIndex;
+  late int _minuteIndex;
+  late int _periodIndex;
+
+  @override
+  void initState() {
+    super.initState();
+    final now = DateTime.now();
+    _firstDay = DateTime(now.year, now.month, now.day);
+    _days = List.generate(
+      scheduleHorizonDays,
+      (i) => _firstDay.add(Duration(days: i)),
+    );
+
+    final start = _clampToRange(widget.initial ?? _defaultStart(now));
+    _dayIndex = DateTime(start.year, start.month, start.day)
+        .difference(_firstDay)
+        .inDays;
+    _hourIndex = (start.hour % 12 == 0 ? 12 : start.hour % 12) - 1;
+    _minuteIndex = start.minute;
+    _periodIndex = start.hour >= 12 ? 1 : 0;
+
+    _dayController = FixedExtentScrollController(initialItem: _dayIndex);
+    _hourController = FixedExtentScrollController(initialItem: _hourIndex);
+    _minuteController = FixedExtentScrollController(initialItem: _minuteIndex);
+    _periodController = FixedExtentScrollController(initialItem: _periodIndex);
+  }
+
+  @override
+  void dispose() {
+    _dayController.dispose();
+    _hourController.dispose();
+    _minuteController.dispose();
+    _periodController.dispose();
+    super.dispose();
+  }
+
+  /// Next round half-hour an hour out, so the sheet opens on a sane value.
+  static DateTime _defaultStart(DateTime now) {
+    final rounded = now.add(const Duration(hours: 1));
+    return DateTime(
+      rounded.year,
+      rounded.month,
+      rounded.day,
+      rounded.hour + (rounded.minute < 30 ? 0 : 1),
+      rounded.minute < 30 ? 30 : 0,
+    );
+  }
+
+  DateTime _clampToRange(DateTime value) {
+    final last = _days.last;
+    if (value.isBefore(_firstDay)) return _defaultStart(DateTime.now());
+    if (value.isAfter(DateTime(last.year, last.month, last.day, 23, 59))) {
+      return DateTime(last.year, last.month, last.day, value.hour, value.minute);
+    }
+    return value;
+  }
+
+  DateTime get _selected {
+    final day = _days[_dayIndex];
+    final hour12 = _hourIndex + 1;
+    final hour24 = _periodIndex == 1 ? (hour12 % 12) + 12 : hour12 % 12;
+    return DateTime(day.year, day.month, day.day, hour24, _minuteIndex);
+  }
+
+  bool get _isValid => _selected.isAfter(DateTime.now());
+
+  String _dayLabel(DateTime day) {
+    final daysAway = day.difference(_firstDay).inDays;
+    if (daysAway == 0) return 'Today';
+    if (daysAway == 1) return 'Tomorrow';
+    return '${formatScheduleWeekday(day)} ${formatScheduleDate(day)}';
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final style = context.prysmStyle;
+    final tokens = style.tokens;
+
+    return Column(
+      mainAxisSize: MainAxisSize.min,
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        Padding(
+          padding: const EdgeInsets.fromLTRB(
+            PrysmTokens.spacing20,
+            PrysmTokens.spacing8,
+            PrysmTokens.spacing20,
+            PrysmTokens.spacing4,
+          ),
+          child: Text('Schedule message', style: style.titleStyle),
+        ),
+        Padding(
+          padding: const EdgeInsets.fromLTRB(
+            PrysmTokens.spacing20,
+            0,
+            PrysmTokens.spacing20,
+            PrysmTokens.spacing12,
+          ),
+          child: Text(
+            _isValid
+                ? 'Sends ${formatScheduleLabel(_selected)}'
+                : 'Choose a time in the future',
+            style: style.captionStyle.copyWith(
+              color: _isValid ? tokens.textSecondary : tokens.danger,
+            ),
+          ),
+        ),
+        const PrysmDivider(),
+        SizedBox(
+          height: _wheelHeight,
+          child: Stack(
+            children: [
+              Center(
+                child: Container(
+                  height: _itemExtent,
+                  margin: const EdgeInsets.symmetric(
+                    horizontal: PrysmTokens.spacing12,
+                  ),
+                  decoration: BoxDecoration(
+                    color: tokens.surfaceElevated,
+                    borderRadius:
+                        BorderRadius.circular(PrysmTokens.radiusChip),
+                  ),
+                ),
+              ),
+              Row(
+                children: [
+                  Expanded(
+                    flex: 5,
+                    child: _Wheel(
+                      controller: _dayController,
+                      itemExtent: _itemExtent,
+                      count: _days.length,
+                      selectedIndex: _dayIndex,
+                      onSelected: (i) => setState(() => _dayIndex = i),
+                      labelAt: (i) => _dayLabel(_days[i]),
+                    ),
+                  ),
+                  Expanded(
+                    flex: 2,
+                    child: _Wheel(
+                      controller: _hourController,
+                      itemExtent: _itemExtent,
+                      count: 12,
+                      selectedIndex: _hourIndex,
+                      onSelected: (i) => setState(() => _hourIndex = i),
+                      labelAt: (i) => '${i + 1}',
+                    ),
+                  ),
+                  Expanded(
+                    flex: 2,
+                    child: _Wheel(
+                      controller: _minuteController,
+                      itemExtent: _itemExtent,
+                      count: 60,
+                      selectedIndex: _minuteIndex,
+                      onSelected: (i) => setState(() => _minuteIndex = i),
+                      labelAt: (i) => i.toString().padLeft(2, '0'),
+                    ),
+                  ),
+                  Expanded(
+                    flex: 2,
+                    child: _Wheel(
+                      controller: _periodController,
+                      itemExtent: _itemExtent,
+                      count: 2,
+                      selectedIndex: _periodIndex,
+                      onSelected: (i) => setState(() => _periodIndex = i),
+                      labelAt: (i) => i == 0 ? 'AM' : 'PM',
+                    ),
+                  ),
+                ],
+              ),
+            ],
+          ),
+        ),
+        const PrysmDivider(),
+        Padding(
+          padding: const EdgeInsets.all(PrysmTokens.spacing16),
+          child: Row(
+            children: [
+              Expanded(
+                child: PrysmButton(
+                  label: 'Cancel',
+                  variant: PrysmButtonVariant.secondary,
+                  onPressed: () => Navigator.pop(context),
+                ),
+              ),
+              const SizedBox(width: PrysmTokens.spacing12),
+              Expanded(
+                child: PrysmButton(
+                  label: 'Schedule',
+                  onPressed:
+                      _isValid ? () => Navigator.pop(context, _selected) : null,
+                ),
+              ),
+            ],
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+class _Wheel extends StatelessWidget {
+  const _Wheel({
+    required this.controller,
+    required this.itemExtent,
+    required this.count,
+    required this.selectedIndex,
+    required this.onSelected,
+    required this.labelAt,
+  });
+
+  final FixedExtentScrollController controller;
+  final double itemExtent;
+  final int count;
+  final int selectedIndex;
+  final ValueChanged<int> onSelected;
+  final String Function(int index) labelAt;
+
+  @override
+  Widget build(BuildContext context) {
+    final style = context.prysmStyle;
+    return ListWheelScrollView.useDelegate(
+      controller: controller,
+      itemExtent: itemExtent,
+      physics: const FixedExtentScrollPhysics(),
+      perspective: 0.002,
+      diameterRatio: 1.6,
+      onSelectedItemChanged: onSelected,
+      childDelegate: ListWheelChildBuilderDelegate(
+        childCount: count,
+        builder: (ctx, index) {
+          final isSelected = index == selectedIndex;
+          return Center(
+            child: Text(
+              labelAt(index),
+              maxLines: 1,
+              overflow: TextOverflow.ellipsis,
+              style: style.bodyStyle.copyWith(
+                color: isSelected
+                    ? style.tokens.textPrimary
+                    : style.tokens.textMuted,
+                fontWeight: isSelected ? FontWeight.w600 : FontWeight.w400,
+              ),
+            ),
+          );
+        },
+      ),
+    );
+  }
+}

--- a/lib/screens/widgets/scheduled_messages_tile.dart
+++ b/lib/screens/widgets/scheduled_messages_tile.dart
@@ -1,0 +1,156 @@
+import 'package:flutter/widgets.dart';
+import 'package:prysm/models/scheduled_message.dart';
+import 'package:prysm/services/scheduled_message_service.dart';
+import 'package:prysm/theme/prysm_style_scope.dart';
+import 'package:prysm/theme/prysm_tokens.dart';
+import 'package:prysm/ui/core/prysm_dialog.dart';
+import 'package:prysm/ui/core/prysm_divider.dart';
+import 'package:prysm/ui/core/prysm_icons.dart';
+import 'package:prysm/ui/core/prysm_list_row.dart';
+import 'package:prysm/ui/core/prysm_toast.dart';
+import 'package:prysm/util/key_manager.dart';
+import 'package:prysm/util/schedule_time_format.dart';
+
+/// Settings row listing the conversation's scheduled messages, with a sheet to
+/// cancel them. Hidden entirely when nothing is queued.
+class ScheduledMessagesTile extends StatefulWidget {
+  const ScheduledMessagesTile({
+    required this.userId,
+    required this.keyManager,
+    required this.conversationId,
+    super.key,
+  });
+
+  final String userId;
+  final KeyManager keyManager;
+  final String conversationId;
+
+  @override
+  State<ScheduledMessagesTile> createState() => _ScheduledMessagesTileState();
+}
+
+class _ScheduledMessagesTileState extends State<ScheduledMessagesTile> {
+  late final ScheduledMessageService _service;
+  List<ScheduledMessage> _pending = const [];
+  bool _loaded = false;
+
+  @override
+  void initState() {
+    super.initState();
+    _service = ScheduledMessageService(
+      userId: widget.userId,
+      keyManager: widget.keyManager,
+    );
+    _load();
+  }
+
+  Future<void> _load() async {
+    final pending = await _service.pendingFor(widget.conversationId);
+    if (!mounted) return;
+    setState(() {
+      _pending = pending;
+      _loaded = true;
+    });
+  }
+
+  Future<void> _cancel(ScheduledMessage message) async {
+    await _service.cancel(message.id);
+    if (!mounted) return;
+    showPrysmToast(context, 'Scheduled message cancelled');
+    await _load();
+  }
+
+  Future<void> _openList() async {
+    await showPrysmSheet<void>(
+      context: context,
+      builder: (ctx) => _ScheduledListSheet(
+        messages: _pending,
+        onCancel: (message) async {
+          Navigator.pop(ctx);
+          await _cancel(message);
+        },
+      ),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    if (!_loaded || _pending.isEmpty) return const SizedBox.shrink();
+
+    final next = _pending.first;
+    return Column(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        PrysmListRow(
+          leading: const Icon(PrysmIcons.accessTime),
+          title: _pending.length == 1
+              ? '1 scheduled message'
+              : '${_pending.length} scheduled messages',
+          subtitle: 'Next: ${formatScheduleLabel(next.sendAt)}',
+          trailing: const Icon(PrysmIcons.chevronRight),
+          onTap: _openList,
+        ),
+        const PrysmDivider(),
+      ],
+    );
+  }
+}
+
+class _ScheduledListSheet extends StatelessWidget {
+  const _ScheduledListSheet({required this.messages, required this.onCancel});
+
+  final List<ScheduledMessage> messages;
+  final Future<void> Function(ScheduledMessage message) onCancel;
+
+  @override
+  Widget build(BuildContext context) {
+    final style = context.prysmStyle;
+    return Column(
+      mainAxisSize: MainAxisSize.min,
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        Padding(
+          padding: const EdgeInsets.fromLTRB(
+            PrysmTokens.spacing20,
+            PrysmTokens.spacing8,
+            PrysmTokens.spacing20,
+            PrysmTokens.spacing12,
+          ),
+          child: Text('Scheduled messages', style: style.titleStyle),
+        ),
+        const PrysmDivider(),
+        Flexible(
+          child: ListView.separated(
+            shrinkWrap: true,
+            itemCount: messages.length,
+            separatorBuilder: (_, _) => const PrysmDivider(),
+            itemBuilder: (ctx, index) {
+              final message = messages[index];
+              return PrysmListRow(
+                title: formatScheduleLabel(message.sendAt),
+                subtitle: message.body,
+                trailing: PrysmTextButton(
+                  label: 'Cancel',
+                  color: style.tokens.danger,
+                  onPressed: () async {
+                    final confirmed = await showPrysmConfirmDialog(
+                      context: ctx,
+                      title: 'Cancel scheduled message?',
+                      content: Text(
+                        'It will not be sent.',
+                        style: style.bodyStyle,
+                      ),
+                      confirmLabel: 'Cancel message',
+                      cancelLabel: 'Keep',
+                    );
+                    if (confirmed == true) await onCancel(message);
+                  },
+                ),
+              );
+            },
+          ),
+        ),
+      ],
+    );
+  }
+}

--- a/lib/services/scheduled_message_service.dart
+++ b/lib/services/scheduled_message_service.dart
@@ -1,0 +1,201 @@
+import 'package:prysm/database/scheduled_messages_db.dart';
+import 'package:prysm/models/scheduled_message.dart';
+import 'package:prysm/services/chat_service.dart';
+import 'package:prysm/services/group_chat_service.dart';
+import 'package:prysm/services/group_service.dart';
+import 'package:prysm/util/key_manager.dart';
+import 'package:prysm/util/logging.dart';
+import 'package:prysm/util/scheduled_activity_notifier.dart';
+import 'package:uuid/uuid.dart';
+
+/// Sends one scheduled message. Returns false to keep the row queued for a
+/// later attempt.
+typedef ScheduledSender = Future<bool> Function(ScheduledMessage message);
+
+/// Stores messages the user chose to send later, and delivers them once their
+/// time has come.
+///
+/// Bodies are encrypted for self at rest, so a queued message is never
+/// plaintext on disk. A message whose time passed while the app was closed is
+/// sent on the next flush rather than dropped.
+class ScheduledMessageService {
+  ScheduledMessageService({
+    required this.userId,
+    required this.keyManager,
+    ScheduledSender? directSender,
+    ScheduledSender? groupSender,
+  })  : _directSender = directSender,
+        _groupSender = groupSender;
+
+  final String userId;
+  final KeyManager keyManager;
+  final ScheduledSender? _directSender;
+  final ScheduledSender? _groupSender;
+
+  bool _flushing = false;
+
+  Future<ScheduledMessage> schedule({
+    required String conversationId,
+    required bool isGroup,
+    required String text,
+    required DateTime sendAt,
+    String? replyToId,
+  }) async {
+    final id = const Uuid().v4();
+    final createdAt = DateTime.now();
+    await ScheduledMessagesDb.insert({
+      'id': id,
+      'conversationId': conversationId,
+      'isGroup': isGroup ? 1 : 0,
+      'body': await keyManager.encryptForSelf(text),
+      'replyTo': replyToId,
+      'sendAt': sendAt.millisecondsSinceEpoch,
+      'createdAt': createdAt.millisecondsSinceEpoch,
+    });
+    ScheduledActivityNotifier.instance.notify();
+    return ScheduledMessage(
+      id: id,
+      conversationId: conversationId,
+      isGroup: isGroup,
+      body: text,
+      replyTo: replyToId,
+      sendAt: sendAt,
+      createdAt: createdAt,
+    );
+  }
+
+  Future<List<ScheduledMessage>> pendingFor(String conversationId) async {
+    final rows = await ScheduledMessagesDb.getForConversation(conversationId);
+    return _decodeRows(rows);
+  }
+
+  Future<int> pendingCountFor(String conversationId) =>
+      ScheduledMessagesDb.countForConversation(conversationId);
+
+  /// When the earliest queued message comes due, or null when nothing is
+  /// queued. Lets callers wake up at that exact moment instead of polling.
+  Future<DateTime?> nextDueAt() async {
+    final at = await ScheduledMessagesDb.getNextSendAt();
+    return at == null ? null : DateTime.fromMillisecondsSinceEpoch(at);
+  }
+
+  Future<void> cancel(String id) async {
+    await ScheduledMessagesDb.delete(id);
+    ScheduledActivityNotifier.instance.notify();
+  }
+
+  Future<void> cancelForConversation(String conversationId) async {
+    await ScheduledMessagesDb.deleteForConversation(conversationId);
+    ScheduledActivityNotifier.instance.notify();
+  }
+
+  /// Sends every message whose time has arrived. Returns true when at least one
+  /// was delivered, so callers can report progress like the other flushers.
+  Future<bool> flushDue({DateTime? now}) async {
+    if (_flushing) return false;
+    _flushing = true;
+    try {
+      final at = now ?? DateTime.now();
+      final due = await _decodeRows(
+        await ScheduledMessagesDb.getDue(at.millisecondsSinceEpoch),
+      );
+      if (due.isEmpty) return false;
+
+      var sent = 0;
+      for (final message in due) {
+        if (await _send(message)) {
+          await ScheduledMessagesDb.delete(message.id);
+          sent++;
+        }
+      }
+      Logging.info(
+        'Flushed scheduled messages: $sent/${due.length} sent',
+        'ScheduledMessageService',
+      );
+      return sent > 0;
+    } finally {
+      _flushing = false;
+    }
+  }
+
+  Future<bool> _send(ScheduledMessage message) async {
+    try {
+      final sender = message.isGroup
+          ? (_groupSender ?? _sendToGroup)
+          : (_directSender ?? _sendToPeer);
+      return await sender(message);
+    } catch (e) {
+      Logging.error(
+        'Scheduled send failed (${message.id}): $e',
+        'ScheduledMessageService',
+      );
+      return false;
+    }
+  }
+
+  Future<bool> _sendToPeer(ScheduledMessage message) async {
+    final service = ChatService(
+      userId: userId,
+      peerId: message.conversationId,
+      keyManager: keyManager,
+    );
+    try {
+      if (!await service.initialize(null)) return false;
+      final sentId = await service.sendTextMessage(
+        message.body,
+        replyToId: message.replyTo,
+      );
+      return sentId != null;
+    } finally {
+      service.dispose();
+    }
+  }
+
+  Future<bool> _sendToGroup(ScheduledMessage message) async {
+    final service = GroupChatService(
+      userId: userId,
+      groupId: message.conversationId,
+      keyManager: keyManager,
+      groupService: GroupService(userId: userId, keyManager: keyManager),
+    );
+    try {
+      if (!await service.initialize()) return false;
+      final sentId = await service.sendTextMessage(
+        message.body,
+        replyToId: message.replyTo,
+      );
+      return sentId != null;
+    } finally {
+      service.dispose();
+    }
+  }
+
+  Future<List<ScheduledMessage>> _decodeRows(
+    List<Map<String, dynamic>> rows,
+  ) async {
+    final result = <ScheduledMessage>[];
+    for (final row in rows) {
+      final id = row['id'] as String;
+      try {
+        result.add(
+          ScheduledMessage(
+            id: id,
+            conversationId: row['conversationId'] as String,
+            isGroup: (row['isGroup'] as int? ?? 0) == 1,
+            body: await keyManager.decryptMessage(row['body'] as String),
+            replyTo: row['replyTo'] as String?,
+            sendAt: DateTime.fromMillisecondsSinceEpoch(row['sendAt'] as int),
+            createdAt:
+                DateTime.fromMillisecondsSinceEpoch(row['createdAt'] as int),
+          ),
+        );
+      } catch (e) {
+        Logging.error(
+          'Scheduled message decrypt failed ($id): $e',
+          'ScheduledMessageService',
+        );
+      }
+    }
+    return result;
+  }
+}

--- a/lib/services/sync_coordinator.dart
+++ b/lib/services/sync_coordinator.dart
@@ -7,9 +7,12 @@ import 'package:prysm/services/message_modify_service.dart';
 import 'package:prysm/services/reaction_service.dart';
 import 'package:prysm/services/read_receipt_service.dart';
 import 'package:prysm/services/group_service.dart';
+import 'package:prysm/services/scheduled_message_service.dart';
 import 'package:prysm/util/key_manager.dart';
+import 'package:prysm/util/logging.dart';
 import 'package:prysm/util/pending_message_db_helper.dart';
 import 'package:prysm/util/pending_activity_notifier.dart';
+import 'package:prysm/util/scheduled_activity_notifier.dart';
 import 'package:prysm/util/battery_saver_policy.dart';
 import 'package:prysm/util/tor_runtime_gate.dart';
 import 'package:prysm/util/tor_service.dart';
@@ -21,26 +24,48 @@ class SyncCoordinator {
   final TorManager torManager;
   final bool Function() isTorStopped;
 
+  /// Longest a send timer is armed for. Scheduled messages can sit for weeks,
+  /// so the wait is chopped into hops that recompute the remaining delay —
+  /// which also absorbs suspends and clock changes.
+  static const Duration _maxArmDelay = Duration(hours: 1);
+
   Timer? _tickTimer;
   Timer? _pendingFlushDebounce;
+  Timer? _scheduledTimer;
   StreamSubscription<void>? _pendingActivitySub;
+  StreamSubscription<void>? _scheduledActivitySub;
   bool _flushing = false;
   bool _hasPendingBacklog = false;
+  bool _disposed = false;
+
+  /// Bumped on every arm request so a slower in-flight arm loses to a newer one
+  /// instead of leaving a stale timer behind.
+  int _armGeneration = 0;
 
   SyncCoordinator({
     required this.userId,
     required this.keyManager,
     required this.torManager,
     required this.isTorStopped,
-  });
+  }) : _scheduledMessages = ScheduledMessageService(
+          userId: userId,
+          keyManager: keyManager,
+        );
+
+  final ScheduledMessageService _scheduledMessages;
 
   void dispose() {
     _tickTimer?.cancel();
     _tickTimer = null;
     _pendingFlushDebounce?.cancel();
     _pendingFlushDebounce = null;
+    _scheduledTimer?.cancel();
+    _scheduledTimer = null;
     _pendingActivitySub?.cancel();
     _pendingActivitySub = null;
+    _scheduledActivitySub?.cancel();
+    _scheduledActivitySub = null;
+    _disposed = true;
   }
 
   Duration get _tickInterval {
@@ -59,6 +84,63 @@ class SyncCoordinator {
         unawaited(flushAllPending());
       });
     });
+    _scheduledActivitySub ??=
+        ScheduledActivityNotifier.instance.onChanged.listen((_) {
+      // A message was just scheduled or cancelled: the earliest due time moved,
+      // so re-aim the timer rather than waiting out the old one.
+      unawaited(_armScheduledTimer());
+    });
+    unawaited(_armScheduledTimer());
+  }
+
+  /// Arms a one-shot timer for the moment the next scheduled message is due.
+  ///
+  /// Kept off [flushAllPending] on purpose: that method holds [_flushing] for
+  /// as long as the retry queues take, and a single unreachable peer can stall
+  /// them for minutes. A scheduled message must go out at its time regardless.
+  Future<void> _armScheduledTimer({Duration? minDelay}) async {
+    final generation = ++_armGeneration;
+    _scheduledTimer?.cancel();
+    _scheduledTimer = null;
+    if (_disposed) return;
+
+    final DateTime? next;
+    try {
+      next = await _scheduledMessages.nextDueAt();
+    } catch (e) {
+      Logging.error(
+        'Could not read next scheduled time: $e',
+        'SyncCoordinator',
+      );
+      return;
+    }
+    if (_disposed || generation != _armGeneration) return;
+    // Nothing queued; ScheduledActivityNotifier re-arms us on the next insert.
+    if (next == null) return;
+
+    var wait = next.difference(DateTime.now());
+    if (wait.isNegative) wait = Duration.zero;
+    if (minDelay != null && wait < minDelay) wait = minDelay;
+    if (wait > _maxArmDelay) wait = _maxArmDelay;
+
+    _scheduledTimer = Timer(wait, () => unawaited(_flushScheduled()));
+  }
+
+  Future<void> _flushScheduled() async {
+    try {
+      if (TorRuntimeGate.blocked || isTorStopped()) return;
+      if (await _scheduledMessages.flushDue()) {
+        PendingActivityNotifier.instance.notify();
+      }
+    } catch (e) {
+      Logging.error('Scheduled flush failed: $e', 'SyncCoordinator');
+    } finally {
+      // A row still due after this attempt means Tor is down or the send
+      // failed, so hold off instead of re-firing on an already-past time.
+      await _armScheduledTimer(
+        minDelay: BatterySaverPolicy.scheduledMessageRetry(),
+      );
+    }
   }
 
   void _scheduleTick(Duration interval) {
@@ -159,6 +241,9 @@ class SyncCoordinator {
 
   /// Call when Tor transitions to connected — immediate flush.
   Future<bool> onTorReconnected() async {
+    // Scheduled sends get their own kick: anything that came due while Tor was
+    // down should not have to wait for the retry queues to finish first.
+    unawaited(_armScheduledTimer());
     return flushAllPending();
   }
 

--- a/lib/ui/chat/prysm_chat_composer_column.dart
+++ b/lib/ui/chat/prysm_chat_composer_column.dart
@@ -14,6 +14,7 @@ class PrysmChatComposerColumn extends StatelessWidget {
     this.replyPreview,
     this.typingTypistNames = const [],
     this.onSendVoice,
+    this.onScheduleText,
     this.onTypingChanged,
     this.draftKey,
     this.topBanner,
@@ -26,6 +27,7 @@ class PrysmChatComposerColumn extends StatelessWidget {
   final VoidCallback onSendImage;
   final VoidCallback onSendFile;
   final void Function(Uint8List bytes, int durationMs)? onSendVoice;
+  final Future<bool> Function(String text, DateTime sendAt)? onScheduleText;
   final ValueChanged<bool>? onTypingChanged;
   final String? draftKey;
   final Widget? topBanner;
@@ -45,6 +47,7 @@ class PrysmChatComposerColumn extends StatelessWidget {
           onSendImage: onSendImage,
           onSendFile: onSendFile,
           onSendVoice: onSendVoice,
+          onScheduleText: onScheduleText,
           onTypingChanged: onTypingChanged,
         ),
       ],

--- a/lib/ui/core/prysm_button.dart
+++ b/lib/ui/core/prysm_button.dart
@@ -59,6 +59,7 @@ class PrysmIconButton extends StatelessWidget {
     required this.onPressed,
     this.color,
     this.tooltip,
+    this.onLongPress,
     this.onLongPressStart,
     super.key,
   });
@@ -67,6 +68,7 @@ class PrysmIconButton extends StatelessWidget {
   final VoidCallback? onPressed;
   final String? tooltip;
   final Color? color;
+  final VoidCallback? onLongPress;
   final GestureLongPressStartCallback? onLongPressStart;
 
   @override
@@ -75,6 +77,7 @@ class PrysmIconButton extends StatelessWidget {
     final iconColor = color ?? tokens.textSecondary;
     final button = PrysmPressable(
       onTap: onPressed,
+      onLongPress: onLongPress,
       onLongPressStart: onLongPressStart,
       borderRadius: BorderRadius.circular(PrysmTokens.radiusButton),
       child: SizedBox(

--- a/lib/util/battery_saver_policy.dart
+++ b/lib/util/battery_saver_policy.dart
@@ -16,6 +16,12 @@ class BatterySaverPolicy {
       ? const Duration(seconds: 30)
       : const Duration(seconds: 10);
 
+  /// Wait before retrying a scheduled message whose send just failed, so an
+  /// overdue row cannot spin the send timer.
+  static Duration scheduledMessageRetry([bool? saving]) => (saving ?? active)
+      ? const Duration(seconds: 30)
+      : const Duration(seconds: 10);
+
   static Duration syncTickIdle([bool? saving]) => (saving ?? active)
       ? const Duration(seconds: 120)
       : const Duration(seconds: 30);

--- a/lib/util/schedule_time_format.dart
+++ b/lib/util/schedule_time_format.dart
@@ -1,0 +1,42 @@
+/// Formatting for scheduled-send times.
+///
+/// The app has no shared date formatter and no intl dependency, so these
+/// mirror the hand-rolled helpers in notification_mute_sheet.dart.
+library;
+
+const _months = [
+  'Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun',
+  'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec',
+];
+
+const _weekdays = [
+  'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun',
+];
+
+String formatScheduleClock(DateTime dt) {
+  final hour = dt.hour % 12 == 0 ? 12 : dt.hour % 12;
+  final minute = dt.minute.toString().padLeft(2, '0');
+  final period = dt.hour >= 12 ? 'PM' : 'AM';
+  return '$hour:$minute $period';
+}
+
+String formatScheduleDate(DateTime dt) =>
+    '${_months[dt.month - 1]} ${dt.day}';
+
+String formatScheduleWeekday(DateTime dt) => _weekdays[dt.weekday - 1];
+
+/// "Today at 4:30 PM" / "Tomorrow at 9:00 AM" / "Thu, Aug 6 at 9:00 AM".
+String formatScheduleLabel(DateTime sendAt, {DateTime? now}) {
+  final reference = now ?? DateTime.now();
+  final today = DateTime(reference.year, reference.month, reference.day);
+  final target = DateTime(sendAt.year, sendAt.month, sendAt.day);
+  final daysAway = target.difference(today).inDays;
+  final time = formatScheduleClock(sendAt);
+
+  if (daysAway == 0) return 'Today at $time';
+  if (daysAway == 1) return 'Tomorrow at $time';
+  if (daysAway > 1 && daysAway < 7) {
+    return '${formatScheduleWeekday(sendAt)} at $time';
+  }
+  return '${formatScheduleWeekday(sendAt)}, ${formatScheduleDate(sendAt)} at $time';
+}

--- a/lib/util/scheduled_activity_notifier.dart
+++ b/lib/util/scheduled_activity_notifier.dart
@@ -1,0 +1,21 @@
+import 'dart:async';
+
+/// Fired when the scheduled-message queue changes (schedule or cancel).
+///
+/// [SyncCoordinator] listens so it can re-arm its send timer for the new
+/// earliest due time instead of waiting out the previous one.
+class ScheduledActivityNotifier {
+  ScheduledActivityNotifier._();
+  static final ScheduledActivityNotifier instance =
+      ScheduledActivityNotifier._();
+
+  final _controller = StreamController<void>.broadcast();
+
+  Stream<void> get onChanged => _controller.stream;
+
+  void notify() {
+    if (!_controller.isClosed) {
+      _controller.add(null);
+    }
+  }
+}

--- a/test/message_schema_migrations_test.dart
+++ b/test/message_schema_migrations_test.dart
@@ -73,6 +73,7 @@ void main() {
       expect(await _tableExists(db, 'message_reactions'), isTrue);
       expect(await _tableExists(db, 'message_read_receipts'), isTrue);
       expect(await _tableExists(db, 'self_messages'), isTrue);
+      expect(await _tableExists(db, 'scheduled_messages'), isTrue);
 
       await db.close();
     });
@@ -192,6 +193,7 @@ void main() {
       expect(await _tableExists(db, 'message_reactions'), isTrue);
       expect(await _tableExists(db, 'message_read_receipts'), isTrue);
       expect(await _tableExists(db, 'self_messages'), isTrue);
+      expect(await _tableExists(db, 'scheduled_messages'), isTrue);
 
       final indexes = (await db.rawQuery('PRAGMA index_list(messages)'))
           .map((r) => r['name'])
@@ -270,6 +272,8 @@ void main() {
 
       // v10 still runs since 9 < 10.
       expect(await _tableExists(db, 'self_messages'), isTrue);
+      // v12 runs too, so an already-v9 install still gains scheduled sends.
+      expect(await _tableExists(db, 'scheduled_messages'), isTrue);
 
       // v9 is gated out at oldVersion=9 (9 < 9 is false): neither the
       // read_receipts table nor the readAt reset happen on this call.

--- a/test/schedule_time_format_test.dart
+++ b/test/schedule_time_format_test.dart
@@ -1,0 +1,41 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:prysm/util/schedule_time_format.dart';
+
+void main() {
+  final now = DateTime(2026, 8, 3, 10, 0); // Monday
+
+  test('midnight and noon use 12-hour clock, not 0', () {
+    expect(formatScheduleClock(DateTime(2026, 8, 3, 0, 5)), '12:05 AM');
+    expect(formatScheduleClock(DateTime(2026, 8, 3, 12, 0)), '12:00 PM');
+    expect(formatScheduleClock(DateTime(2026, 8, 3, 13, 7)), '1:07 PM');
+  });
+
+  test('today and tomorrow are named', () {
+    expect(
+      formatScheduleLabel(DateTime(2026, 8, 3, 16, 30), now: now),
+      'Today at 4:30 PM',
+    );
+    expect(
+      formatScheduleLabel(DateTime(2026, 8, 4, 9, 0), now: now),
+      'Tomorrow at 9:00 AM',
+    );
+  });
+
+  test('within the week uses the weekday, beyond it adds the date', () {
+    expect(
+      formatScheduleLabel(DateTime(2026, 8, 6, 9, 0), now: now),
+      'Thu at 9:00 AM',
+    );
+    expect(
+      formatScheduleLabel(DateTime(2026, 8, 13, 9, 0), now: now),
+      'Thu, Aug 13 at 9:00 AM',
+    );
+  });
+
+  test('a later time on the same day still counts as today', () {
+    expect(
+      formatScheduleLabel(DateTime(2026, 8, 3, 23, 59), now: now),
+      'Today at 11:59 PM',
+    );
+  });
+}

--- a/test/scheduled_message_service_test.dart
+++ b/test/scheduled_message_service_test.dart
@@ -1,0 +1,258 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:prysm/crypto/identity.dart';
+import 'package:prysm/database/scheduled_messages_db.dart';
+import 'package:prysm/models/scheduled_message.dart';
+import 'package:prysm/services/scheduled_message_service.dart';
+import 'package:prysm/util/key_manager.dart';
+import 'package:prysm/util/scheduled_activity_notifier.dart';
+import 'package:sqflite_common_ffi/sqflite_ffi.dart';
+
+void main() {
+  late KeyManager keyManager;
+
+  setUpAll(() {
+    sqfliteFfiInit();
+    databaseFactory = databaseFactoryFfi;
+  });
+
+  setUp(() async {
+    final db = await databaseFactory.openDatabase(
+      '${inMemoryDatabasePath}_${DateTime.now().microsecondsSinceEpoch}',
+      options: OpenDatabaseOptions(
+        version: 1,
+        onCreate: (db, version) => ScheduledMessagesDb.createTable(db),
+      ),
+    );
+    ScheduledMessagesDb.setDatabaseForTest(db);
+    keyManager = KeyManager.fromIdentity(await IdentityKeyPair.generate());
+  });
+
+  tearDown(() => ScheduledMessagesDb.setDatabaseForTest(null));
+
+  ScheduledMessageService serviceWith({
+    List<ScheduledMessage>? directSent,
+    List<ScheduledMessage>? groupSent,
+    bool succeed = true,
+  }) {
+    return ScheduledMessageService(
+      userId: 'me.onion',
+      keyManager: keyManager,
+      directSender: (m) async {
+        directSent?.add(m);
+        return succeed;
+      },
+      groupSender: (m) async {
+        groupSent?.add(m);
+        return succeed;
+      },
+    );
+  }
+
+  test('schedule stores the body encrypted, never as plaintext', () async {
+    final service = serviceWith();
+    await service.schedule(
+      conversationId: 'peer.onion',
+      isGroup: false,
+      text: 'secret plan',
+      sendAt: DateTime.now().add(const Duration(hours: 1)),
+    );
+
+    final rows = await ScheduledMessagesDb.getForConversation('peer.onion');
+    expect(rows.length, 1);
+    expect(rows.first['body'], isNot(contains('secret plan')));
+
+    final pending = await service.pendingFor('peer.onion');
+    expect(pending.single.body, 'secret plan');
+  });
+
+  test('flushDue only sends messages whose time has arrived', () async {
+    final service = serviceWith();
+    final now = DateTime.now();
+    await service.schedule(
+      conversationId: 'peer.onion',
+      isGroup: false,
+      text: 'due',
+      sendAt: now.subtract(const Duration(minutes: 5)),
+    );
+    await service.schedule(
+      conversationId: 'peer.onion',
+      isGroup: false,
+      text: 'later',
+      sendAt: now.add(const Duration(hours: 2)),
+    );
+
+    final sent = <ScheduledMessage>[];
+    expect(await serviceWith(directSent: sent).flushDue(now: now), isTrue);
+
+    expect(sent.map((m) => m.body).toList(), ['due']);
+    final remaining = await service.pendingFor('peer.onion');
+    expect(remaining.single.body, 'later');
+  });
+
+  test('a message overdue from a previous run is still sent, not dropped',
+      () async {
+    final service = serviceWith();
+    await service.schedule(
+      conversationId: 'peer.onion',
+      isGroup: false,
+      text: 'missed while app was closed',
+      sendAt: DateTime.now().subtract(const Duration(days: 3)),
+    );
+
+    final sent = <ScheduledMessage>[];
+    await serviceWith(directSent: sent).flushDue();
+
+    expect(sent.single.body, 'missed while app was closed');
+    expect(await service.pendingCountFor('peer.onion'), 0);
+  });
+
+  test('a failed send stays queued for the next flush', () async {
+    final service = serviceWith();
+    await service.schedule(
+      conversationId: 'peer.onion',
+      isGroup: false,
+      text: 'retry me',
+      sendAt: DateTime.now().subtract(const Duration(minutes: 1)),
+    );
+
+    expect(await serviceWith(succeed: false).flushDue(), isFalse);
+    expect(await service.pendingCountFor('peer.onion'), 1);
+
+    final sent = <ScheduledMessage>[];
+    expect(await serviceWith(directSent: sent).flushDue(), isTrue);
+    expect(sent.single.body, 'retry me');
+    expect(await service.pendingCountFor('peer.onion'), 0);
+  });
+
+  test('group messages route to the group sender', () async {
+    final service = serviceWith();
+    await service.schedule(
+      conversationId: 'group-1',
+      isGroup: true,
+      text: 'hi team',
+      sendAt: DateTime.now().subtract(const Duration(minutes: 1)),
+    );
+
+    final direct = <ScheduledMessage>[];
+    final group = <ScheduledMessage>[];
+    await serviceWith(directSent: direct, groupSent: group).flushDue();
+
+    expect(direct, isEmpty);
+    expect(group.single.body, 'hi team');
+    expect(group.single.isGroup, isTrue);
+  });
+
+  test('cancel removes a pending message without sending it', () async {
+    final service = serviceWith();
+    final scheduled = await service.schedule(
+      conversationId: 'peer.onion',
+      isGroup: false,
+      text: 'never mind',
+      sendAt: DateTime.now().subtract(const Duration(minutes: 1)),
+    );
+
+    await service.cancel(scheduled.id);
+
+    final sent = <ScheduledMessage>[];
+    expect(await serviceWith(directSent: sent).flushDue(), isFalse);
+    expect(sent, isEmpty);
+  });
+
+  test('pending list is ordered by send time and scoped per conversation',
+      () async {
+    final service = serviceWith();
+    final now = DateTime.now();
+    await service.schedule(
+      conversationId: 'peer.onion',
+      isGroup: false,
+      text: 'second',
+      sendAt: now.add(const Duration(hours: 2)),
+    );
+    await service.schedule(
+      conversationId: 'peer.onion',
+      isGroup: false,
+      text: 'first',
+      sendAt: now.add(const Duration(hours: 1)),
+    );
+    await service.schedule(
+      conversationId: 'other.onion',
+      isGroup: false,
+      text: 'elsewhere',
+      sendAt: now.add(const Duration(hours: 1)),
+    );
+
+    final pending = await service.pendingFor('peer.onion');
+    expect(pending.map((m) => m.body).toList(), ['first', 'second']);
+    expect(await service.pendingCountFor('other.onion'), 1);
+  });
+
+  test('nextDueAt reports the earliest queued time, or null when empty',
+      () async {
+    final service = serviceWith();
+    expect(await service.nextDueAt(), isNull);
+
+    final now = DateTime.now();
+    final soon = now.add(const Duration(minutes: 5));
+    await service.schedule(
+      conversationId: 'peer.onion',
+      isGroup: false,
+      text: 'later',
+      sendAt: now.add(const Duration(hours: 3)),
+    );
+    await service.schedule(
+      conversationId: 'group-1',
+      isGroup: true,
+      text: 'sooner',
+      sendAt: soon,
+    );
+
+    expect(
+      await service.nextDueAt(),
+      DateTime.fromMillisecondsSinceEpoch(soon.millisecondsSinceEpoch),
+    );
+  });
+
+  test('nextDueAt skips ahead once the earliest message is sent', () async {
+    final service = serviceWith();
+    final now = DateTime.now();
+    final later = now.add(const Duration(hours: 3));
+    await service.schedule(
+      conversationId: 'peer.onion',
+      isGroup: false,
+      text: 'overdue',
+      sendAt: now.subtract(const Duration(minutes: 1)),
+    );
+    await service.schedule(
+      conversationId: 'peer.onion',
+      isGroup: false,
+      text: 'later',
+      sendAt: later,
+    );
+
+    expect(await service.flushDue(), isTrue);
+    expect(
+      await service.nextDueAt(),
+      DateTime.fromMillisecondsSinceEpoch(later.millisecondsSinceEpoch),
+    );
+  });
+
+  test('scheduling and cancelling both announce the queue changed', () async {
+    final service = serviceWith();
+    final events = <void>[];
+    final sub = ScheduledActivityNotifier.instance.onChanged.listen(events.add);
+    addTearDown(sub.cancel);
+
+    final message = await service.schedule(
+      conversationId: 'peer.onion',
+      isGroup: false,
+      text: 'hello',
+      sendAt: DateTime.now().add(const Duration(hours: 1)),
+    );
+    await pumpEventQueue();
+    expect(events.length, 1);
+
+    await service.cancel(message.id);
+    await pumpEventQueue();
+    expect(events.length, 2);
+  });
+}


### PR DESCRIPTION
Long-pressing the send button opens a date/time picker; the message is queued and delivered once its time arrives, in both direct chats and groups. A message whose time passed while the app was closed is sent on the next flush rather than dropped.

Queued bodies are encrypted for self at rest, so a pending message is never plaintext on disk. Pending messages are listed and cancellable from the per-chat settings screen.

Sends are driven by a dedicated one-shot timer in SyncCoordinator armed at the exact due instant, deliberately kept off flushAllPending: that method holds its _flushing guard for as long as the retry queues take, and a single unreachable peer can stall them for minutes.

Also stops HomeScreen.dispose() from shutting Tor down. The controller is owned by _MyAppState and outlives the widget, so a rebuild that remounts HomeScreen killed a Tor process the new instance still needed, which left every pending queue blocked. Real exit still stops Tor via quitApp() and the detached lifecycle branch.