### PR TITLE
feat: implement share extension for media sharing

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -56,6 +56,41 @@
                 <action android:name="android.intent.action.MAIN"/>
                 <category android:name="android.intent.category.LAUNCHER"/>
             </intent-filter>
+            <intent-filter>
+                <action android:name="android.intent.action.SEND" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <data android:mimeType="text/*" />
+            </intent-filter>
+            <intent-filter>
+                <action android:name="android.intent.action.SEND" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <data android:mimeType="image/*" />
+            </intent-filter>
+            <intent-filter>
+                <action android:name="android.intent.action.SEND_MULTIPLE" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <data android:mimeType="image/*" />
+            </intent-filter>
+            <intent-filter>
+                <action android:name="android.intent.action.SEND" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <data android:mimeType="video/*" />
+            </intent-filter>
+            <intent-filter>
+                <action android:name="android.intent.action.SEND_MULTIPLE" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <data android:mimeType="video/*" />
+            </intent-filter>
+            <intent-filter>
+                <action android:name="android.intent.action.SEND" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <data android:mimeType="*/*" />
+            </intent-filter>
+            <intent-filter>
+                <action android:name="android.intent.action.SEND_MULTIPLE" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <data android:mimeType="*/*" />
+            </intent-filter>
         </activity>
         <!-- Don't delete the meta-data below.
              This is used by the Flutter tool to generate GeneratedPluginRegistrant.java -->

--- a/ios/Runner.xcodeproj/project.pbxproj
+++ b/ios/Runner.xcodeproj/project.pbxproj
@@ -7,6 +7,10 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		A1B2C3D41CF9000F007C0109 /* Share Extension.appex in Embed App Extensions */ = {isa = PBXBuildFile; fileRef = A1B2C3D41CF9000F007C0101 /* Share Extension.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
+		A1B2C3D41CF9000F007C010A /* ShareViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D41CF9000F007C0102 /* ShareViewController.swift */; };
+		A1B2C3D41CF9000F007C010B /* MainInterface.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = A1B2C3D41CF9000F007C0103 /* MainInterface.storyboard */; };
+		A1B2C3D41CF9000F007C0113 /* receive-sharing-intent in Frameworks */ = {isa = PBXBuildFile; productRef = A1B2C3D41CF9000F007C0112 /* receive-sharing-intent */; };
 		1174314C4A5D7D891452CF57 /* Pods_Runner.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = CBD973338B2CF8E334E94651 /* Pods_Runner.framework */; };
 		1498D2341E8E89220040F4C2 /* GeneratedPluginRegistrant.m in Sources */ = {isa = PBXBuildFile; fileRef = 1498D2331E8E89220040F4C2 /* GeneratedPluginRegistrant.m */; };
 		331C808B294A63AB00263BE5 /* RunnerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 331C807B294A618700263BE5 /* RunnerTests.swift */; };
@@ -23,6 +27,13 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
+		A1B2C3D41CF9000F007C0110 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 97C146E61CF9000F007C117D /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = A1B2C3D41CF9000F007C0108;
+			remoteInfo = "Share Extension";
+		};
 		331C8085294A63A400263BE5 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 97C146E61CF9000F007C117D /* Project object */;
