### PR TITLE
feat: integrate connectivity_plus for network reachability

### DIFF
--- a/lib/services/app_update_service.dart
+++ b/lib/services/app_update_service.dart
@@ -10,6 +10,7 @@ import 'package:prysm/models/release_info.dart';
 import 'package:prysm/screens/widgets/update_available_dialog.dart';
 import 'package:prysm/services/settings_service.dart';
 import 'package:prysm/util/logging.dart';
+import 'package:prysm/util/network_reachability.dart';
 import 'package:prysm/util/updater_downloader.dart';
 import 'package:prysm/util/version_compare.dart';
 
@@ -61,6 +62,13 @@ class AppUpdateService {
 
   Future<UpdateCheckResult> checkForUpdate() async {
     try {
+      if (!await NetworkReachability.hasInternet()) {
+        return const UpdateCheckResult(
+          status: UpdateCheckStatus.error,
+          errorMessage: 'No network connection.',
+        );
+      }
+
       final release = await fetchLatestRelease();
       final current = await getCurrentVersion();
       if (isNewerVersion(current, release.tagName)) {
@@ -71,12 +79,24 @@ class AppUpdateService {
       }
       return const UpdateCheckResult(status: UpdateCheckStatus.upToDate);
     } catch (e, st) {
-      Logging.error('Update check failed: $e\n$st', 'AppUpdateService');
+      if (!_isConnectivityError(e)) {
+        Logging.error('Update check failed: $e\n$st', 'AppUpdateService');
+      }
       return UpdateCheckResult(
         status: UpdateCheckStatus.error,
-        errorMessage: e.toString(),
+        errorMessage: _isConnectivityError(e)
+            ? 'No network connection.'
+            : e.toString(),
       );
     }
+  }
+
+  static bool _isConnectivityError(Object error) {
+    if (error is SocketException) return true;
+    final text = error.toString();
+    return text.contains('SocketException') ||
+        text.contains('Failed host lookup') ||
+        text.contains('No address associated with hostname');
   }
 
   Future<void> checkOnStartup(BuildContext context) async {

--- a/lib/util/network_reachability.dart
+++ b/lib/util/network_reachability.dart
@@ -1,15 +1,30 @@
-import 'dart:async';
+import 'dart:io';
 
-import 'package:http/http.dart' as http;
+import 'package:connectivity_plus/connectivity_plus.dart';
 
-/// Lightweight internet reachability probe (not just link-up).
+/// OS-level link-up check: active WiFi/mobile/ethernet plus a non-loopback IPv4.
 class NetworkReachability {
   NetworkReachability._();
 
-  static const _probeUrl = 'https://www.google.com/generate_204';
+  static const _linkUpTransports = {
+    ConnectivityResult.wifi,
+    ConnectivityResult.mobile,
+    ConnectivityResult.ethernet,
+  };
 
-  /// Injectable probe for tests. Defaults to a short HTTP HEAD request.
+  /// Injectable probe for tests. Defaults to OS transport + local address checks.
   static Future<bool> Function({Duration timeout}) probe = _defaultProbe;
+
+  /// Injectable connectivity check for tests.
+  static Future<List<ConnectivityResult>> Function() checkConnectivity =
+      () => Connectivity().checkConnectivity();
+
+  /// Injectable network interface listing for tests.
+  static Future<List<NetworkInterface>> Function() listNetworkInterfaces =
+      () => NetworkInterface.list(
+        type: InternetAddressType.IPv4,
+        includeLinkLocal: true,
+      );
 
   static Future<bool> hasInternet({
     Duration timeout = const Duration(seconds: 3),
@@ -24,15 +39,14 @@ class NetworkReachability {
   static Future<bool> _defaultProbe({
     Duration timeout = const Duration(seconds: 3),
   }) async {
-    try {
-      final response = await http
-          .head(Uri.parse(_probeUrl))
-          .timeout(timeout);
-      return response.statusCode >= 200 && response.statusCode < 400;
-    } on TimeoutException {
-      return false;
-    } catch (_) {
+    final results = await checkConnectivity();
+    if (!results.any(_linkUpTransports.contains)) {
       return false;
     }
+
+    final interfaces = await listNetworkInterfaces();
+    return interfaces.any(
+      (iface) => iface.addresses.any((addr) => !addr.isLoopback),
+    );
   }
 }

--- a/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -8,6 +8,7 @@ import Foundation
 import audio_session
 import audioplayers_darwin
 import battery_plus
+import connectivity_plus
 import desktop_drop
 import desktop_multi_window
 import device_info_plus
@@ -40,6 +41,7 @@ func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
   AudioSessionPlugin.register(with: registry.registrar(forPlugin: "AudioSessionPlugin"))
   AudioplayersDarwinPlugin.register(with: registry.registrar(forPlugin: "AudioplayersDarwinPlugin"))
   BatteryPlusMacosPlugin.register(with: registry.registrar(forPlugin: "BatteryPlusMacosPlugin"))
+  ConnectivityPlusPlugin.register(with: registry.registrar(forPlugin: "ConnectivityPlusPlugin"))
   DesktopDropPlugin.register(with: registry.registrar(forPlugin: "DesktopDropPlugin"))
   FlutterMultiWindowPlugin.register(with: registry.registrar(forPlugin: "FlutterMultiWindowPlugin"))
   DeviceInfoPlusMacosPlugin.register(with: registry.registrar(forPlugin: "DeviceInfoPlusMacosPlugin"))

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -42,6 +42,7 @@ dependencies:
   cupertino_icons: ^1.0.8
   sqflite_common_ffi: ^2.3.6
   http: ^1.5.0
+  connectivity_plus: ^6.1.4
   hex: ^0.2.0
   shelf: ^1.4.2
   shelf_web_socket: ^2.0.1

--- a/test/network_reachability_test.dart
+++ b/test/network_reachability_test.dart
@@ -1,33 +1,136 @@
+import 'dart:io';
+
+import 'package:connectivity_plus/connectivity_plus.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:prysm/util/network_reachability.dart';
 
+class _FakeNetworkInterface implements NetworkInterface {
+  _FakeNetworkInterface(this._addresses);
+
+  final List<InternetAddress> _addresses;
+
+  @override
+  List<InternetAddress> get addresses => _addresses;
+
+  @override
+  int get index => 1;
+
+  @override
+  String get name => 'fake0';
+}
+
+List<NetworkInterface> _ifaces(String host) => [
+  _FakeNetworkInterface([InternetAddress(host)]),
+];
+
 void main() {
   final originalProbe = NetworkReachability.probe;
+  final originalCheckConnectivity = NetworkReachability.checkConnectivity;
+  final originalListNetworkInterfaces = NetworkReachability.listNetworkInterfaces;
 
   tearDown(() {
     NetworkReachability.probe = originalProbe;
+    NetworkReachability.checkConnectivity = originalCheckConnectivity;
+    NetworkReachability.listNetworkInterfaces = originalListNetworkInterfaces;
   });
 
-  test('hasInternet returns true when probe succeeds', () async {
-    NetworkReachability.probe =
-        ({Duration timeout = const Duration(seconds: 3)}) async => true;
+  group('hasInternet probe override', () {
+    test('returns true when probe succeeds', () async {
+      NetworkReachability.probe =
+          ({Duration timeout = const Duration(seconds: 3)}) async => true;
 
-    expect(await NetworkReachability.hasInternet(), isTrue);
+      expect(await NetworkReachability.hasInternet(), isTrue);
+    });
+
+    test('returns false when probe fails', () async {
+      NetworkReachability.probe =
+          ({Duration timeout = const Duration(seconds: 3)}) async => false;
+
+      expect(await NetworkReachability.hasInternet(), isFalse);
+    });
+
+    test('returns false when probe throws', () async {
+      NetworkReachability.probe =
+          ({Duration timeout = const Duration(seconds: 3)}) async {
+        throw Exception('network down');
+      };
+
+      expect(await NetworkReachability.hasInternet(), isFalse);
+    });
   });
 
-  test('hasInternet returns false when probe fails', () async {
-    NetworkReachability.probe =
-        ({Duration timeout = const Duration(seconds: 3)}) async => false;
+  group('default probe', () {
+    setUp(() {
+      NetworkReachability.probe = originalProbe;
+    });
 
-    expect(await NetworkReachability.hasInternet(), isFalse);
-  });
+    Future<bool> runDefaultProbe({
+      required List<ConnectivityResult> connectivity,
+      required List<NetworkInterface> interfaces,
+    }) async {
+      NetworkReachability.checkConnectivity = () async => connectivity;
+      NetworkReachability.listNetworkInterfaces = () async => interfaces;
+      return NetworkReachability.hasInternet();
+    }
 
-  test('hasInternet returns false when probe throws', () async {
-    NetworkReachability.probe =
-        ({Duration timeout = const Duration(seconds: 3)}) async {
-      throw Exception('network down');
-    };
+    test('wifi with local IPv4 returns true', () async {
+      expect(
+        await runDefaultProbe(
+          connectivity: [ConnectivityResult.wifi],
+          interfaces: _ifaces('192.168.1.5'),
+        ),
+        isTrue,
+      );
+    });
 
-    expect(await NetworkReachability.hasInternet(), isFalse);
+    test('mobile with local IPv4 returns true', () async {
+      expect(
+        await runDefaultProbe(
+          connectivity: [ConnectivityResult.mobile],
+          interfaces: _ifaces('10.0.0.2'),
+        ),
+        isTrue,
+      );
+    });
+
+    test('ethernet with local IPv4 returns true', () async {
+      expect(
+        await runDefaultProbe(
+          connectivity: [ConnectivityResult.ethernet],
+          interfaces: _ifaces('192.168.0.10'),
+        ),
+        isTrue,
+      );
+    });
+
+    test('no connectivity returns false', () async {
+      expect(
+        await runDefaultProbe(
+          connectivity: [ConnectivityResult.none],
+          interfaces: _ifaces('192.168.1.5'),
+        ),
+        isFalse,
+      );
+    });
+
+    test('wifi with only loopback returns false', () async {
+      expect(
+        await runDefaultProbe(
+          connectivity: [ConnectivityResult.wifi],
+          interfaces: _ifaces('127.0.0.1'),
+        ),
+        isFalse,
+      );
+    });
+
+    test('vpn only with local IPv4 returns false', () async {
+      expect(
+        await runDefaultProbe(
+          connectivity: [ConnectivityResult.vpn],
+          interfaces: _ifaces('192.168.1.5'),
+        ),
+        isFalse,
+      );
+    });
   });
 }

--- a/windows/flutter/generated_plugin_registrant.cc
+++ b/windows/flutter/generated_plugin_registrant.cc
@@ -8,6 +8,7 @@
 
 #include <audioplayers_windows/audioplayers_windows_plugin.h>
 #include <battery_plus/battery_plus_windows_plugin.h>
+#include <connectivity_plus/connectivity_plus_windows_plugin.h>
 #include <desktop_drop/desktop_drop_plugin.h>
 #include <desktop_multi_window/desktop_multi_window_plugin.h>
 #include <emoji_picker_flutter/emoji_picker_flutter_plugin_c_api.h>
@@ -29,6 +30,8 @@ void RegisterPlugins(flutter::PluginRegistry* registry) {
       registry->GetRegistrarForPlugin("AudioplayersWindowsPlugin"));
   BatteryPlusWindowsPluginRegisterWithRegistrar(
       registry->GetRegistrarForPlugin("BatteryPlusWindowsPlugin"));
+  ConnectivityPlusWindowsPluginRegisterWithRegistrar(
+      registry->GetRegistrarForPlugin("ConnectivityPlusWindowsPlugin"));
   DesktopDropPluginRegisterWithRegistrar(
       registry->GetRegistrarForPlugin("DesktopDropPlugin"));
   DesktopMultiWindowPluginRegisterWithRegistrar(

--- a/windows/flutter/generated_plugins.cmake
+++ b/windows/flutter/generated_plugins.cmake
@@ -5,6 +5,7 @@
 list(APPEND FLUTTER_PLUGIN_LIST
   audioplayers_windows
   battery_plus
+  connectivity_plus
   desktop_drop
   desktop_multi_window
   emoji_picker_flutter


### PR DESCRIPTION
- Added connectivity_plus dependency to pubspec.yaml.
- Implemented network reachability checks in AppUpdateService to handle internet connectivity status.
- Enhanced NetworkReachability class with OS-level checks and updated probe methods.
- Updated tests for network reachability to cover various connectivity scenarios.
- Registered connectivity_plus plugin for macOS and Windows platforms.