### PR TITLE
chore: update iOS build workflow to package .app as .ipa

### DIFF
--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -214,16 +214,19 @@ jobs:
 
       - run: flutter build ios --release --no-codesign
 
-      - name: Package .app as zip
+      - name: Package .app as ipa
         run: |
           cd build/ios/iphoneos
-          zip -r prysm-ios.zip Runner.app
+          mkdir Payload
+          mv Runner.app Payload/
+          zip -r prysm-ios.zip Payload
+          mv prysm-ios.zip prysm-ios.ipa
 
       - id: upload
         uses: actions/upload-artifact@v4
         with:
           name: pr-${{ env.PR_NUMBER }}-ios-build
-          path: build/ios/iphoneos/prysm-ios.zip
+          path: build/ios/iphoneos/prysm-ios.ipa
 
   build-android:
     needs: [authorize]

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -140,15 +140,18 @@ jobs:
 
       - run: flutter build ios --release --no-codesign
 
-      - name: Package .app as zip
+      - name: Package .app as ipa
         run: |
           cd build/ios/iphoneos
-          zip -r prysm-ios.zip Runner.app
+          mkdir Payload
+          mv Runner.app Payload/
+          zip -r prysm-ios.zip Payload
+          mv prysm-ios.zip prysm-ios.ipa
 
       - uses: actions/upload-artifact@v4
         with:
           name: ios-build
-          path: build/ios/iphoneos/prysm-ios.zip
+          path: build/ios/iphoneos/prysm-ios.ipa
 
   # ----------------------
   # ANDROID BUILD


### PR DESCRIPTION
- Changed the packaging step to create an .ipa file instead of a .zip file.
- Adjusted the upload artifact path to reflect the new .ipa file format.