@@ -33,6 +44,17 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXCopyFilesBuildPhase section */
+		A1B2C3D41CF9000F007C010C /* Embed App Extensions */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "";
+			dstSubfolderSpec = 13;
+			files = (
+				A1B2C3D41CF9000F007C0109 /* Share Extension.appex in Embed App Extensions */,
+			);
+			name = "Embed App Extensions";
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		9705A1C41CF9048500538489 /* Embed Frameworks */ = {
 			isa = PBXCopyFilesBuildPhase;
 			buildActionMask = 2147483647;
@@ -46,6 +68,12 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		A1B2C3D41CF9000F007C0101 /* Share Extension.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.app-extension"; includeInIndex = 0; path = "Share Extension.appex"; sourceTree = BUILT_PRODUCTS_DIR; };
+		A1B2C3D41CF9000F007C0102 /* ShareViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShareViewController.swift; sourceTree = "<group>"; };
+		A1B2C3D41CF9000F007C0104 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/MainInterface.storyboard; sourceTree = "<group>"; };
+		A1B2C3D41CF9000F007C0105 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		A1B2C3D41CF9000F007C0106 /* Share Extension.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = "Share Extension.entitlements"; sourceTree = "<group>"; };
+		A1B2C3D41CF9000F007C0107 /* Runner.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = Runner.entitlements; sourceTree = "<group>"; };
 		02BF09F2E2E8923055BF4CE3 /* Pods-RunnerTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RunnerTests.debug.xcconfig"; path = "Target Support Files/Pods-RunnerTests/Pods-RunnerTests.debug.xcconfig"; sourceTree = "<group>"; };
 		1498D2321E8E86230040F4C2 /* GeneratedPluginRegistrant.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = GeneratedPluginRegistrant.h; sourceTree = "<group>"; };
 		1498D2331E8E89220040F4C2 /* GeneratedPluginRegistrant.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = GeneratedPluginRegistrant.m; sourceTree = "<group>"; };
@@ -76,6 +104,14 @@
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
+		A1B2C3D41CF9000F007C010E /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				A1B2C3D41CF9000F007C0113 /* receive-sharing-intent in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		97C146EB1CF9000F007C117D /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
@@ -108,6 +144,17 @@
 			);
 			name = Pods;
 			path = Pods;
+			sourceTree = "<group>";
+		};
+		A1B2C3D41CF9000F007C010D /* Share Extension */ = {
+			isa = PBXGroup;
+			children = (
+				A1B2C3D41CF9000F007C0106 /* Share Extension.entitlements */,
+				A1B2C3D41CF9000F007C0102 /* ShareViewController.swift */,
+				A1B2C3D41CF9000F007C0103 /* MainInterface.storyboard */,
+				A1B2C3D41CF9000F007C0105 /* Info.plist */,
+			);
+			path = "Share Extension";
 			sourceTree = "<group>";
 		};
 		331C8082294A63A400263BE5 /* RunnerTests */ = {
@@ -144,6 +191,7 @@
 			children = (
 				9740EEB11CF90186004384FC /* Flutter */,
 				97C146F01CF9000F007C117D /* Runner */,
+				A1B2C3D41CF9000F007C010D /* Share Extension */,
 				97C146EF1CF9000F007C117D /* Products */,
 				331C8082294A63A400263BE5 /* RunnerTests */,
 				1958A3FA5006577C4B71C855 /* Pods */,
@@ -155,6 +203,7 @@
 			isa = PBXGroup;
 			children = (
 				97C146EE1CF9000F007C117D /* Runner.app */,
+				A1B2C3D41CF9000F007C0101 /* Share Extension.appex */,
 				331C8081294A63A400263BE5 /* RunnerTests.xctest */,
 			);
 			name = Products;
@@ -163,6 +212,7 @@
 		97C146F01CF9000F007C117D /* Runner */ = {
 			isa = PBXGroup;
 			children = (
+				A1B2C3D41CF9000F007C0107 /* Runner.entitlements */,
 				97C146FA1CF9000F007C117D /* Main.storyboard */,
 				97C146FD1CF9000F007C117D /* Assets.xcassets */,
 				97C146FF1CF9000F007C117D /* LaunchScreen.storyboard */,
@@ -189,6 +239,26 @@
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
+		A1B2C3D41CF9000F007C0108 /* Share Extension */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = A1B2C3D41CF9000F007C0114 /* Build configuration list for PBXNativeTarget "Share Extension" */;
+			buildPhases = (
+				A1B2C3D41CF9000F007C010F /* Sources */,
+				A1B2C3D41CF9000F007C010E /* Frameworks */,
+				A1B2C3D41CF9000F007C0118 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = "Share Extension";
+			packageProductDependencies = (
+				A1B2C3D41CF9000F007C0112 /* receive-sharing-intent */,
+			);
+			productName = "Share Extension";
+			productReference = A1B2C3D41CF9000F007C0101 /* Share Extension.appex */;
+			productType = "com.apple.product-type.app-extension";
+		};
 		331C8080294A63A400263BE5 /* RunnerTests */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = 331C8087294A63A400263BE5 /* Build configuration list for PBXNativeTarget "RunnerTests" */;
@@ -218,6 +288,7 @@
 				97C146EB1CF9000F007C117D /* Frameworks */,
 				97C146EC1CF9000F007C117D /* Resources */,
 				9705A1C41CF9048500538489 /* Embed Frameworks */,
+				A1B2C3D41CF9000F007C010C /* Embed App Extensions */,
 				3B06AD1E1E4923F5004D2608 /* Thin Binary */,
 				2DC1522E40F0697619799C0C /* [CP] Embed Pods Frameworks */,
 				3A413320293AE1602D13B2C1 /* [CP] Copy Pods Resources */,
@@ -225,6 +296,7 @@
 			buildRules = (
 			);
 			dependencies = (
+				A1B2C3D41CF9000F007C0111 /* PBXTargetDependency */,
 			);
 			name = Runner;
 			packageProductDependencies = (
@@ -265,18 +337,28 @@
 			mainGroup = 97C146E51CF9000F007C117D;
 			packageReferences = (
 				781AD8BC2B33823900A9FFBB /* XCLocalSwiftPackageReference "FlutterGeneratedPluginSwiftPackage" */,
+				A1B2C3D41CF9000F007C0119 /* XCLocalSwiftPackageReference "receive_sharing_intent" */,
 			);
 			productRefGroup = 97C146EF1CF9000F007C117D /* Products */;
 			projectDirPath = "";
 			projectRoot = "";
 			targets = (
 				97C146ED1CF9000F007C117D /* Runner */,
+				A1B2C3D41CF9000F007C0108 /* Share Extension */,
 				331C8080294A63A400263BE5 /* RunnerTests */,
 			);
 		};
 /* End PBXProject section */
 
 /* Begin PBXResourcesBuildPhase section */
+		A1B2C3D41CF9000F007C0118 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				A1B2C3D41CF9000F007C010B /* MainInterface.storyboard in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		331C807F294A63A400263BE5 /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -410,6 +492,14 @@
 /* End PBXShellScriptBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
+		A1B2C3D41CF9000F007C010F /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				A1B2C3D41CF9000F007C010A /* ShareViewController.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		331C807D294A63A400263BE5 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -433,6 +523,11 @@
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
+		A1B2C3D41CF9000F007C0111 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = A1B2C3D41CF9000F007C0108 /* Share Extension */;
+			targetProxy = A1B2C3D41CF9000F007C0110 /* PBXContainerItemProxy */;
+		};
 		331C8086294A63A400263BE5 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			target = 97C146ED1CF9000F007C117D /* Runner */;
@@ -441,6 +536,14 @@
 /* End PBXTargetDependency section */
 
 /* Begin PBXVariantGroup section */
+		A1B2C3D41CF9000F007C0103 /* MainInterface.storyboard */ = {
+			isa = PBXVariantGroup;
+			children = (
+				A1B2C3D41CF9000F007C0104 /* Base */,
+			);
+			name = MainInterface.storyboard;
+			sourceTree = "<group>";
+		};
 		97C146FA1CF9000F007C117D /* Main.storyboard */ = {
 			isa = PBXVariantGroup;
 			children = (
@@ -518,7 +621,9 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
+				CODE_SIGN_ENTITLEMENTS = Runner/Runner.entitlements;
 				CURRENT_PROJECT_VERSION = "$(FLUTTER_BUILD_NUMBER)";
+				CUSTOM_GROUP_ID = group.github.xmreur.prysm;
 				ENABLE_BITCODE = NO;
 				INFOPLIST_FILE = Runner/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -700,7 +805,9 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
+				CODE_SIGN_ENTITLEMENTS = Runner/Runner.entitlements;
 				CURRENT_PROJECT_VERSION = "$(FLUTTER_BUILD_NUMBER)";
+				CUSTOM_GROUP_ID = group.github.xmreur.prysm;
 				ENABLE_BITCODE = NO;
 				INFOPLIST_FILE = Runner/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -722,7 +829,9 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
+				CODE_SIGN_ENTITLEMENTS = Runner/Runner.entitlements;
 				CURRENT_PROJECT_VERSION = "$(FLUTTER_BUILD_NUMBER)";
+				CUSTOM_GROUP_ID = group.github.xmreur.prysm;
 				ENABLE_BITCODE = NO;
 				INFOPLIST_FILE = Runner/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -736,6 +845,99 @@
 				VERSIONING_SYSTEM = "apple-generic";
 			};
 			name = Release;
+		};
+		A1B2C3D41CF9000F007C0115 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CODE_SIGN_ENTITLEMENTS = "Share Extension/Share Extension.entitlements";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = "$(FLUTTER_BUILD_NUMBER)";
+				CUSTOM_GROUP_ID = group.github.xmreur.prysm;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = "Share Extension/Info.plist";
+				INFOPLIST_KEY_CFBundleDisplayName = "Share Extension";
+				IPHONEOS_DEPLOYMENT_TARGET = 18.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@executable_path/../../Frameworks",
+				);
+				MARKETING_VERSION = "$(FLUTTER_BUILD_NAME)";
+				PRODUCT_BUNDLE_IDENTIFIER = "github.xmreur.prysm.Share-Extension";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SKIP_INSTALL = YES;
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		A1B2C3D41CF9000F007C0116 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CODE_SIGN_ENTITLEMENTS = "Share Extension/Share Extension.entitlements";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = "$(FLUTTER_BUILD_NUMBER)";
+				CUSTOM_GROUP_ID = group.github.xmreur.prysm;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = "Share Extension/Info.plist";
+				INFOPLIST_KEY_CFBundleDisplayName = "Share Extension";
+				IPHONEOS_DEPLOYMENT_TARGET = 18.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@executable_path/../../Frameworks",
+				);
+				MARKETING_VERSION = "$(FLUTTER_BUILD_NAME)";
+				PRODUCT_BUNDLE_IDENTIFIER = "github.xmreur.prysm.Share-Extension";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SKIP_INSTALL = YES;
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Release;
+		};
+		A1B2C3D41CF9000F007C0117 /* Profile */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CODE_SIGN_ENTITLEMENTS = "Share Extension/Share Extension.entitlements";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = "$(FLUTTER_BUILD_NUMBER)";
+				CUSTOM_GROUP_ID = group.github.xmreur.prysm;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = "Share Extension/Info.plist";
+				INFOPLIST_KEY_CFBundleDisplayName = "Share Extension";
+				IPHONEOS_DEPLOYMENT_TARGET = 18.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@executable_path/../../Frameworks",
+				);
+				MARKETING_VERSION = "$(FLUTTER_BUILD_NAME)";
+				PRODUCT_BUNDLE_IDENTIFIER = "github.xmreur.prysm.Share-Extension";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SKIP_INSTALL = YES;
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Profile;
 		};
 /* End XCBuildConfiguration section */
 
