### PR TITLE
chore: enhance release asset management with versioned filenames and …

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -194,6 +194,7 @@ jobs:
       - build-linux
       - build-macos
       - build-android
+      - build-ios
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -208,17 +209,24 @@ jobs:
 
       - name: Package release assets
         run: |
+          VERSION="${{ github.ref_name }}"
           mkdir -p release-assets
 
-          cp artifacts/android-apk/app-release.apk release-assets/prysm-android.apk
+          cp artifacts/android-apk/app-release.apk "release-assets/Prysm-android-${VERSION}.apk"
 
           cd artifacts/windows-build
-          zip -r ../../release-assets/prysm-windows.zip .
+          zip -r "../../release-assets/Prysm-windows-x86_64-${VERSION}.zip" .
           cd ../../
 
-          tar -czf release-assets/prysm-linux.tar.gz -C artifacts/linux-build .
+          cd artifacts/linux-build
+          zip -r "../../release-assets/Prysm-linux-x86_64-${VERSION}.zip" .
+          cd ../../
 
-          cp artifacts/macos-build/prysm-macos.zip release-assets/prysm-macos.zip
+          unzip -q artifacts/macos-build/prysm-macos.zip -d /tmp/prysm-macos
+          cd /tmp/prysm-macos
+          zip -r "$GITHUB_WORKSPACE/release-assets/Prysm-macos-${VERSION}.zip" prysm.app
+
+          cp artifacts/ios-build/prysm-ios.ipa "release-assets/Prysm-ios-${VERSION}.ipa"
 
           # Updater binaries from prysm-auto-updater until built in this repo.
           UPDATER_TAG="v0.0.2"

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -4,21 +4,26 @@ Prysm publishes tagged releases (`v*`) to [GitHub Releases](https://github.com/x
 
 ## Asset naming
 
-| Filename | Platform |
-|----------|----------|
-| `prysm-android.apk` | Android |
-| `prysm-windows.zip` | Windows |
-| `prysm-linux.tar.gz` | Linux |
-| `prysm-macos.zip` | macOS |
+Versioned assets use the release tag in the filename (e.g. tag `v0.6.1-fix`):
+
+| Filename pattern | Platform |
+|------------------|----------|
+| `Prysm-android-v0.6.1-fix.apk` | Android |
+| `Prysm-ios-v0.6.1-fix.ipa` | iOS (unsigned, sideload) |
+| `Prysm-windows-x86_64-v0.6.1-fix.zip` | Windows |
+| `Prysm-linux-x86_64-v0.6.1-fix.zip` | Linux |
+| `Prysm-macos-v0.6.1-fix.zip` | macOS (contains `prysm.app`) |
 | `prysm-updater-windows.exe` | Desktop updater (Windows) |
 | `prysm-updater-linux` | Desktop updater (Linux) |
 | `prysm-updater-macos` | Desktop updater (macOS) |
 
 Tag format: `v0.5.1` (semver with `v` prefix).
 
+Older releases may use legacy names (`prysm-android.apk`, `prysm-linux.tar.gz`, etc.); the in-app updater falls back to those when the versioned asset is not found.
+
 ## Android updates
 
-The app checks `api.github.com/repos/xmreur/prysm/releases/latest`, compares the tag to the installed version, and downloads `prysm-android.apk` (or any `.apk` asset as fallback). The APK must be signed with the same key as the installed app.
+The app checks `api.github.com/repos/xmreur/prysm/releases/latest`, compares the tag to the installed version, and downloads `Prysm-android-<tag>.apk` (with legacy `.apk` fallback). The APK must be signed with the same key as the installed app.
 
 ## Desktop updates
 
@@ -28,7 +33,7 @@ The main app spawns the external updater with CLI arguments:
 prysm-updater-<platform> --url <package_download_url> --install-dir <app_directory>
 ```
 
-- `--url`: direct download URL for the platform package (`prysm-windows.zip`, `prysm-linux.tar.gz`, or `prysm-macos.zip`).
+- `--url`: direct download URL for the platform package (e.g. `Prysm-linux-x86_64-v0.6.1-fix.zip`).
 - `--install-dir`: directory containing the running app (Windows/Linux: executable directory; macOS: `.app` bundle path).
 
 The main app exits after launching the updater so files can be replaced.

--- a/lib/models/release_info.dart
+++ b/lib/models/release_info.dart
@@ -54,10 +54,19 @@ class ReleaseInfo {
 
 /// GitHub release asset filenames published by CI.
 abstract final class ReleaseAssetNames {
-  static const androidApk = 'prysm-android.apk';
-  static const windowsZip = 'prysm-windows.zip';
-  static const linuxTarGz = 'prysm-linux.tar.gz';
-  static const macosZip = 'prysm-macos.zip';
+  static String androidApk(String tagName) => 'Prysm-android-$tagName.apk';
+  static String iosIpa(String tagName) => 'Prysm-ios-$tagName.ipa';
+  static String windowsZip(String tagName) =>
+      'Prysm-windows-x86_64-$tagName.zip';
+  static String linuxZip(String tagName) => 'Prysm-linux-x86_64-$tagName.zip';
+  static String macosZip(String tagName) => 'Prysm-macos-$tagName.zip';
+
+  /// Legacy filenames from releases before versioned asset naming.
+  static const legacyAndroidApk = 'prysm-android.apk';
+  static const legacyWindowsZip = 'prysm-windows.zip';
+  static const legacyLinuxTarGz = 'prysm-linux.tar.gz';
+  static const legacyMacosZip = 'prysm-macos.zip';
+
   static const updaterWindows = 'prysm-updater-windows.exe';
   static const updaterLinux = 'prysm-updater-linux';
   static const updaterMacos = 'prysm-updater-macos';

--- a/lib/services/app_update_service.dart
+++ b/lib/services/app_update_service.dart
@@ -113,19 +113,24 @@ class AppUpdateService {
   }
 
   String? androidApkUrl(ReleaseInfo release) {
-    return release.assetUrl(ReleaseAssetNames.androidApk) ??
+    return release.assetUrl(ReleaseAssetNames.androidApk(release.tagName)) ??
+        release.assetUrl(ReleaseAssetNames.legacyAndroidApk) ??
         release.assetUrlEndingWith('.apk');
   }
 
   String? desktopPackageUrl(ReleaseInfo release) {
     if (Platform.isWindows) {
-      return release.assetUrl(ReleaseAssetNames.windowsZip);
+      return release.assetUrl(ReleaseAssetNames.windowsZip(release.tagName)) ??
+          release.assetUrl(ReleaseAssetNames.legacyWindowsZip);
     }
     if (Platform.isLinux) {
-      return release.assetUrl(ReleaseAssetNames.linuxTarGz);
+      return release.assetUrl(ReleaseAssetNames.linuxZip(release.tagName)) ??
+          release.assetUrl(ReleaseAssetNames.legacyLinuxTarGz) ??
+          release.assetUrlEndingWith('.zip');
     }
     if (Platform.isMacOS) {
-      return release.assetUrl(ReleaseAssetNames.macosZip);
+      return release.assetUrl(ReleaseAssetNames.macosZip(release.tagName)) ??
+          release.assetUrl(ReleaseAssetNames.legacyMacosZip);
     }
     return null;
   }

--- a/test/release_info_test.dart
+++ b/test/release_info_test.dart
@@ -3,31 +3,86 @@ import 'package:prysm/models/release_info.dart';
 
 void main() {
   group('ReleaseInfo', () {
-    test('parses assets and resolves by filename', () {
+    test('parses assets and resolves versioned filenames', () {
       final release = ReleaseInfo.fromJson({
-        'tag_name': 'v0.5.1',
+        'tag_name': 'v0.6.1-fix',
         'body': 'Bug fixes',
         'assets': [
           {
-            'name': 'prysm-android.apk',
-            'browser_download_url': 'https://example.com/prysm-android.apk',
+            'name': 'Prysm-android-v0.6.1-fix.apk',
+            'browser_download_url': 'https://example.com/Prysm-android-v0.6.1-fix.apk',
           },
           {
-            'name': 'prysm-windows.zip',
-            'browser_download_url': 'https://example.com/prysm-windows.zip',
+            'name': 'Prysm-windows-x86_64-v0.6.1-fix.zip',
+            'browser_download_url':
+                'https://example.com/Prysm-windows-x86_64-v0.6.1-fix.zip',
+          },
+          {
+            'name': 'Prysm-linux-x86_64-v0.6.1-fix.zip',
+            'browser_download_url':
+                'https://example.com/Prysm-linux-x86_64-v0.6.1-fix.zip',
+          },
+          {
+            'name': 'Prysm-macos-v0.6.1-fix.zip',
+            'browser_download_url':
+                'https://example.com/Prysm-macos-v0.6.1-fix.zip',
+          },
+          {
+            'name': 'Prysm-ios-v0.6.1-fix.ipa',
+            'browser_download_url':
+                'https://example.com/Prysm-ios-v0.6.1-fix.ipa',
           },
         ],
       });
 
-      expect(release.tagName, 'v0.5.1');
+      expect(release.tagName, 'v0.6.1-fix');
       expect(release.body, 'Bug fixes');
       expect(
-        release.assetUrl(ReleaseAssetNames.androidApk),
-        'https://example.com/prysm-android.apk',
+        release.assetUrl(ReleaseAssetNames.androidApk('v0.6.1-fix')),
+        'https://example.com/Prysm-android-v0.6.1-fix.apk',
+      );
+      expect(
+        release.assetUrl(ReleaseAssetNames.windowsZip('v0.6.1-fix')),
+        'https://example.com/Prysm-windows-x86_64-v0.6.1-fix.zip',
+      );
+      expect(
+        release.assetUrl(ReleaseAssetNames.linuxZip('v0.6.1-fix')),
+        'https://example.com/Prysm-linux-x86_64-v0.6.1-fix.zip',
+      );
+      expect(
+        release.assetUrl(ReleaseAssetNames.macosZip('v0.6.1-fix')),
+        'https://example.com/Prysm-macos-v0.6.1-fix.zip',
+      );
+      expect(
+        release.assetUrl(ReleaseAssetNames.iosIpa('v0.6.1-fix')),
+        'https://example.com/Prysm-ios-v0.6.1-fix.ipa',
       );
       expect(
         release.assetUrlEndingWith('.apk'),
-        'https://example.com/prysm-android.apk',
+        'https://example.com/Prysm-android-v0.6.1-fix.apk',
+      );
+    });
+
+    test('ReleaseAssetNames builds expected versioned filenames', () {
+      expect(
+        ReleaseAssetNames.androidApk('v0.5.1'),
+        'Prysm-android-v0.5.1.apk',
+      );
+      expect(
+        ReleaseAssetNames.windowsZip('v0.5.1'),
+        'Prysm-windows-x86_64-v0.5.1.zip',
+      );
+      expect(
+        ReleaseAssetNames.linuxZip('v0.5.1'),
+        'Prysm-linux-x86_64-v0.5.1.zip',
+      );
+      expect(
+        ReleaseAssetNames.macosZip('v0.5.1'),
+        'Prysm-macos-v0.5.1.zip',
+      );
+      expect(
+        ReleaseAssetNames.iosIpa('v0.5.1'),
+        'Prysm-ios-v0.5.1.ipa',
       );
     });
   });


### PR DESCRIPTION
…add iOS build support

- Updated GitHub Actions workflow to include iOS build step and package .ipa files.
- Modified asset naming conventions to include version tags in filenames for better clarity.
- Updated documentation to reflect new asset naming patterns and legacy fallback options.
- Enhanced release info model and update service to support versioned asset URLs.
- Added tests to ensure correct parsing and resolution of versioned filenames.