@@ -770,6 +972,16 @@
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
+		A1B2C3D41CF9000F007C0114 /* Build configuration list for PBXNativeTarget "Share Extension" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				A1B2C3D41CF9000F007C0115 /* Debug */,
+				A1B2C3D41CF9000F007C0116 /* Release */,
+				A1B2C3D41CF9000F007C0117 /* Profile */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
 /* End XCConfigurationList section */
 
 /* Begin XCLocalSwiftPackageReference section */
@@ -777,12 +989,21 @@
 			isa = XCLocalSwiftPackageReference;
 			relativePath = Flutter/ephemeral/Packages/FlutterGeneratedPluginSwiftPackage;
 		};
+		A1B2C3D41CF9000F007C0119 /* XCLocalSwiftPackageReference "receive_sharing_intent" */ = {
+			isa = XCLocalSwiftPackageReference;
+			relativePath = "Flutter/ephemeral/Packages/.packages/receive_sharing_intent";
+		};
 /* End XCLocalSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
 		78A3181F2AECB46A00862997 /* FlutterGeneratedPluginSwiftPackage */ = {
 			isa = XCSwiftPackageProductDependency;
 			productName = FlutterGeneratedPluginSwiftPackage;
+		};
+		A1B2C3D41CF9000F007C0112 /* receive-sharing-intent */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = A1B2C3D41CF9000F007C0119 /* XCLocalSwiftPackageReference "receive_sharing_intent" */;
+			productName = "receive-sharing-intent";
 		};
 /* End XCSwiftPackageProductDependency section */
 	};

--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -8,6 +8,19 @@
 	<string>$(DEVELOPMENT_LANGUAGE)</string>
 	<key>CFBundleDisplayName</key>
 	<string>Prysm</string>
+	<key>AppGroupId</key>
+	<string>$(CUSTOM_GROUP_ID)</string>
+	<key>CFBundleURLTypes</key>
+	<array>
+		<dict>
+			<key>CFBundleTypeRole</key>
+			<string>Editor</string>
+			<key>CFBundleURLSchemes</key>
+			<array>
+				<string>ShareMedia-$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+			</array>
+		</dict>
+	</array>
 	<key>CFBundleExecutable</key>
 	<string>$(EXECUTABLE_NAME)</string>
 	<key>CFBundleIdentifier</key>
@@ -32,6 +45,8 @@
 	<string>Prysm needs microphone access for voice messages and calls.</string>
 	<key>NSPhotoLibraryAddUsageDescription</key>
 	<string>Prysm needs access to save images to your photo library.</string>
+	<key>NSPhotoLibraryUsageDescription</key>
+	<string>Prysm needs access to your photo library when you share images into the app.</string>
 	<key>UIBackgroundModes</key>
 	<array>
 		<string>audio</string>

--- a/ios/Runner/Runner.entitlements
+++ b/ios/Runner/Runner.entitlements
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>com.apple.security.application-groups</key>
+	<array>
+		<string>group.github.xmreur.prysm</string>
+	</array>
+</dict>
+</plist>

--- a/ios/Share Extension/Base.lproj/MainInterface.storyboard
+++ b/ios/Share Extension/Base.lproj/MainInterface.storyboard
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="13122.16" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="j1y-V4-xli">
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="13104.12"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <scenes>
+        <scene sceneID="ceB-am-kn3">
+            <objects>
+                <viewController id="j1y-V4-xli" customClass="ShareViewController" customModuleProvider="target" sceneMemberID="viewController">
+                    <view key="view" opaque="NO" contentMode="scaleToFill" id="wbc-yd-nQP">
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <color key="backgroundColor" red="0.0" green="0.0" blue="0.0" alpha="0.0" colorSpace="custom" customColorSpace="sRGB"/>
+                        <viewLayoutGuide key="safeArea" id="1Xd-am-t49"/>
+                    </view>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="CEy-Cv-SGf" userLabel="First Responder" sceneMemberID="firstResponder"/>
+            </objects>
+        </scene>
+    </scenes>
+</document>

--- a/ios/Share Extension/Info.plist
+++ b/ios/Share Extension/Info.plist
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>AppGroupId</key>
+	<string>$(CUSTOM_GROUP_ID)</string>
+	<key>CFBundleVersion</key>
+	<string>$(FLUTTER_BUILD_NUMBER)</string>
+	<key>NSExtension</key>
+	<dict>
+		<key>NSExtensionAttributes</key>
+		<dict>
+			<key>PHSupportedMediaTypes</key>
+			<array>
+				<string>Video</string>
+				<string>Image</string>
+			</array>
+			<key>NSExtensionActivationRule</key>
+			<dict>
+				<key>NSExtensionActivationSupportsText</key>
+				<true/>
+				<key>NSExtensionActivationSupportsWebURLWithMaxCount</key>
+				<integer>1</integer>
+				<key>NSExtensionActivationSupportsImageWithMaxCount</key>
+				<integer>100</integer>
+				<key>NSExtensionActivationSupportsMovieWithMaxCount</key>
+				<integer>100</integer>
+				<key>NSExtensionActivationSupportsFileWithMaxCount</key>
+				<integer>1</integer>
+			</dict>
+		</dict>
+		<key>NSExtensionMainStoryboard</key>
+		<string>MainInterface</string>
+		<key>NSExtensionPointIdentifier</key>
+		<string>com.apple.share-services</string>
+	</dict>
+</dict>
+</plist>

--- a/ios/Share Extension/Share Extension.entitlements
+++ b/ios/Share Extension/Share Extension.entitlements
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>com.apple.security.application-groups</key>
+	<array>
+		<string>group.github.xmreur.prysm</string>
+	</array>
+</dict>
+</plist>

--- a/ios/Share Extension/ShareViewController.swift
+++ b/ios/Share Extension/ShareViewController.swift
@@ -1,0 +1,7 @@
+import receive_sharing_intent
+
+class ShareViewController: RSIShareViewController {
+    override func shouldAutoRedirect() -> Bool {
+        return true
+    }
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -44,6 +44,7 @@ import 'package:prysm/ui/prysm_list_row.dart';
 import 'package:prysm/ui/core/prysm_app.dart';
 import 'package:prysm/ui/core/prysm_button.dart';
 import 'package:prysm/util/notification_service.dart';
+import 'package:prysm/services/share_intent_service.dart';
 import 'package:prysm/util/decoy_session_data.dart';
 import 'package:prysm/screens/onboarding/onboarding_screen.dart';
 import 'package:flutter_background/flutter_background.dart';
@@ -212,6 +213,9 @@ Future<void> _runMainApp() async {
 
   WidgetsBinding.instance.addPostFrameCallback((_) {
     unawaited(NotificationService().init());
+    if (Platform.isAndroid || Platform.isIOS) {
+      unawaited(ShareIntentService.instance.init());
+    }
   });
 
   // Request notification permissions after runApp so dialogs appear over UI.
@@ -344,6 +348,7 @@ class _MyAppState extends State<MyApp> {
   @override
   void initState() {
     super.initState();
+    ShareIntentService.instance.isDecoyMode = () => _panicDecoySession;
     _startupError = widget.startupError;
     _loadSavedTheme();
     _checkMigration();

--- a/lib/models/share_target.dart
+++ b/lib/models/share_target.dart
@@ -1,0 +1,14 @@
+import 'package:prysm/models/detached_chat_launch.dart';
+
+/// Destination chosen in the share-target chat picker.
+class ShareTarget {
+  const ShareTarget({
+    required this.kind,
+    required this.conversationId,
+    required this.displayName,
+  });
+
+  final DetachedChatKind kind;
+  final String conversationId;
+  final String displayName;
+}

--- a/lib/models/shared_content.dart
+++ b/lib/models/shared_content.dart
@@ -1,0 +1,22 @@
+enum SharedContentKind { text, file }
+
+/// Payload received from the OS share sheet (one item; multi-share uses the first).
+class SharedContent {
+  const SharedContent({
+    required this.kind,
+    this.text,
+    this.filePath,
+    this.mimeType,
+    this.fileName,
+  });
+
+  final SharedContentKind kind;
+  final String? text;
+  final String? filePath;
+  final String? mimeType;
+  final String? fileName;
+
+  bool get isText => kind == SharedContentKind.text;
+
+  bool get isFile => kind == SharedContentKind.file;
+}

--- a/lib/screens/home/home_screen.dart
+++ b/lib/screens/home/home_screen.dart
@@ -28,6 +28,8 @@ import 'package:prysm/services/active_conversation_tracker.dart';
 import 'package:prysm/services/notification_open_chat_resolver.dart';
 import 'package:prysm/services/pending_call_action.dart';
 import 'package:prysm/services/pending_notification_route.dart';
+import 'package:prysm/services/pending_share_store.dart';
+import 'package:prysm/services/share_intent_service.dart';
 import 'package:prysm/services/settings_service.dart';
 import 'package:prysm/util/battery_saver_policy.dart';
 import 'package:prysm/services/tray_service.dart';
@@ -45,6 +47,8 @@ import 'package:prysm/models/conversation_preferences.dart';
 import 'package:prysm/models/group.dart';
 import 'package:prysm/services/conversation_preferences_service.dart';
 import 'package:prysm/models/detached_chat_launch.dart';
+import 'package:prysm/models/share_target.dart';
+import 'package:prysm/screens/share_target_picker_screen.dart';
 import 'package:prysm/services/detached_chat_bridge.dart';
 import 'package:prysm/services/detached_chat_host.dart';
 import 'package:prysm/services/detached_chat_window_registry.dart';
@@ -150,6 +154,7 @@ class _HomeScreenState extends State<HomeScreen> with WidgetsBindingObserver {
   bool _loadUsersInProgress = false;
   bool _loadUsersQueued = false;
   bool _loadUsersQueuedLight = false;
+  bool _sharePickerOpen = false;
 
   int get _archivedCount => conversations
       .where((c) => _conversationPrefs[c.id]?.isArchived ?? false)
@@ -421,6 +426,7 @@ class _HomeScreenState extends State<HomeScreen> with WidgetsBindingObserver {
     });
     NotificationService.onNotificationTap = _handleNotificationTap;
     NotificationService.onCallNotificationTap = _handleCallNotificationAction;
+    ShareIntentService.instance.onPendingShare = _handlePendingShareIntent;
 
     if (!Platform.isAndroid && !Platform.isIOS) {
       unawaited(TrayService.instance.start(userId: widget.onionAddress));
@@ -632,6 +638,74 @@ class _HomeScreenState extends State<HomeScreen> with WidgetsBindingObserver {
   Future<void> _consumePendingNotificationRoute() async {
     if (PendingNotificationRouteStore.instance.peek() == null) return;
     await _openChatFromNotificationPayload(null);
+  }
+
+  void _handlePendingShareIntent() {
+    if (!mounted || widget.decoyMode) return;
+    unawaited(_consumePendingShare());
+  }
+
+  List<Conversation> get _shareableConversations {
+    return conversations.where((conversation) {
+      if (conversation is DirectConversation &&
+          BlockService.instance.isBlocked(conversation.id)) {
+        return false;
+      }
+      return !(_conversationPrefs[conversation.id]?.isArchived ?? false);
+    }).toList();
+  }
+
+  Group? _groupById(String groupId) {
+    try {
+      return groups.firstWhere((group) => group.id == groupId);
+    } catch (_) {
+      return null;
+    }
+  }
+
+  void _openChatFromShareTarget(ShareTarget target) {
+    switch (target.kind) {
+      case DetachedChatKind.direct:
+        final contact = contacts.cast<Contact?>().firstWhere(
+          (c) => c?.id == target.conversationId,
+          orElse: () => null,
+        );
+        if (contact != null) onSelectContact(contact);
+      case DetachedChatKind.group:
+        final group = _groupById(target.conversationId);
+        if (group != null) onSelectGroup(group);
+      case DetachedChatKind.self:
+        onSelectSelfChat();
+    }
+  }
+
+  Future<void> _consumePendingShare() async {
+    if (widget.decoyMode || !mounted || _sharePickerOpen) return;
+    final content = PendingShareStore.instance.peek();
+    if (content == null) return;
+
+    _sharePickerOpen = true;
+    final target = await Navigator.of(context).push<ShareTarget>(
+      PrysmPageRoute(
+        page: ShareTargetPickerScreen(
+          content: content,
+          conversations: _shareableConversations,
+          userId: appUser.id,
+          userName: appUser.name,
+          userAvatarBase64: appUser.avatarBase64,
+          contacts: contacts,
+          keyManager: widget.keyManager,
+          groupById: _groupById,
+        ),
+      ),
+    );
+    _sharePickerOpen = false;
+
+    if (!mounted) return;
+    if (target != null) {
+      _openChatFromShareTarget(target);
+      scheduleLoadUsers(light: true);
+    }
   }
 
   void _closeMobileDrawerIfOpen() {
@@ -913,6 +987,7 @@ class _HomeScreenState extends State<HomeScreen> with WidgetsBindingObserver {
     _syncActiveConversationTracker();
     unawaited(_consumePendingNotificationRoute());
     unawaited(_consumePendingCallAction());
+    unawaited(_consumePendingShare());
   }
 
   bool _mapsEqual<K, V>(Map<K, V> a, Map<K, V> b) {
@@ -1586,6 +1661,9 @@ class _HomeScreenState extends State<HomeScreen> with WidgetsBindingObserver {
     if (NotificationService.onCallNotificationTap ==
         _handleCallNotificationAction) {
       NotificationService.onCallNotificationTap = null;
+    }
+    if (ShareIntentService.instance.onPendingShare == _handlePendingShareIntent) {
+      ShareIntentService.instance.onPendingShare = null;
     }
     WidgetsBinding.instance.removeObserver(this);
     _searchController.dispose();

--- a/lib/screens/share_target_picker_screen.dart
+++ b/lib/screens/share_target_picker_screen.dart
@@ -1,0 +1,264 @@
+import 'package:flutter/widgets.dart';
+import 'package:prysm/models/contact.dart';
+import 'package:prysm/models/conversation.dart';
+import 'package:prysm/models/detached_chat_launch.dart';
+import 'package:prysm/models/group.dart';
+import 'package:prysm/models/share_target.dart';
+import 'package:prysm/models/shared_content.dart';
+import 'package:prysm/screens/widgets/contact_avatar.dart';
+import 'package:prysm/services/block_service.dart';
+import 'package:prysm/services/pending_share_store.dart';
+import 'package:prysm/services/share_send_service.dart';
+import 'package:prysm/theme/prysm_theme.dart';
+import 'package:prysm/ui/core/prysm_button.dart';
+import 'package:prysm/ui/core/prysm_icons.dart';
+import 'package:prysm/ui/core/prysm_list_row.dart';
+import 'package:prysm/ui/core/prysm_progress.dart';
+import 'package:prysm/ui/core/prysm_text_field.dart';
+import 'package:prysm/ui/core/prysm_toast.dart';
+import 'package:prysm/ui/prysm_scaffold.dart';
+import 'package:prysm/util/key_manager.dart';
+
+class ShareTargetPickerScreen extends StatefulWidget {
+  const ShareTargetPickerScreen({
+    required this.content,
+    required this.conversations,
+    required this.userId,
+    required this.userName,
+    required this.userAvatarBase64,
+    required this.contacts,
+    required this.keyManager,
+    required this.groupById,
+    super.key,
+  });
+
+  final SharedContent content;
+  final List<Conversation> conversations;
+  final String userId;
+  final String userName;
+  final String? userAvatarBase64;
+  final List<Contact> contacts;
+  final KeyManager keyManager;
+  final Group? Function(String groupId) groupById;
+
+  @override
+  State<ShareTargetPickerScreen> createState() =>
+      _ShareTargetPickerScreenState();
+}
+
+class _ShareTargetPickerScreenState extends State<ShareTargetPickerScreen> {
+  final _searchController = TextEditingController();
+  String _searchQuery = '';
+  bool _sending = false;
+
+  @override
+  void dispose() {
+    _searchController.dispose();
+    super.dispose();
+  }
+
+  List<_SharePickerRow> get _rows {
+    final query = _searchQuery.trim().toLowerCase();
+    final rows = <_SharePickerRow>[];
+
+    if (query.isEmpty || 'chat with myself'.contains(query)) {
+      rows.add(
+        _SharePickerRow(
+          target: ShareTarget(
+            kind: DetachedChatKind.self,
+            conversationId: DetachedChatLaunch.selfConversationId,
+            displayName: 'Chat with myself',
+          ),
+          title: 'Chat with myself',
+          subtitle: 'Notes to self',
+          avatarName: widget.userName,
+          avatarBase64: widget.userAvatarBase64,
+        ),
+      );
+    }
+
+    for (final conv in widget.conversations) {
+      if (conv is DirectConversation &&
+          BlockService.instance.isBlocked(conv.id)) {
+        continue;
+      }
+      final title = conv.displayName;
+      if (query.isNotEmpty && !title.toLowerCase().contains(query)) {
+        continue;
+      }
+
+      if (conv is DirectConversation) {
+        final contact = conv.contact;
+        rows.add(
+          _SharePickerRow(
+            target: ShareTarget(
+              kind: DetachedChatKind.direct,
+              conversationId: contact.id,
+              displayName: contact.displayName,
+            ),
+            title: contact.displayName,
+            subtitle: contact.id,
+            avatarName: contact.displayName,
+            avatarBase64: contact.avatarBase64,
+          ),
+        );
+      } else if (conv is GroupConversation) {
+        final group = conv.group;
+        rows.add(
+          _SharePickerRow(
+            target: ShareTarget(
+              kind: DetachedChatKind.group,
+              conversationId: group.id,
+              displayName: group.name,
+            ),
+            title: group.name,
+            subtitle: 'Group',
+            avatarName: group.name,
+            avatarBase64: group.avatarBase64,
+          ),
+        );
+      }
+    }
+
+    return rows;
+  }
+
+  String get _contentSummary {
+    if (widget.content.isText) {
+      final text = widget.content.text ?? '';
+      if (text.length <= 80) return text;
+      return '${text.substring(0, 77)}...';
+    }
+    return widget.content.fileName ?? 'Shared file';
+  }
+
+  Future<void> _sendTo(_SharePickerRow row) async {
+    if (_sending) return;
+    setState(() => _sending = true);
+
+    final result = await ShareSendService.send(
+      target: row.target,
+      content: widget.content,
+      userId: widget.userId,
+      keyManager: widget.keyManager,
+      contacts: widget.contacts,
+      groupById: widget.groupById,
+    );
+
+    if (!mounted) return;
+    setState(() => _sending = false);
+
+    if (result.success) {
+      PendingShareStore.instance.clear();
+      showPrysmToast(context, 'Sent to ${row.target.displayName}');
+      Navigator.of(context).pop(row.target);
+      return;
+    }
+
+    showPrysmToast(
+      context,
+      result.errorMessage ?? 'Could not send shared content.',
+    );
+  }
+
+  void _cancel() {
+    PendingShareStore.instance.clear();
+    Navigator.of(context).pop();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final rows = _rows;
+    final tokens = context.prysmTokens;
+
+    return PrysmPage(
+      title: 'Share to Prysm',
+      leading: PrysmIconButton(
+        icon: PrysmIcons.close,
+        onPressed: _sending ? null : _cancel,
+      ),
+      body: Stack(
+        children: [
+          Column(
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            children: [
+              Padding(
+                padding: const EdgeInsets.fromLTRB(16, 8, 16, 12),
+                child: Text(
+                  _contentSummary,
+                  maxLines: 3,
+                  overflow: TextOverflow.ellipsis,
+                  style: TextStyle(
+                    color: tokens.textSecondary,
+                    fontSize: 14,
+                  ),
+                ),
+              ),
+              Padding(
+                padding: const EdgeInsets.symmetric(horizontal: 16),
+                child: PrysmTextField(
+                  controller: _searchController,
+                  hintText: 'Search conversations',
+                  onChanged: (value) =>
+                      setState(() => _searchQuery = value.toLowerCase()),
+                ),
+              ),
+              const SizedBox(height: 8),
+              Expanded(
+                child: rows.isEmpty
+                    ? Center(
+                        child: Text(
+                          'No conversations found',
+                          style: TextStyle(color: tokens.textSecondary),
+                        ),
+                      )
+                    : ListView.builder(
+                        itemCount: rows.length,
+                        itemBuilder: (context, index) {
+                          final row = rows[index];
+                          return Padding(
+                            padding: const EdgeInsets.symmetric(
+                              horizontal: 8,
+                              vertical: 2,
+                            ),
+                            child: PrysmListRow(
+                              leading: ContactAvatar(
+                                name: row.avatarName,
+                                avatarBase64: row.avatarBase64,
+                              ),
+                              title: row.title,
+                              subtitle: row.subtitle,
+                              onTap: _sending ? null : () => _sendTo(row),
+                            ),
+                          );
+                        },
+                      ),
+              ),
+            ],
+          ),
+          if (_sending)
+            const ColoredBox(
+              color: Color(0x66000000),
+              child: Center(child: PrysmProgressIndicator()),
+            ),
+        ],
+      ),
+    );
+  }
+}
+
+class _SharePickerRow {
+  const _SharePickerRow({
+    required this.target,
+    required this.title,
+    required this.subtitle,
+    required this.avatarName,
+    this.avatarBase64,
+  });
+
+  final ShareTarget target;
+  final String title;
+  final String subtitle;
+  final String avatarName;
+  final String? avatarBase64;
+}

--- a/lib/services/detached_chat_bridge.dart
+++ b/lib/services/detached_chat_bridge.dart
@@ -276,6 +276,60 @@ class DetachedChatBridge {
     );
   }
 
+  static Future<String?> sendSharedText({
+    required DetachedChatKind chatKind,
+    required String conversationId,
+    required String text,
+    String? replyToId,
+    required String messageId,
+    required String userId,
+    required KeyManager keyManager,
+    required List<Contact> contacts,
+    required Group? Function(String groupId) groupById,
+  }) {
+    return _sendText(
+      chatKind: chatKind,
+      conversationId: conversationId,
+      text: text,
+      replyToId: replyToId,
+      messageId: messageId,
+      userId: userId,
+      keyManager: keyManager,
+      contacts: contacts,
+      groupById: groupById,
+    );
+  }
+
+  static Future<String?> sendSharedFile({
+    required DetachedChatKind chatKind,
+    required String conversationId,
+    required Uint8List bytes,
+    required String fileName,
+    required String type,
+    String? replyToId,
+    required String messageId,
+    bool viewOnce = false,
+    required String userId,
+    required KeyManager keyManager,
+    required List<Contact> contacts,
+    required Group? Function(String groupId) groupById,
+  }) {
+    return _sendFile(
+      chatKind: chatKind,
+      conversationId: conversationId,
+      bytes: bytes,
+      fileName: fileName,
+      type: type,
+      replyToId: replyToId,
+      messageId: messageId,
+      viewOnce: viewOnce,
+      userId: userId,
+      keyManager: keyManager,
+      contacts: contacts,
+      groupById: groupById,
+    );
+  }
+
   static Future<String?> _sendText({
     required DetachedChatKind chatKind,
     required String conversationId,

--- a/lib/services/pending_share_store.dart
+++ b/lib/services/pending_share_store.dart
@@ -1,0 +1,26 @@
+import 'package:prysm/models/shared_content.dart';
+
+/// Holds an OS share payload until [HomeScreen] can show the chat picker.
+class PendingShareStore {
+  PendingShareStore._();
+
+  static final PendingShareStore instance = PendingShareStore._();
+
+  SharedContent? _pending;
+
+  void set(SharedContent? content) {
+    _pending = content;
+  }
+
+  SharedContent? peek() => _pending;
+
+  SharedContent? take() {
+    final content = _pending;
+    _pending = null;
+    return content;
+  }
+
+  void clear() {
+    _pending = null;
+  }
+}

--- a/lib/services/share_intent_service.dart
+++ b/lib/services/share_intent_service.dart
@@ -1,0 +1,93 @@
+import 'dart:async';
+import 'dart:io';
+
+import 'package:path/path.dart' as p;
+import 'package:prysm/models/shared_content.dart';
+import 'package:prysm/services/pending_share_store.dart';
+import 'package:prysm/util/logging.dart';
+import 'package:receive_sharing_intent/receive_sharing_intent.dart';
+
+typedef ShareDecoyModeCheck = bool Function();
+
+/// Listens for inbound OS share intents on Android and iOS.
+class ShareIntentService {
+  ShareIntentService._();
+
+  static final ShareIntentService instance = ShareIntentService._();
+
+  StreamSubscription<List<SharedMediaFile>>? _mediaSub;
+  bool _initialized = false;
+
+  ShareDecoyModeCheck? isDecoyMode;
+  void Function()? onPendingShare;
+
+  Future<void> init() async {
+    if (_initialized) return;
+    if (!Platform.isAndroid && !Platform.isIOS) return;
+
+    _initialized = true;
+
+    _mediaSub = ReceiveSharingIntent.instance.getMediaStream().listen(
+      _handleMedia,
+      onError: (Object error, StackTrace stack) {
+        Logging.error('Share media stream error: $error\n$stack', 'ShareIntent');
+      },
+    );
+
+    try {
+      final initial = await ReceiveSharingIntent.instance.getInitialMedia();
+      _handleMedia(initial);
+    } catch (error, stack) {
+      Logging.error('Share initial media error: $error\n$stack', 'ShareIntent');
+    }
+  }
+
+  Future<void> dispose() async {
+    await _mediaSub?.cancel();
+    _mediaSub = null;
+    _initialized = false;
+  }
+
+  void _handleMedia(List<SharedMediaFile> files) {
+    if (files.isEmpty) return;
+    if (isDecoyMode?.call() == true) {
+      unawaited(ReceiveSharingIntent.instance.reset());
+      return;
+    }
+
+    // Multi-item shares: only the first item is forwarded.
+    final content = _mapFirst(files.first);
+    if (content == null) {
+      unawaited(ReceiveSharingIntent.instance.reset());
+      return;
+    }
+
+    PendingShareStore.instance.set(content);
+    unawaited(ReceiveSharingIntent.instance.reset());
+    onPendingShare?.call();
+  }
+
+  static SharedContent? mapMediaFile(SharedMediaFile file) => _mapFirst(file);
+
+  static SharedContent? _mapFirst(SharedMediaFile file) {
+    switch (file.type) {
+      case SharedMediaType.text:
+      case SharedMediaType.url:
+        final text = file.path.trim();
+        if (text.isEmpty) return null;
+        return SharedContent(kind: SharedContentKind.text, text: text);
+      case SharedMediaType.image:
+      case SharedMediaType.video:
+      case SharedMediaType.file:
+        final path = file.path.trim();
+        if (path.isEmpty) return null;
+        final fileName = p.basename(Uri.parse(path).path);
+        return SharedContent(
+          kind: SharedContentKind.file,
+          filePath: path,
+          mimeType: file.mimeType,
+          fileName: fileName.isEmpty ? 'shared_file' : fileName,
+        );
+    }
+  }
+}

--- a/lib/services/share_send_service.dart
+++ b/lib/services/share_send_service.dart
@@ -1,0 +1,127 @@
+import 'dart:typed_data';
+
+import 'package:path/path.dart' as p;
+import 'package:prysm/models/contact.dart';
+import 'package:prysm/models/group.dart';
+import 'package:prysm/models/share_target.dart';
+import 'package:prysm/models/shared_content.dart';
+import 'package:prysm/services/detached_chat_bridge.dart';
+import 'package:prysm/util/chat_attachment_ingress.dart';
+import 'package:prysm/util/file_bytes_reader.dart';
+import 'package:prysm/util/file_transfer_policy.dart';
+import 'package:prysm/util/key_manager.dart';
+import 'package:uuid/uuid.dart';
+
+class ShareSendResult {
+  const ShareSendResult({
+    required this.success,
+    this.errorMessage,
+  });
+
+  final bool success;
+  final String? errorMessage;
+}
+
+/// Sends shared OS content into a conversation without opening the chat UI.
+class ShareSendService {
+  ShareSendService._();
+
+  static Future<ShareSendResult> send({
+    required ShareTarget target,
+    required SharedContent content,
+    required String userId,
+    required KeyManager keyManager,
+    required List<Contact> contacts,
+    required Group? Function(String groupId) groupById,
+  }) async {
+    final messageId = const Uuid().v4();
+    final chatKind = target.kind;
+    final conversationId = target.conversationId;
+
+    if (content.isText) {
+      final text = content.text?.trim() ?? '';
+      if (text.isEmpty) {
+        return const ShareSendResult(
+          success: false,
+          errorMessage: 'Nothing to send.',
+        );
+      }
+      final sentId = await DetachedChatBridge.sendSharedText(
+        chatKind: chatKind,
+        conversationId: conversationId,
+        text: text,
+        messageId: messageId,
+        userId: userId,
+        keyManager: keyManager,
+        contacts: contacts,
+        groupById: groupById,
+      );
+      return ShareSendResult(
+        success: sentId != null,
+        errorMessage: sentId == null ? 'Could not send message.' : null,
+      );
+    }
+
+    final path = content.filePath;
+    if (path == null || path.isEmpty) {
+      return const ShareSendResult(
+        success: false,
+        errorMessage: 'Shared file is unavailable.',
+      );
+    }
+
+    final bytes = await readFileBytesDeferred(path);
+    if (!FileTransferPolicy.isWithinMaxFileSize(bytes.length)) {
+      return ShareSendResult(
+        success: false,
+        errorMessage: FileTransferPolicy.maxFileSizeError,
+      );
+    }
+
+    final fileName = _resolveFileName(content);
+    final isImage = ChatAttachmentIngress.isImageFileName(fileName) ||
+        (content.mimeType?.startsWith('image/') ?? false);
+
+    Uint8List payload = bytes;
+    var type = 'file';
+    if (isImage) {
+      payload = await ChatAttachmentIngress.prepareImageBytes(bytes);
+      if (!FileTransferPolicy.isWithinMaxFileSize(payload.length)) {
+        return ShareSendResult(
+          success: false,
+          errorMessage: FileTransferPolicy.maxFileSizeError,
+        );
+      }
+      type = 'image';
+    }
+
+    final sentId = await DetachedChatBridge.sendSharedFile(
+      chatKind: chatKind,
+      conversationId: conversationId,
+      bytes: payload,
+      fileName: fileName,
+      type: type,
+      messageId: messageId,
+      userId: userId,
+      keyManager: keyManager,
+      contacts: contacts,
+      groupById: groupById,
+    );
+
+    return ShareSendResult(
+      success: sentId != null,
+      errorMessage: sentId == null ? 'Could not send file.' : null,
+    );
+  }
+
+  static String _resolveFileName(SharedContent content) {
+    final fromContent = content.fileName?.trim();
+    if (fromContent != null && fromContent.isNotEmpty) {
+      return fromContent;
+    }
+    final path = content.filePath;
+    if (path == null || path.isEmpty) return 'shared_file';
+    final base = p.basename(Uri.parse(path).path);
+    return base.isEmpty ? 'shared_file' : base;
+  }
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -96,6 +96,7 @@ dependencies:
   ota_update: ^7.1.0
   package_info_plus: ^8.3.0
   pub_semver: ^2.2.0
+  receive_sharing_intent: ^1.9.0
 
 # opus_flutter_windows 3.0.0 on pub.dev declares `pluginClass: none`, which
 # newer Flutter tooling treats as a native method-channel plugin. That makes

--- a/test/pending_share_store_test.dart
+++ b/test/pending_share_store_test.dart
@@ -1,0 +1,24 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:prysm/models/shared_content.dart';
+import 'package:prysm/services/pending_share_store.dart';
+
+void main() {
+  test('PendingShareStore set peek take clear', () {
+    final store = PendingShareStore.instance;
+    store.clear();
+
+    expect(store.peek(), isNull);
+
+    const content = SharedContent(kind: SharedContentKind.text, text: 'hello');
+    store.set(content);
+    expect(store.peek(), same(content));
+
+    final taken = store.take();
+    expect(taken, same(content));
+    expect(store.peek(), isNull);
+
+    store.set(content);
+    store.clear();
+    expect(store.peek(), isNull);
+  });
+}

--- a/test/share_intent_mapper_test.dart
+++ b/test/share_intent_mapper_test.dart
@@ -1,0 +1,53 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:prysm/models/shared_content.dart';
+import 'package:prysm/services/share_intent_service.dart';
+import 'package:receive_sharing_intent/receive_sharing_intent.dart';
+
+void main() {
+  group('ShareIntentService.mapMediaFile', () {
+    test('maps text payloads', () {
+      final content = ShareIntentService.mapMediaFile(
+        SharedMediaFile(path: 'hello world', type: SharedMediaType.text),
+      );
+
+      expect(content?.kind, SharedContentKind.text);
+      expect(content?.text, 'hello world');
+    });
+
+    test('maps url payloads as text', () {
+      final content = ShareIntentService.mapMediaFile(
+        SharedMediaFile(
+          path: 'https://example.com',
+          type: SharedMediaType.url,
+        ),
+      );
+
+      expect(content?.kind, SharedContentKind.text);
+      expect(content?.text, 'https://example.com');
+    });
+
+    test('maps image files', () {
+      final content = ShareIntentService.mapMediaFile(
+        SharedMediaFile(
+          path: '/tmp/photo.jpg',
+          type: SharedMediaType.image,
+          mimeType: 'image/jpeg',
+        ),
+      );
+
+      expect(content?.kind, SharedContentKind.file);
+      expect(content?.filePath, '/tmp/photo.jpg');
+      expect(content?.fileName, 'photo.jpg');
+      expect(content?.mimeType, 'image/jpeg');
+    });
+
+    test('ignores empty payloads', () {
+      expect(
+        ShareIntentService.mapMediaFile(
+          SharedMediaFile(path: '   ', type: SharedMediaType.text),
+        ),
+        isNull,
+      );
+    });
+  });
+}

--- a/test/shared_content_test.dart
+++ b/test/shared_content_test.dart
@@ -1,0 +1,25 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:prysm/models/shared_content.dart';
+import 'package:prysm/util/file_transfer_policy.dart';
+
+void main() {
+  group('SharedContent file limits', () {
+    test('max file size policy rejects oversized payloads', () {
+      final oversized = FileTransferPolicy.maxFileSizeBytes + 1;
+      expect(FileTransferPolicy.isWithinMaxFileSize(oversized), isFalse);
+      expect(
+        FileTransferPolicy.isWithinMaxFileSize(FileTransferPolicy.maxFileSizeBytes),
+        isTrue,
+      );
+    });
+
+    test('text content is identified correctly', () {
+      const content = SharedContent(
+        kind: SharedContentKind.text,
+        text: 'shared note',
+      );
+      expect(content.isText, isTrue);
+      expect(content.isFile, isFalse);
+    });
+  });
+}


### PR DESCRIPTION
- Added a new share extension to enable sharing text, images, and videos from other apps into the Prysm app.
- Updated AndroidManifest.xml to handle various share intents for different media types.
- Enhanced iOS Info.plist and added necessary entitlements for the share extension.
- Created ShareViewController to manage the share interface and handle incoming shared content.
- Introduced models for shared content and share targets to facilitate sharing functionality.
- Implemented services to manage incoming share intents and send shared content to conversations.
- Added tests for pending share store and share intent mapping to ensure reliability.