### PR TITLE
feat: implement direct message authentication and pending message han…

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,11 @@ Tor onion addresses are separate from Prysm identity keys.
 
 - **Double Ratchet** (`ratchet-1`) with X3DH-style prekey bundles for session bootstrap.
 - Per-message **AES-256-GCM** with chain-derived keys (forward secrecy).
-- Files use ephemeral X25519 + HKDF + AES-GCM (`dh-aead-1` / `file-aead-1`).
+- Fallback / first-contact messages use **signed** ephemeral DH (`dm-signed-1`): Ed25519 binds the sender's signing key to the ciphertext.
+- Peer attachments use **signed** file envelopes (`file-signed-1`) with an Ed25519-authenticated key wrap.
+- Unsigned `dh-aead-1` / `file-aead-1` are legacy-read-only for messages already stored locally; new inbound peer messages without a valid signature are rejected.
+- While the app is locked, inbound direct messages are stored as `pending_auth` (ciphertext only, no display or content notifications). Signed envelopes with a known sender identity are signature-checked immediately; ratchet and unsigned messages are promoted or quarantined on unlock.
+- First-contact ingress awaits a Tor profile fetch to resolve the sender's identity before authentication.
 
 ### Group messages
 

--- a/lib/app/unlock_controller.dart
+++ b/lib/app/unlock_controller.dart
@@ -2,6 +2,7 @@ import 'package:prysm/crypto/key_store.dart';
 import 'package:prysm/models/panic_action.dart';
 import 'package:prysm/services/panic_pin_service.dart';
 import 'package:prysm/services/panic_wipe_service.dart';
+import 'package:prysm/services/pending_auth_message_service.dart';
 import 'package:prysm/services/settings_service.dart';
 import 'package:prysm/services/unlock_lockout_service.dart';
 import 'package:prysm/util/db_helper.dart';
@@ -74,6 +75,8 @@ class UnlockController {
               keyManager.safeRead(CryptoKeyStore.publicIdentityKey),
           contactCount: await _contactCount(),
         );
+        await PendingAuthMessageService(keyManager: keyManager)
+            .promotePendingAfterUnlock();
         return const UnlockOutcome(unlocked: true);
       }
       await lockout.recordPrimaryFailure();

--- a/lib/crypto/constants.dart
+++ b/lib/crypto/constants.dart
@@ -17,9 +17,11 @@ class CryptoConstants {
   static const int argon2Lanes = 1;
 
   static const String schemeDhAead1 = 'dh-aead-1';
+  static const String schemeDmSigned1 = 'dm-signed-1';
   static const String schemeGroupAead1 = 'group-aead-1';
   static const String schemeControlWrap1 = 'control-wrap-1';
   static const String schemeFileAead1 = 'file-aead-1';
+  static const String schemeFileSigned1 = 'file-signed-1';
   static const String schemeCallAead1 = 'call-aead-1';
   static const String schemeRatchet1 = 'ratchet-1';
   static const String schemeGroupSender1 = 'group-sender-1';

--- a/lib/crypto/crypto.dart
+++ b/lib/crypto/crypto.dart
@@ -5,6 +5,7 @@ export 'aead.dart';
 export 'identity.dart';
 export 'key_store.dart';
 export 'wire.dart';
+export 'direct_message_auth.dart';
 export 'group_crypto.dart';
 export 'qr_payload.dart';
 export 'ratchet/prekey_bundle.dart';

--- a/lib/crypto/direct_message_auth.dart
+++ b/lib/crypto/direct_message_auth.dart
@@ -1,0 +1,201 @@
+import 'dart:convert';
+
+import 'package:prysm/constants/group_constants.dart';
+import 'package:prysm/crypto/constants.dart';
+import 'package:prysm/crypto/envelope.dart';
+import 'package:prysm/crypto/identity.dart';
+import 'package:prysm/crypto/ratchet/ratchet_service.dart';
+import 'package:prysm/crypto/wire.dart';
+import 'package:prysm/util/key_manager.dart';
+
+/// Result of inbound direct-message authentication.
+enum DirectAuthOutcome {
+  accepted,
+  pendingAuth,
+  rejected,
+}
+
+const Set<String> _directMediaTypes = {'file', 'image', 'audio'};
+
+/// Authenticates inbound 1:1 ciphertext before storage or promotion.
+class DirectMessageAuth {
+  DirectMessageAuth._();
+
+  static String? _schemeOfWire(String wire) {
+    final envelope = CryptoEnvelope.tryParse(wire);
+    if (envelope == null) {
+      final parsed = _tryParseRatchetWire(wire);
+      return parsed?['scheme'] as String?;
+    }
+    return CryptoEnvelope.schemeOf(envelope);
+  }
+
+  static Map<String, dynamic>? _tryParseRatchetWire(String wire) {
+    final trimmed = wire.trimLeft();
+    if (!trimmed.startsWith('{')) return null;
+    try {
+      final parsed = jsonDecode(wire);
+      if (parsed is! Map<String, dynamic>) return null;
+      if (parsed['crypto'] != CryptoConstants.cryptoVersion) return null;
+      return parsed;
+    } catch (_) {
+      return null;
+    }
+  }
+
+  static bool _isDirectMediaType(String type) => _directMediaTypes.contains(type);
+
+  static Future<DirectAuthOutcome> authenticateInboundDirect({
+    required String senderId,
+    required String wire,
+    required String type,
+    required String? localUserId,
+    required KeyManager keyManager,
+    required Future<IdentityPublicKeys?> Function(String peerId) resolveIdentity,
+    bool fullDecrypt = true,
+    bool allowLegacyUnsignedDhAead = false,
+    bool allowLegacyUnsignedFile = false,
+  }) async {
+    if (localUserId != null && senderId == localUserId) {
+      return DirectAuthOutcome.accepted;
+    }
+
+    if (!isDirectMessageType(type)) {
+      return DirectAuthOutcome.accepted;
+    }
+
+    final scheme = _schemeOfWire(wire);
+    if (scheme == null) {
+      return fullDecrypt
+          ? DirectAuthOutcome.rejected
+          : DirectAuthOutcome.pendingAuth;
+    }
+
+    final peerKeys = await resolveIdentity(senderId);
+
+    if (scheme == CryptoConstants.schemeDmSigned1) {
+      if (peerKeys == null) {
+        return fullDecrypt
+            ? DirectAuthOutcome.rejected
+            : DirectAuthOutcome.pendingAuth;
+      }
+      try {
+        if (fullDecrypt && keyManager.isUnlocked) {
+          await keyManager.decryptPeerMessage(
+            peerId: senderId,
+            wire: wire,
+            peer: peerKeys,
+            allowLegacyUnsignedDhAead: false,
+          );
+        } else {
+          await CryptoWire.verifyDmSignedWire(wire, peerKeys);
+        }
+        return fullDecrypt && keyManager.isUnlocked
+            ? DirectAuthOutcome.accepted
+            : DirectAuthOutcome.pendingAuth;
+      } catch (_) {
+        return DirectAuthOutcome.rejected;
+      }
+    }
+
+    if (_isDirectMediaType(type) &&
+        scheme == CryptoConstants.schemeFileSigned1) {
+      if (peerKeys == null) {
+        return fullDecrypt
+            ? DirectAuthOutcome.rejected
+            : DirectAuthOutcome.pendingAuth;
+      }
+      try {
+        if (fullDecrypt && keyManager.isUnlocked) {
+          await CryptoWire.decryptFileFromPeer(
+            wire,
+            keyManager.identity,
+            peerKeys,
+            allowLegacyUnsignedFile: false,
+          );
+        } else {
+          await CryptoWire.verifySignedFileWrap(wire, peerKeys);
+        }
+        return fullDecrypt && keyManager.isUnlocked
+            ? DirectAuthOutcome.accepted
+            : DirectAuthOutcome.pendingAuth;
+      } catch (_) {
+        return DirectAuthOutcome.rejected;
+      }
+    }
+
+    if (scheme == CryptoConstants.schemeRatchet1) {
+      if (!fullDecrypt || !keyManager.isUnlocked || peerKeys == null) {
+        return DirectAuthOutcome.pendingAuth;
+      }
+      try {
+        await RatchetService.instance.decryptText(
+          peerId: senderId,
+          wire: wire,
+          local: keyManager.identity,
+          peer: peerKeys,
+          allowLegacyUnsignedDhAead: false,
+        );
+        return DirectAuthOutcome.accepted;
+      } catch (_) {
+        return DirectAuthOutcome.rejected;
+      }
+    }
+
+    if (scheme == CryptoConstants.schemeDhAead1) {
+      if (peerKeys != null) {
+        return DirectAuthOutcome.rejected;
+      }
+      return DirectAuthOutcome.pendingAuth;
+    }
+
+    if (_isDirectMediaType(type) &&
+        scheme == CryptoConstants.schemeFileAead1) {
+      if (peerKeys != null) {
+        return DirectAuthOutcome.rejected;
+      }
+      return DirectAuthOutcome.pendingAuth;
+    }
+
+    if (!fullDecrypt) {
+      return DirectAuthOutcome.pendingAuth;
+    }
+
+    if (type == 'text' && scheme == CryptoConstants.schemeDhAead1) {
+      if (!allowLegacyUnsignedDhAead || peerKeys == null) {
+        return DirectAuthOutcome.rejected;
+      }
+      try {
+        await keyManager.decryptPeerMessage(
+          peerId: senderId,
+          wire: wire,
+          peer: peerKeys,
+          allowLegacyUnsignedDhAead: true,
+        );
+        return DirectAuthOutcome.accepted;
+      } catch (_) {
+        return DirectAuthOutcome.rejected;
+      }
+    }
+
+    if (_isDirectMediaType(type) &&
+        scheme == CryptoConstants.schemeFileAead1 &&
+        allowLegacyUnsignedFile &&
+        peerKeys != null &&
+        keyManager.isUnlocked) {
+      try {
+        await CryptoWire.decryptFileFromPeer(
+          wire,
+          keyManager.identity,
+          peerKeys,
+          allowLegacyUnsignedFile: true,
+        );
+        return DirectAuthOutcome.accepted;
+      } catch (_) {
+        return DirectAuthOutcome.rejected;
+      }
+    }
+
+    return DirectAuthOutcome.rejected;
+  }
+}

--- a/lib/crypto/envelope.dart
+++ b/lib/crypto/envelope.dart
@@ -23,6 +23,24 @@ class CryptoEnvelope {
     };
   }
 
+  static Map<String, dynamic> dmSigned1({
+    required Uint8List ephemeralPublic,
+    required Uint8List ciphertext,
+    required Uint8List nonce,
+    required List<int> signature,
+    String alg = 'aes-gcm',
+  }) {
+    return {
+      'crypto': CryptoConstants.cryptoVersion,
+      'scheme': CryptoConstants.schemeDmSigned1,
+      'alg': alg,
+      'ephemeralPub': base64Encode(ephemeralPublic),
+      'nonce': base64Encode(nonce),
+      'ciphertext': base64Encode(ciphertext),
+      'sig': base64Encode(signature),
+    };
+  }
+
   static Map<String, dynamic> groupAead1({
     required Uint8List iv,
     required Uint8List ciphertext,
@@ -57,6 +75,20 @@ class CryptoEnvelope {
     return {
       'crypto': CryptoConstants.cryptoVersion,
       'scheme': CryptoConstants.schemeFileAead1,
+      'wrappedKey': wrappedKey,
+      'nonce': base64Encode(nonce),
+      'ciphertext': base64Encode(ciphertext),
+    };
+  }
+
+  static Map<String, dynamic> fileSigned1({
+    required Map<String, dynamic> wrappedKey,
+    required Uint8List nonce,
+    required Uint8List ciphertext,
+  }) {
+    return {
+      'crypto': CryptoConstants.cryptoVersion,
+      'scheme': CryptoConstants.schemeFileSigned1,
       'wrappedKey': wrappedKey,
       'nonce': base64Encode(nonce),
       'ciphertext': base64Encode(ciphertext),

--- a/lib/crypto/ratchet/ratchet_service.dart
+++ b/lib/crypto/ratchet/ratchet_service.dart
@@ -96,12 +96,14 @@ class RatchetService {
     required String wire,
     required IdentityKeyPair local,
     required IdentityPublicKeys peer,
+    bool allowLegacyUnsignedDhAead = false,
   }) =>
       decryptBytes(
         peerId: peerId,
         wire: wire,
         local: local,
         peer: peer,
+        allowLegacyUnsignedDhAead: allowLegacyUnsignedDhAead,
       ).then(utf8.decode);
 
   Future<Uint8List> decryptBytes({
@@ -109,18 +111,23 @@ class RatchetService {
     required String wire,
     required IdentityKeyPair local,
     required IdentityPublicKeys peer,
+    bool allowLegacyUnsignedDhAead = false,
   }) async {
     final envelope = jsonDecode(wire) as Map<String, dynamic>;
     final scheme = envelope['scheme'] as String?;
 
+    if (scheme == CryptoConstants.schemeDmSigned1) {
+      return CryptoWire.decryptSignedFromPeer(wire, local, peer);
+    }
+
     if (scheme == CryptoConstants.schemeDhAead1) {
-      return CryptoWire.decryptFromPeer(wire, local, peer.agreePublic);
+      if (!allowLegacyUnsignedDhAead) {
+        throw const FormatException('Unsigned peer message rejected');
+      }
+      return CryptoWire.decryptLegacyFromPeer(wire, local);
     }
 
     if (scheme != CryptoConstants.schemeRatchet1) {
-      if (envelope['crypto'] == CryptoConstants.cryptoVersion) {
-        return CryptoWire.decryptFromPeer(wire, local, peer.agreePublic);
-      }
       throw FormatException('Unsupported ciphertext scheme: $scheme');
     }
 

--- a/lib/crypto/wire.dart
+++ b/lib/crypto/wire.dart
@@ -13,8 +13,16 @@ class CryptoWire {
   CryptoWire._();
 
   static final X25519 _x25519 = X25519();
+  static final Ed25519 _ed25519 = Ed25519();
 
-  /// Ephemeral X25519 + HKDF + AES-GCM for 1:1 text/binary.
+  static String _dmSignPayload({
+    required String ephemeralPub,
+    required String nonce,
+    required String ciphertext,
+  }) =>
+      '$ephemeralPub|$nonce|$ciphertext';
+
+  /// Ephemeral X25519 + HKDF + AES-GCM for 1:1 text/binary (unsigned).
   static Future<String> encryptForPeer(
     Uint8List plaintext,
     IdentityKeyPair sender,
@@ -48,18 +56,86 @@ class CryptoWire {
   ) =>
       encryptForPeer(utf8.encode(plaintext), sender, peerAgreePublic);
 
-  static Future<Uint8List> decryptFromPeer(
-    String wire,
-    IdentityKeyPair recipient,
-    SimplePublicKey senderAgreePublic,
+  /// Signed 1:1 DM: dh-aead-1 core + Ed25519 sender authentication.
+  static Future<String> encryptSignedForPeer(
+    Uint8List plaintext,
+    IdentityKeyPair sender,
+    SimplePublicKey peerAgreePublic,
   ) async {
-    final envelope = CryptoEnvelope.tryParse(wire);
-    if (envelope == null) {
-      throw FormatException('Not a v2 crypto envelope');
+    final ephemeral = await _x25519.newKeyPair();
+    final ephemeralPublic = await ephemeral.extractPublicKey();
+    final shared = await _x25519.sharedSecretKey(
+      keyPair: ephemeral,
+      remotePublicKey: peerAgreePublic,
+    );
+    final sharedBytes = await shared.extractBytes();
+    final aeadKey = await CryptoKdf.hkdf(
+      sharedSecret: sharedBytes,
+      info: utf8.encode(CryptoConstants.hkdfInfoDhAead),
+      salt: ephemeralPublic.bytes,
+    );
+    final enc = await CryptoAead.encryptAesGcm(plaintext, key: aeadKey);
+    final ephemeralPubB64 = base64Encode(ephemeralPublic.bytes);
+    final nonceB64 = base64Encode(enc.nonce);
+    final ciphertextB64 = base64Encode(enc.ciphertext);
+    final signPayload = utf8.encode(
+      _dmSignPayload(
+        ephemeralPub: ephemeralPubB64,
+        nonce: nonceB64,
+        ciphertext: ciphertextB64,
+      ),
+    );
+    final signature = await sender.sign(signPayload);
+    final envelope = CryptoEnvelope.dmSigned1(
+      ephemeralPublic: Uint8List.fromList(ephemeralPublic.bytes),
+      ciphertext: enc.ciphertext,
+      nonce: enc.nonce,
+      signature: signature.bytes,
+    );
+    return CryptoEnvelope.encode(envelope);
+  }
+
+  static Future<String> encryptSignedTextForPeer(
+    String plaintext,
+    IdentityKeyPair sender,
+    SimplePublicKey peerAgreePublic,
+  ) =>
+      encryptSignedForPeer(utf8.encode(plaintext), sender, peerAgreePublic);
+
+  static Future<void> _verifyDmSignedEnvelope(
+    Map<String, dynamic> envelope,
+    IdentityPublicKeys sender,
+  ) async {
+    final sigRaw = envelope['sig'] as String?;
+    if (sigRaw == null) {
+      throw const FormatException('Missing DM signature');
     }
-    if (CryptoEnvelope.schemeOf(envelope) != CryptoConstants.schemeDhAead1) {
-      throw FormatException('Unsupported scheme');
+    final ephemeralPubB64 = envelope['ephemeralPub'] as String;
+    final nonceB64 = envelope['nonce'] as String;
+    final ciphertextB64 = envelope['ciphertext'] as String;
+    final signPayload = utf8.encode(
+      _dmSignPayload(
+        ephemeralPub: ephemeralPubB64,
+        nonce: nonceB64,
+        ciphertext: ciphertextB64,
+      ),
+    );
+    final valid = await _ed25519.verify(
+      signPayload,
+      signature: Signature(
+        base64Decode(sigRaw),
+        publicKey: sender.signPublic,
+      ),
+    );
+    if (!valid) {
+      throw const FormatException('Invalid DM signature');
     }
+  }
+
+  static Future<Uint8List> _decryptDhAead1Envelope(
+    Map<String, dynamic> envelope,
+    IdentityKeyPair recipient,
+  ) async {
     final ephemeralBytes = base64Decode(envelope['ephemeralPub'] as String);
     final nonce = base64Decode(envelope['nonce'] as String);
     final ciphertext = base64Decode(envelope['ciphertext'] as String);
@@ -84,13 +160,69 @@ class CryptoWire {
     );
   }
 
+  /// Decrypts a signed peer DM (`dm-signed-1`).
+  static Future<Uint8List> decryptSignedFromPeer(
+    String wire,
+    IdentityKeyPair recipient,
+    IdentityPublicKeys sender,
+  ) async {
+    final envelope = CryptoEnvelope.tryParse(wire);
+    if (envelope == null) {
+      throw FormatException('Not a v2 crypto envelope');
+    }
+    if (CryptoEnvelope.schemeOf(envelope) != CryptoConstants.schemeDmSigned1) {
+      throw FormatException('Unsupported scheme');
+    }
+    await _verifyDmSignedEnvelope(envelope, sender);
+    return _decryptDhAead1Envelope(envelope, recipient);
+  }
+
+  static Future<String> decryptSignedTextFromPeer(
+    String wire,
+    IdentityKeyPair recipient,
+    IdentityPublicKeys sender,
+  ) async {
+    final bytes = await decryptSignedFromPeer(wire, recipient, sender);
+    return utf8.decode(bytes);
+  }
+
+  /// Legacy unsigned `dh-aead-1` decrypt (confidentiality only, no sender auth).
+  static Future<Uint8List> decryptLegacyFromPeer(
+    String wire,
+    IdentityKeyPair recipient,
+  ) async {
+    final envelope = CryptoEnvelope.tryParse(wire);
+    if (envelope == null) {
+      throw FormatException('Not a v2 crypto envelope');
+    }
+    if (CryptoEnvelope.schemeOf(envelope) != CryptoConstants.schemeDhAead1) {
+      throw FormatException('Unsupported scheme');
+    }
+    return _decryptDhAead1Envelope(envelope, recipient);
+  }
+
+  static Future<String> decryptLegacyTextFromPeer(
+    String wire,
+    IdentityKeyPair recipient,
+  ) async {
+    final bytes = await decryptLegacyFromPeer(wire, recipient);
+    return utf8.decode(bytes);
+  }
+
+  static Future<Uint8List> decryptFromPeer(
+    String wire,
+    IdentityKeyPair recipient,
+    SimplePublicKey senderAgreePublic,
+  ) async {
+    return decryptLegacyFromPeer(wire, recipient);
+  }
+
   static Future<String> decryptTextFromPeer(
     String wire,
     IdentityKeyPair recipient,
     SimplePublicKey senderAgreePublic,
   ) async {
-    final bytes = await decryptFromPeer(wire, recipient, senderAgreePublic);
-    return utf8.decode(bytes);
+    return decryptLegacyTextFromPeer(wire, recipient);
   }
 
   /// Encrypt for self (uses own agreement public key).
@@ -112,8 +244,7 @@ class CryptoWire {
     String wire,
     IdentityKeyPair identity,
   ) async {
-    final pub = await identity.agreePublicKey;
-    return decryptFromPeer(wire, identity, pub);
+    return decryptLegacyFromPeer(wire, identity);
   }
 
   static Future<String> decryptTextForSelf(
@@ -139,6 +270,52 @@ class CryptoWire {
     };
   }
 
+  /// Signed key wrap for authenticated peer file/binary payloads.
+  static Future<Map<String, dynamic>> wrapKeyForPeerSigned(
+    Uint8List keyBytes,
+    IdentityKeyPair sender,
+    SimplePublicKey peerAgreePublic,
+  ) async {
+    final wire = await encryptSignedForPeer(keyBytes, sender, peerAgreePublic);
+    final parsed = CryptoEnvelope.tryParse(wire)!;
+    return {
+      'ephemeralPub': parsed['ephemeralPub'],
+      'nonce': parsed['nonce'],
+      'ciphertext': parsed['ciphertext'],
+      'sig': parsed['sig'],
+    };
+  }
+
+  static Future<void> _verifySignedWrap(
+    Map<String, dynamic> wrapped,
+    IdentityPublicKeys sender,
+  ) async {
+    final sigRaw = wrapped['sig'] as String?;
+    if (sigRaw == null) {
+      throw const FormatException('Missing signed wrap signature');
+    }
+    final ephemeralPubB64 = wrapped['ephemeralPub'] as String;
+    final nonceB64 = wrapped['nonce'] as String;
+    final ciphertextB64 = wrapped['ciphertext'] as String;
+    final signPayload = utf8.encode(
+      _dmSignPayload(
+        ephemeralPub: ephemeralPubB64,
+        nonce: nonceB64,
+        ciphertext: ciphertextB64,
+      ),
+    );
+    final valid = await _ed25519.verify(
+      signPayload,
+      signature: Signature(
+        base64Decode(sigRaw),
+        publicKey: sender.signPublic,
+      ),
+    );
+    if (!valid) {
+      throw const FormatException('Invalid signed wrap signature');
+    }
+  }
+
   static Future<Uint8List> unwrapKeyFromPeer(
     Map<String, dynamic> wrapped,
     IdentityKeyPair recipient,
@@ -151,8 +328,25 @@ class CryptoWire {
       'nonce': wrapped['nonce'],
       'ciphertext': wrapped['ciphertext'],
     });
-    final pub = await recipient.agreePublicKey;
-    return decryptFromPeer(wire, recipient, pub);
+    return decryptLegacyFromPeer(wire, recipient);
+  }
+
+  static Future<Uint8List> unwrapSignedKeyFromPeer(
+    Map<String, dynamic> wrapped,
+    IdentityKeyPair recipient,
+    IdentityPublicKeys sender,
+  ) async {
+    await _verifySignedWrap(wrapped, sender);
+    final wire = CryptoEnvelope.encode({
+      'crypto': CryptoConstants.cryptoVersion,
+      'scheme': CryptoConstants.schemeDmSigned1,
+      'alg': 'aes-gcm',
+      'ephemeralPub': wrapped['ephemeralPub'],
+      'nonce': wrapped['nonce'],
+      'ciphertext': wrapped['ciphertext'],
+      'sig': wrapped['sig'],
+    });
+    return decryptSignedFromPeer(wire, recipient, sender);
   }
 
   /// File payload: random AEAD key encrypts body; key wrapped for peer/self.
@@ -165,9 +359,10 @@ class CryptoWire {
     final aeadKey = await CryptoAead.secretKeyFromBytes(fileKey);
     final enc = await CryptoAead.encryptAesGcm(bytes, key: aeadKey);
     final selfPub = await identity.agreePublicKey;
-    final peerWrapped = await wrapKeyForPeer(fileKey, identity, peerAgreePublic);
+    final peerWrapped =
+        await wrapKeyForPeerSigned(fileKey, identity, peerAgreePublic);
     final selfWrapped = await wrapKeyForPeer(fileKey, identity, selfPub);
-    final peerPayload = CryptoEnvelope.encode(CryptoEnvelope.fileAead1(
+    final peerPayload = CryptoEnvelope.encode(CryptoEnvelope.fileSigned1(
       wrappedKey: peerWrapped,
       nonce: enc.nonce,
       ciphertext: enc.ciphertext,
@@ -180,6 +375,38 @@ class CryptoWire {
     return (peerPayload: peerPayload, selfPayload: selfPayload);
   }
 
+  static Future<Uint8List> _decryptFileEnvelope(
+    Map<String, dynamic> envelope,
+    IdentityKeyPair recipient, {
+    IdentityPublicKeys? sender,
+    bool allowLegacyUnsignedFile = false,
+  }) async {
+    final scheme = CryptoEnvelope.schemeOf(envelope);
+    final wrapped = envelope['wrappedKey'] as Map<String, dynamic>;
+    final nonce = base64Decode(envelope['nonce'] as String);
+    final ciphertext = base64Decode(envelope['ciphertext'] as String);
+    final Uint8List fileKey;
+    if (scheme == CryptoConstants.schemeFileSigned1) {
+      if (sender == null) {
+        throw const FormatException('Missing sender keys for signed file');
+      }
+      fileKey = await unwrapSignedKeyFromPeer(wrapped, recipient, sender);
+    } else if (scheme == CryptoConstants.schemeFileAead1) {
+      if (!allowLegacyUnsignedFile) {
+        throw const FormatException('Unsigned peer file rejected');
+      }
+      fileKey = await unwrapKeyFromPeer(wrapped, recipient);
+    } else {
+      throw FormatException('Invalid file envelope scheme: $scheme');
+    }
+    final aeadKey = await CryptoAead.secretKeyFromBytes(fileKey);
+    return CryptoAead.decryptAesGcm(
+      ciphertextWithTag: ciphertext,
+      key: aeadKey,
+      nonce: nonce,
+    );
+  }
+
   static Future<Uint8List> decryptFile(
     String wire,
     IdentityKeyPair identity,
@@ -188,15 +415,61 @@ class CryptoWire {
     if (envelope == null || envelope['scheme'] != CryptoConstants.schemeFileAead1) {
       throw FormatException('Invalid file envelope');
     }
-    final wrapped = envelope['wrappedKey'] as Map<String, dynamic>;
-    final nonce = base64Decode(envelope['nonce'] as String);
-    final ciphertext = base64Decode(envelope['ciphertext'] as String);
-    final fileKey = await unwrapKeyFromPeer(wrapped, identity);
-    final aeadKey = await CryptoAead.secretKeyFromBytes(fileKey);
-    return CryptoAead.decryptAesGcm(
-      ciphertextWithTag: ciphertext,
-      key: aeadKey,
-      nonce: nonce,
+    return _decryptFileEnvelope(
+      envelope,
+      identity,
+      allowLegacyUnsignedFile: true,
     );
+  }
+
+  /// Decrypts a peer-sent file (`file-signed-1` or legacy `file-aead-1`).
+  static Future<Uint8List> decryptFileFromPeer(
+    String wire,
+    IdentityKeyPair recipient,
+    IdentityPublicKeys sender, {
+    bool allowLegacyUnsignedFile = false,
+  }) async {
+    final envelope = CryptoEnvelope.tryParse(wire);
+    if (envelope == null) {
+      throw FormatException('Invalid file envelope');
+    }
+    final scheme = CryptoEnvelope.schemeOf(envelope);
+    if (scheme != CryptoConstants.schemeFileSigned1 &&
+        scheme != CryptoConstants.schemeFileAead1) {
+      throw FormatException('Invalid peer file envelope scheme: $scheme');
+    }
+    return _decryptFileEnvelope(
+      envelope,
+      recipient,
+      sender: sender,
+      allowLegacyUnsignedFile: allowLegacyUnsignedFile,
+    );
+  }
+
+  /// Verifies signed wrap signature without decrypting the file body.
+  static Future<void> verifySignedFileWrap(
+    String wire,
+    IdentityPublicKeys sender,
+  ) async {
+    final envelope = CryptoEnvelope.tryParse(wire);
+    if (envelope == null ||
+        envelope['scheme'] != CryptoConstants.schemeFileSigned1) {
+      throw const FormatException('Not a signed file envelope');
+    }
+    final wrapped = envelope['wrappedKey'] as Map<String, dynamic>;
+    await _verifySignedWrap(wrapped, sender);
+  }
+
+  /// Verifies dm-signed-1 signature without decrypting plaintext.
+  static Future<void> verifyDmSignedWire(
+    String wire,
+    IdentityPublicKeys sender,
+  ) async {
+    final envelope = CryptoEnvelope.tryParse(wire);
+    if (envelope == null ||
+        envelope['scheme'] != CryptoConstants.schemeDmSigned1) {
+      throw const FormatException('Not a dm-signed envelope');
+    }
+    await _verifyDmSignedEnvelope(envelope, sender);
   }
 }

--- a/lib/database/message_crud_dao.dart
+++ b/lib/database/message_crud_dao.dart
@@ -348,4 +348,16 @@ class MessageCrudDao {
       );
     });
   }
+
+  /// Direct messages awaiting post-unlock authentication.
+  Future<List<Map<String, dynamic>>> getPendingAuthDirectMessages() async {
+    return await _protect(() async {
+      final db = await _database;
+      return db.query(
+        'messages',
+        where: "groupId IS NULL AND status = 'pending_auth'",
+        orderBy: 'timestamp ASC',
+      );
+    });
+  }
 }

--- a/lib/database/messages.dart
+++ b/lib/database/messages.dart
@@ -232,6 +232,9 @@ class MessagesDb {
   }) =>
       _crudDao.getExpiredMessages(cutoff: cutoff, limit: limit);
 
+  static Future<List<Map<String, dynamic>>> getPendingAuthDirectMessages() =>
+      _crudDao.getPendingAuthDirectMessages();
+
   /// Get messages for a group, newest first (dedupe by id in caller)
   static Future<List<Map<String, dynamic>>> getMessagesForGroupBatch(
     String groupId, {

--- a/lib/screens/chat.dart
+++ b/lib/screens/chat.dart
@@ -850,6 +850,9 @@ class _ChatScreenState extends State<ChatScreen> {
     return FileAttachmentResolver.decryptEncryptedSource(
       msg['message'] as String,
       keyManager,
+      senderId: msg['senderId'] as String?,
+      localUserId: widget.userId,
+      allowLegacyUnsignedFile: true,
     );
   }
 

--- a/lib/server/PrysmServer.dart
+++ b/lib/server/PrysmServer.dart
@@ -3,6 +3,7 @@ import 'dart:convert';
 import 'dart:io';
 
 import 'package:prysm/client/TorHttpClient.dart';
+import 'package:prysm/crypto/identity.dart';
 import 'package:prysm/server/inbound_message_router.dart';
 import 'package:prysm/transport/inbound_ws_peer_link.dart';
 import 'package:prysm/transport/transport_preference.dart';
@@ -12,9 +13,11 @@ import 'package:prysm/util/db_helper.dart';
 import 'package:prysm/util/key_manager.dart';
 import 'package:prysm/util/logging.dart';
 import 'package:prysm/util/peer_profile_cache.dart';
+import 'package:prysm/util/peer_identity_loader.dart';
 import 'package:prysm/util/profile_http_uri.dart';
 import 'package:prysm/util/tor_delivery.dart';
 import 'package:prysm/services/block_service.dart';
+import 'package:prysm/services/peer_identity_resolver.dart';
 import 'package:prysm/services/settings_service.dart';
 import 'package:shelf/shelf.dart';
 import 'package:shelf/shelf_io.dart' as io;
@@ -44,6 +47,21 @@ class PrysmServer {
       settings: settings,
       localOnionAddress: () => localOnionAddress,
       fetchSenderProfile: _fetchSenderProfile,
+      resolvePeerIdentity: _resolvePeerIdentityForIngress,
+    );
+  }
+
+  Future<IdentityPublicKeys?> _resolvePeerIdentityForIngress(
+    String senderId,
+  ) async {
+    final resolver = PeerIdentityResolver(
+      peerId: senderId,
+      keyManager: keyManager,
+    );
+    return resolvePeerIdentityForIngress(
+      keyManager,
+      senderId,
+      fetchOverTor: () => resolver.fetchOverTor(),
     );
   }
 

--- a/lib/server/inbound_message_router.dart
+++ b/lib/server/inbound_message_router.dart
@@ -17,11 +17,14 @@ import 'package:prysm/util/conversation_refresh_notifier.dart';
 import 'package:prysm/util/disappearing_activity_notifier.dart';
 import 'package:prysm/util/db_helper.dart';
 import 'package:prysm/util/inbound_message_notifier.dart';
+import 'package:prysm/crypto/direct_message_auth.dart';
+import 'package:prysm/crypto/identity.dart';
 import 'package:prysm/crypto/ratchet/prekey_bundle.dart';
 import 'package:prysm/util/key_manager.dart';
 import 'package:prysm/util/logging.dart';
 import 'package:prysm/util/notification_preview.dart';
 import 'package:prysm/util/notification_service.dart';
+import 'package:prysm/util/peer_identity_loader.dart';
 
 class InboundHandleResult {
   final int statusCode;
@@ -55,12 +58,15 @@ class InboundMessageRouter {
     required this.settings,
     required this.localOnionAddress,
     this.fetchSenderProfile,
+    this.resolvePeerIdentity,
   });
 
   final KeyManager keyManager;
   final SettingsService settings;
   final String? Function() localOnionAddress;
   final void Function(String senderId)? fetchSenderProfile;
+  final Future<IdentityPublicKeys?> Function(String senderId)?
+      resolvePeerIdentity;
 
   Future<InboundHandleResult> buildPublicKey() async {
     final body = await _publicIdentityBody();
@@ -452,6 +458,7 @@ class InboundMessageRouter {
 
     final inboundGroupId = data['groupId'] as String?;
     final localUserId = local;
+    var messageStatus = (data['status'] as String?) ?? 'received';
     if (inboundGroupId != null && localUserId != null) {
       final joinedAt = await DBHelper.getMemberJoinedAt(
         inboundGroupId,
@@ -459,6 +466,28 @@ class InboundMessageRouter {
       );
       if (joinedAt != null && messageTimestamp < joinedAt) {
         return InboundHandleResult.ok({'status': 'received', 'id': data['id']});
+      }
+    }
+
+    if (inboundGroupId == null && isDirectMessageType(type)) {
+      final auth = await DirectMessageAuth.authenticateInboundDirect(
+        senderId: senderId,
+        wire: data['message'] as String,
+        type: type,
+        localUserId: localUserId,
+        keyManager: keyManager,
+        resolveIdentity: _resolvePeerIdentity,
+        fullDecrypt: keyManager.isUnlocked,
+      );
+      switch (auth) {
+        case DirectAuthOutcome.rejected:
+          return InboundHandleResult.badRequest(
+            'Invalid or unsigned direct message',
+          );
+        case DirectAuthOutcome.pendingAuth:
+          messageStatus = 'pending_auth';
+        case DirectAuthOutcome.accepted:
+          break;
       }
     }
 
@@ -480,7 +509,7 @@ class InboundMessageRouter {
       if (data['fileName'] != null) 'fileName': data['fileName'] as String,
       if (data['fileSize'] != null) 'fileSize': data['fileSize'],
       'timestamp': messageTimestamp,
-      'status': (data['status'] ?? 'received') as String,
+      'status': messageStatus,
       if (data['replyTo'] != null) 'replyTo': data['replyTo'],
       'viewOnce': (data['viewOnce'] == true || data['viewOnce'] == 1) ? 1 : 0,
       'expiresAt': ?expiresAt,
@@ -490,15 +519,16 @@ class InboundMessageRouter {
       DisappearingActivityNotifier.instance.notify();
     }
 
-    if (inserted != null) {
+    if (inserted != null && inserted['status'] != 'pending_auth') {
       InboundMessageNotifier.instance.notify(
         InboundMessageEvent.fromRow(inserted),
       );
+      ConversationRefreshNotifier.instance.notifyInboundMessage();
     }
 
-    ConversationRefreshNotifier.instance.notifyInboundMessage();
-
-    if (settings.enableNotifications) {
+    if (settings.enableNotifications &&
+        inserted != null &&
+        inserted['status'] != 'pending_auth') {
       final appState = WidgetsBinding.instance.lifecycleState;
       final isBackground =
           appState == AppLifecycleState.paused ||
@@ -559,6 +589,13 @@ class InboundMessageRouter {
       'id': data['id'],
       'timestamp': timeReceived,
     });
+  }
+
+  Future<IdentityPublicKeys?> _resolvePeerIdentity(String senderId) async {
+    if (resolvePeerIdentity != null) {
+      return resolvePeerIdentity!(senderId);
+    }
+    return loadPeerIdentityFromDb(keyManager, senderId);
   }
 
   bool _isValidMessageData(dynamic data) {

--- a/lib/services/call/call_manager.dart
+++ b/lib/services/call/call_manager.dart
@@ -390,12 +390,18 @@ class CallManager extends ChangeNotifier {
     if (callId == null || sessionId == 0 || wrappedKey == null) return;
 
     try {
+      final peerKey = await _keyResolver!.resolve(event.peerOnion);
+      if (peerKey == null) {
+        await _sendEnd(event.peerOnion, callId, reason: 'error');
+        return;
+      }
       final session = await CallSession.fromInbound(
         callId: callId,
         sessionId: sessionId,
         peerOnion: event.peerOnion,
         wrappedKey: wrappedKey,
         keyManager: _keyManager,
+        peer: peerKey,
         codec: _codecFromPayload(payload['codec']),
       );
       _session = session;

--- a/lib/services/call/call_session.dart
+++ b/lib/services/call/call_session.dart
@@ -71,9 +71,13 @@ class CallSession {
     required String peerOnion,
     required String wrappedKey,
     required KeyManager keyManager,
+    required IdentityPublicKeys peer,
     CallCodecParams codec = const CallCodecParams(),
   }) async {
-    final material = await keyManager.decryptBytes(wrappedKey);
+    final material = await keyManager.decryptBytesFromPeer(
+      wire: wrappedKey,
+      peer: peer,
+    );
     if (material.length < 36) {
       throw const FormatException('Invalid wrapped call key');
     }

--- a/lib/services/chat_media_service.dart
+++ b/lib/services/chat_media_service.dart
@@ -102,7 +102,12 @@ class ChatMediaService {
     if (isGroup) {
       return _decryptGroupBytes(row);
     }
-    return FileAttachmentResolver.decryptEncryptedSource(wire, keyManager);
+    return FileAttachmentResolver.decryptEncryptedSource(
+      wire,
+      keyManager,
+      senderId: row['senderId'] as String,
+      localUserId: userId,
+    );
   }
 
   Future<Uint8List> resolveFileBytes(ChatMediaItem item) async {
@@ -111,7 +116,11 @@ class ChatMediaService {
       return _decryptGroupBytes(row);
     }
     final message = _fileMessageFromRow(row, item);
-    return FileAttachmentResolver.resolve(message, keyManager: keyManager);
+    return FileAttachmentResolver.resolve(
+      message,
+      keyManager: keyManager,
+      localUserId: userId,
+    );
   }
 
   Future<VoicePlaybackInfo> resolveVoicePlayback(ChatMediaItem item) async {
@@ -156,6 +165,7 @@ class ChatMediaService {
     final bytes = await FileAttachmentResolver.resolve(
       message,
       keyManager: keyManager,
+      localUserId: userId,
     );
     await File(cachePath).writeAsBytes(bytes);
     final durationMs = WaveformExtractor.estimateDurationMs(bytes);

--- a/lib/services/file_attachment_resolver.dart
+++ b/lib/services/file_attachment_resolver.dart
@@ -4,6 +4,7 @@ import 'package:flutter/foundation.dart';
 import 'package:prysm/database/messages.dart';
 import 'package:prysm/models/chat/prysm_message.dart';
 import 'package:prysm/crypto/wire.dart';
+import 'package:prysm/util/db_helper.dart';
 import 'package:prysm/util/key_manager.dart';
 
 class FileAttachmentResolver {
@@ -16,7 +17,9 @@ class FileAttachmentResolver {
   static Future<Uint8List> resolve(
     FileMessage message, {
     KeyManager? keyManager,
+    String? localUserId,
     void Function(double progress)? onProgress,
+    bool allowLegacyUnsignedFile = true,
   }) async {
     final cached = _cache[message.id];
     if (cached != null) {
@@ -25,7 +28,12 @@ class FileAttachmentResolver {
     }
 
     onProgress?.call(0.1);
-    final bytes = await _resolveUncached(message, keyManager: keyManager);
+    final bytes = await _resolveUncached(
+      message,
+      keyManager: keyManager,
+      localUserId: localUserId,
+      allowLegacyUnsignedFile: allowLegacyUnsignedFile,
+    );
     onProgress?.call(0.7);
     _putCache(message.id, bytes);
     onProgress?.call(1.0);
@@ -35,6 +43,8 @@ class FileAttachmentResolver {
   static Future<Uint8List> _resolveUncached(
     FileMessage message, {
     KeyManager? keyManager,
+    String? localUserId,
+    bool allowLegacyUnsignedFile = true,
   }) async {
     var source = message.source;
     if (source.isEmpty) {
@@ -67,7 +77,13 @@ class FileAttachmentResolver {
       }
     }
 
-    return decryptEncryptedSource(source, keyManager);
+    return decryptEncryptedSource(
+      source,
+      keyManager,
+      senderId: message.authorId,
+      localUserId: localUserId,
+      allowLegacyUnsignedFile: allowLegacyUnsignedFile,
+    );
   }
 
   static bool _looksLikeBase64Payload(String source) {
@@ -88,8 +104,28 @@ class FileAttachmentResolver {
 
   static Future<Uint8List> decryptEncryptedSource(
     String encryptedJson,
-    KeyManager keyManager,
-  ) async {
+    KeyManager keyManager, {
+    String? senderId,
+    String? localUserId,
+    bool allowLegacyUnsignedFile = true,
+  }) async {
+    if (senderId != null &&
+        localUserId != null &&
+        senderId != localUserId) {
+      final user = await DBHelper.getUserById(senderId);
+      final identityJson = (user?['identityJson'] as String?) ??
+          (user?['publicKeyPem'] as String?);
+      if (identityJson == null || identityJson.isEmpty) {
+        throw const FormatException('Missing peer identity');
+      }
+      final peerKey = keyManager.importPeerIdentity(identityJson);
+      return CryptoWire.decryptFileFromPeer(
+        encryptedJson,
+        keyManager.identity,
+        peerKey,
+        allowLegacyUnsignedFile: allowLegacyUnsignedFile,
+      );
+    }
     return CryptoWire.decryptFile(encryptedJson, keyManager.identity);
   }
 

--- a/lib/services/message_view_mapper.dart
+++ b/lib/services/message_view_mapper.dart
@@ -12,6 +12,7 @@ import 'package:prysm/screens/widgets/message_reaction_bar.dart';
 import 'package:prysm/util/db_helper.dart';
 import 'package:prysm/util/key_manager.dart';
 import 'package:prysm/util/logging.dart';
+import 'package:prysm/util/message_auth_status.dart';
 import 'package:prysm/util/message_modify_policy.dart';
 import 'package:prysm/util/message_status_mapper.dart';
 
@@ -69,6 +70,7 @@ class MessageViewMapper {
       peerId: senderId,
       wire: wire,
       peer: peerKey,
+      allowLegacyUnsignedDhAead: true,
     );
   }
 
@@ -95,6 +97,9 @@ class MessageViewMapper {
         continue;
       }
       final meta = metadataFromDbRow(msg);
+      if (MessageAuthStatus.isUndisplayable(msg['status'] as String?)) {
+        continue;
+      }
       if (rowShowsAsDeleted(msg, meta)) {
         messages.add(_deletedMessageFromRow(msg, {
           ...meta,

--- a/lib/services/pending_auth_message_service.dart
+++ b/lib/services/pending_auth_message_service.dart
@@ -1,0 +1,87 @@
+import 'package:prysm/crypto/direct_message_auth.dart';
+import 'package:prysm/crypto/identity.dart';
+import 'package:prysm/database/messages.dart';
+import 'package:prysm/services/peer_identity_resolver.dart';
+import 'package:prysm/util/conversation_refresh_notifier.dart';
+import 'package:prysm/util/inbound_message_notifier.dart';
+import 'package:prysm/util/key_manager.dart';
+import 'package:prysm/util/logging.dart';
+import 'package:prysm/util/peer_identity_loader.dart';
+
+/// Promotes or quarantines direct messages received while the app was locked.
+class PendingAuthMessageService {
+  PendingAuthMessageService({
+    required this.keyManager,
+    Future<IdentityPublicKeys?> Function(String senderId)? resolvePeerIdentity,
+  }) : _resolvePeerIdentity = resolvePeerIdentity;
+
+  final KeyManager keyManager;
+  final Future<IdentityPublicKeys?> Function(String senderId)?
+      _resolvePeerIdentity;
+
+  Future<void> promotePendingAfterUnlock({String? localUserId}) async {
+    if (!keyManager.isUnlocked) return;
+
+    final pending = await MessagesDb.getPendingAuthDirectMessages();
+    if (pending.isEmpty) return;
+
+    var promoted = false;
+    for (final row in pending) {
+      final senderId = row['senderId'] as String;
+      final wire = row['message'] as String?;
+      final type = row['type'] as String? ?? 'text';
+      final messageId = row['id'] as String;
+      if (wire == null || wire.isEmpty) {
+        await MessagesDb.updateMessageStatus(messageId, 'quarantined');
+        continue;
+      }
+
+      try {
+        final auth = await DirectMessageAuth.authenticateInboundDirect(
+          senderId: senderId,
+          wire: wire,
+          type: type,
+          localUserId: localUserId,
+          keyManager: keyManager,
+          resolveIdentity: _resolveIdentity,
+          fullDecrypt: true,
+        );
+        if (auth == DirectAuthOutcome.accepted) {
+          await MessagesDb.updateMessageStatus(messageId, 'received');
+          final updated = {...row, 'status': 'received'};
+          InboundMessageNotifier.instance.notify(
+            InboundMessageEvent.fromRow(updated),
+          );
+          promoted = true;
+        } else {
+          await MessagesDb.updateMessageStatus(messageId, 'quarantined');
+        }
+      } catch (e, stack) {
+        Logging.error(
+          'Pending auth promotion failed for $messageId: $e\n$stack',
+          'PendingAuthMessageService',
+        );
+        await MessagesDb.updateMessageStatus(messageId, 'quarantined');
+      }
+    }
+
+    if (promoted) {
+      ConversationRefreshNotifier.instance.notifyInboundMessage();
+    }
+  }
+
+  Future<IdentityPublicKeys?> _resolveIdentity(String senderId) async {
+    if (_resolvePeerIdentity != null) {
+      return _resolvePeerIdentity(senderId);
+    }
+    final resolver = PeerIdentityResolver(
+      peerId: senderId,
+      keyManager: keyManager,
+    );
+    return resolvePeerIdentityForIngress(
+      keyManager,
+      senderId,
+      fetchOverTor: () => resolver.fetchOverTor(),
+    );
+  }
+}

--- a/lib/util/direct_chat_message_decrypt.dart
+++ b/lib/util/direct_chat_message_decrypt.dart
@@ -3,8 +3,9 @@ import 'package:prysm/models/chat/prysm_message.dart';
 import 'package:prysm/constants/media_constants.dart';
 import 'package:prysm/util/db_helper.dart';
 import 'package:prysm/util/key_manager.dart';
-import 'package:prysm/util/message_modify_policy.dart';
 import 'package:prysm/util/logging.dart';
+import 'package:prysm/util/message_auth_status.dart';
+import 'package:prysm/util/message_modify_policy.dart';
 
 /// Decrypts direct-chat DB rows using the main window's unlocked [KeyManager].
 class DirectChatMessageDecrypt {
@@ -36,6 +37,7 @@ class DirectChatMessageDecrypt {
       peerId: senderId,
       wire: wire,
       peer: peerKey,
+      allowLegacyUnsignedDhAead: true,
     );
   }
 
@@ -48,6 +50,9 @@ class DirectChatMessageDecrypt {
 
     for (final msg in rawMessages) {
       final meta = metadataFromDbRow(msg);
+      if (MessageAuthStatus.isUndisplayable(msg['status'] as String?)) {
+        continue;
+      }
       if (rowShowsAsDeleted(msg, meta)) {
         messages.add(
           TextMessage(

--- a/lib/util/key_manager.dart
+++ b/lib/util/key_manager.dart
@@ -195,7 +195,11 @@ class KeyManager {
         peerBundle: peerPrekey,
       );
     } on StateError {
-      return CryptoWire.encryptTextForPeer(message, identity, peer.agreePublic);
+      return CryptoWire.encryptSignedTextForPeer(
+        message,
+        identity,
+        peer.agreePublic,
+      );
     }
   }
 
@@ -203,12 +207,14 @@ class KeyManager {
     required String peerId,
     required String wire,
     required IdentityPublicKeys peer,
+    bool allowLegacyUnsignedDhAead = false,
   }) async {
     return RatchetService.instance.decryptText(
       peerId: peerId,
       wire: wire,
       local: identity,
       peer: peer,
+      allowLegacyUnsignedDhAead: allowLegacyUnsignedDhAead,
     );
   }
 
@@ -236,7 +242,7 @@ class KeyManager {
     String? peerId,
     PrekeyBundle? peerPrekey,
   }) async {
-    return CryptoWire.encryptForPeer(data, identity, peer.agreePublic);
+    return CryptoWire.encryptSignedForPeer(data, identity, peer.agreePublic);
   }
 
   Future<String> encryptBytesForSelf(Uint8List data) async {

--- a/lib/util/key_manager.dart
+++ b/lib/util/key_manager.dart
@@ -234,6 +234,13 @@ class KeyManager {
     return CryptoWire.decryptForSelf(wire, identity);
   }
 
+  Future<Uint8List> decryptBytesFromPeer({
+    required String wire,
+    required IdentityPublicKeys peer,
+  }) async {
+    return CryptoWire.decryptSignedFromPeer(wire, identity, peer);
+  }
+
   Future<Uint8List> decryptMyMessageBytes(String wire) => decryptBytes(wire);
 
   Future<String> encryptBytesForPeer(

--- a/lib/util/message_auth_status.dart
+++ b/lib/util/message_auth_status.dart
@@ -1,0 +1,11 @@
+/// Message statuses used for inbound authentication gating.
+class MessageAuthStatus {
+  MessageAuthStatus._();
+
+  static const String received = 'received';
+  static const String pendingAuth = 'pending_auth';
+  static const String quarantined = 'quarantined';
+
+  static bool isUndisplayable(String? status) =>
+      status == pendingAuth || status == quarantined;
+}

--- a/lib/util/network_reachability.dart
+++ b/lib/util/network_reachability.dart
@@ -1,6 +1,7 @@
 import 'dart:io';
 
 import 'package:connectivity_plus/connectivity_plus.dart';
+import 'package:prysm/util/desktop_platform.dart';
 
 /// OS-level link-up check: active WiFi/mobile/ethernet plus a non-loopback IPv4.
 class NetworkReachability {
@@ -10,6 +11,13 @@ class NetworkReachability {
     ConnectivityResult.wifi,
     ConnectivityResult.mobile,
     ConnectivityResult.ethernet,
+  };
+
+  static const _desktopLinkUpTransports = {
+    ConnectivityResult.wifi,
+    ConnectivityResult.mobile,
+    ConnectivityResult.ethernet,
+    ConnectivityResult.other,
   };
 
   /// Injectable probe for tests. Defaults to OS transport + local address checks.
@@ -26,6 +34,9 @@ class NetworkReachability {
         includeLinkLocal: true,
       );
 
+  /// Injectable desktop flag for tests. Defaults to [isDesktopPlatform].
+  static bool isDesktop = isDesktopPlatform;
+
   static Future<bool> hasInternet({
     Duration timeout = const Duration(seconds: 3),
   }) async {
@@ -39,11 +50,32 @@ class NetworkReachability {
   static Future<bool> _defaultProbe({
     Duration timeout = const Duration(seconds: 3),
   }) async {
-    final results = await checkConnectivity();
-    if (!results.any(_linkUpTransports.contains)) {
-      return false;
+    final results = await _safeCheckConnectivity();
+    final linkUpTransports =
+        isDesktop ? _desktopLinkUpTransports : _linkUpTransports;
+
+    if (results.any(linkUpTransports.contains)) {
+      return _hasNonLoopbackInterface();
     }
 
+    // connectivity_plus on Linux requires NetworkManager; fall back to
+    // interface checks on desktop when NM is absent (e.g. systemd-networkd).
+    if (isDesktop) {
+      return _hasNonLoopbackInterface();
+    }
+
+    return false;
+  }
+
+  static Future<List<ConnectivityResult>> _safeCheckConnectivity() async {
+    try {
+      return await checkConnectivity();
+    } catch (_) {
+      return [ConnectivityResult.none];
+    }
+  }
+
+  static Future<bool> _hasNonLoopbackInterface() async {
     final interfaces = await listNetworkInterfaces();
     return interfaces.any(
       (iface) => iface.addresses.any((addr) => !addr.isLoopback),

--- a/lib/util/peer_identity_loader.dart
+++ b/lib/util/peer_identity_loader.dart
@@ -1,4 +1,5 @@
 import 'package:prysm/crypto/identity.dart';
+import 'package:prysm/services/peer_identity_resolver.dart';
 import 'package:prysm/util/db_helper.dart';
 import 'package:prysm/util/key_manager.dart';
 
@@ -15,6 +16,18 @@ Future<IdentityPublicKeys?> loadPeerIdentityFromDb(
   } catch (_) {
     return null;
   }
+}
+
+/// Resolves peer identity for ingress: local DB first, then awaited Tor fetch.
+Future<IdentityPublicKeys?> resolvePeerIdentityForIngress(
+  KeyManager keyManager,
+  String peerId, {
+  required Future<ResolvedPeerIdentity?> Function() fetchOverTor,
+}) async {
+  final cached = await loadPeerIdentityFromDb(keyManager, peerId);
+  if (cached != null) return cached;
+  final resolved = await fetchOverTor();
+  return resolved?.identity;
 }
 
 /// Resolves the public keys that signed a group message.

--- a/test/call_manager_test.dart
+++ b/test/call_manager_test.dart
@@ -30,6 +30,7 @@ void main() {
   late _FakeTransport transport;
   late _FakeKeyResolver keyResolver;
   late KeyManager keyManager;
+  late KeyManager peerKeyManager;
   late CallSignalingNotifier notifier;
   late CallManager manager;
   late _RecordingForegroundSession foreground;
@@ -59,6 +60,7 @@ void main() {
     final local = await IdentityKeyPair.generate();
     final peer = await IdentityKeyPair.generate();
     keyManager = KeyManager.fromIdentity(local);
+    peerKeyManager = KeyManager.fromIdentity(peer);
     localKeys = IdentityPublicKeys(
       signPublic: await local.signPublicKey,
       agreePublic: await local.agreePublicKey,
@@ -148,7 +150,7 @@ void main() {
     notifier.applyInbound('peer.onion', 'call_offer', {
       'callId': caller.callId,
       'sessionId': caller.sessionId,
-      'wrappedKey': await caller.wrapKeyForPeer(localKeys, keyManager),
+      'wrappedKey': await caller.wrapKeyForPeer(localKeys, peerKeyManager),
     });
     await Future<void>.delayed(Duration.zero);
     await manager.acceptIncoming();
@@ -171,7 +173,7 @@ void main() {
     notifier.applyInbound('peer.onion', 'call_offer', {
       'callId': caller.callId,
       'sessionId': caller.sessionId,
-      'wrappedKey': await caller.wrapKeyForPeer(localKeys, keyManager),
+      'wrappedKey': await caller.wrapKeyForPeer(localKeys, peerKeyManager),
     });
 
     await Future<void>.delayed(Duration.zero);
@@ -189,7 +191,7 @@ void main() {
     notifier.applyInbound('peer.onion', 'call_offer', {
       'callId': caller.callId,
       'sessionId': caller.sessionId,
-      'wrappedKey': await caller.wrapKeyForPeer(localKeys, keyManager),
+      'wrappedKey': await caller.wrapKeyForPeer(localKeys, peerKeyManager),
     });
     await Future<void>.delayed(Duration.zero);
     await manager.acceptIncoming();
@@ -220,7 +222,7 @@ void main() {
     notifier.applyInbound('peer.onion', 'call_offer', {
       'callId': caller.callId,
       'sessionId': caller.sessionId,
-      'wrappedKey': await caller.wrapKeyForPeer(localKeys, keyManager),
+      'wrappedKey': await caller.wrapKeyForPeer(localKeys, peerKeyManager),
     });
     await Future<void>.delayed(Duration.zero);
     await manager.acceptIncoming();
@@ -242,7 +244,7 @@ void main() {
     notifier.applyInbound('peer.onion', 'call_offer', {
       'callId': caller.callId,
       'sessionId': caller.sessionId,
-      'wrappedKey': await caller.wrapKeyForPeer(localKeys, keyManager),
+      'wrappedKey': await caller.wrapKeyForPeer(localKeys, peerKeyManager),
     });
     await Future<void>.delayed(Duration.zero);
     await manager.acceptIncoming();
@@ -265,7 +267,7 @@ void main() {
     notifier.applyInbound('peer.onion', 'call_offer', {
       'callId': caller.callId,
       'sessionId': caller.sessionId,
-      'wrappedKey': await caller.wrapKeyForPeer(localKeys, keyManager),
+      'wrappedKey': await caller.wrapKeyForPeer(localKeys, peerKeyManager),
     });
     await Future<void>.delayed(Duration.zero);
     expect(manager.snapshot.state, CallState.incoming);
@@ -291,7 +293,7 @@ void main() {
     notifier.applyInbound('peer.onion', 'call_offer', {
       'callId': caller.callId,
       'sessionId': caller.sessionId,
-      'wrappedKey': await caller.wrapKeyForPeer(localKeys, keyManager),
+      'wrappedKey': await caller.wrapKeyForPeer(localKeys, peerKeyManager),
     });
     await Future<void>.delayed(Duration.zero);
     expect(foreground.syncCalls, isNotEmpty);
@@ -311,7 +313,7 @@ void main() {
     notifier.applyInbound('peer.onion', 'call_offer', {
       'callId': caller.callId,
       'sessionId': caller.sessionId,
-      'wrappedKey': await caller.wrapKeyForPeer(localKeys, keyManager),
+      'wrappedKey': await caller.wrapKeyForPeer(localKeys, peerKeyManager),
     });
     await Future<void>.delayed(Duration.zero);
     expect(manager.snapshot.state, CallState.incoming);
@@ -337,7 +339,7 @@ void main() {
       notifier.applyInbound('blocked.onion', 'call_offer', {
         'callId': caller.callId,
         'sessionId': caller.sessionId,
-        'wrappedKey': await caller.wrapKeyForPeer(localKeys, keyManager),
+        'wrappedKey': await caller.wrapKeyForPeer(localKeys, peerKeyManager),
       });
 
       await Future<void>.delayed(Duration.zero);

--- a/test/call_session_test.dart
+++ b/test/call_session_test.dart
@@ -10,12 +10,16 @@ void main() {
     final local = await IdentityKeyPair.generate();
     final peer = await IdentityKeyPair.generate();
     final km = KeyManager.fromIdentity(local);
+    final localPub = IdentityPublicKeys(
+      signPublic: await local.signPublicKey,
+      agreePublic: await local.agreePublicKey,
+      fingerprint: 'local',
+    );
     final peerPub = IdentityPublicKeys(
       signPublic: await peer.signPublicKey,
       agreePublic: await peer.agreePublicKey,
       fingerprint: 'test',
     );
-
     final session = CallSession.createOutbound(
       callId: 'c1',
       sessionId: 42,
@@ -29,6 +33,7 @@ void main() {
       peerOnion: 'peer.onion',
       wrappedKey: wrapped,
       keyManager: KeyManager.fromIdentity(peer),
+      peer: localPub,
     );
 
     final frame = await session.encryptAudioFrame(Uint8List.fromList([1, 2, 3]));

--- a/test/crypto/crypto_test.dart
+++ b/test/crypto/crypto_test.dart
@@ -148,10 +148,9 @@ void main() {
       );
       expect(CryptoEnvelope.isV2(wire), isTrue);
 
-      final plain = await CryptoWire.decryptTextFromPeer(
+      final plain = await CryptoWire.decryptLegacyTextFromPeer(
         wire,
         bob,
-        await alice.agreePublicKey,
       );
       expect(plain, 'hello prysm');
     });
@@ -160,10 +159,21 @@ void main() {
       final alice = await IdentityKeyPair.generate();
       final bob = await IdentityKeyPair.generate();
       final bobPub = await bob.agreePublicKey;
+      final alicePub = IdentityPublicKeys(
+        signPublic: await alice.signPublicKey,
+        agreePublic: await alice.agreePublicKey,
+        fingerprint: IdentityKeyPair.fingerprintFromPublicJson(
+          await alice.toPublicJson(),
+        ),
+      );
       final bytes = Uint8List.fromList([10, 20, 30, 40, 50]);
 
       final payloads = await CryptoWire.encryptFile(bytes, alice, bobPub);
-      final dec = await CryptoWire.decryptFile(payloads.peerPayload, bob);
+      final dec = await CryptoWire.decryptFileFromPeer(
+        payloads.peerPayload,
+        bob,
+        alicePub,
+      );
       expect(dec, bytes);
     });
   });

--- a/test/crypto/direct_message_auth_test.dart
+++ b/test/crypto/direct_message_auth_test.dart
@@ -1,0 +1,117 @@
+import 'dart:convert';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:prysm/crypto/crypto.dart';
+import 'package:prysm/util/key_manager.dart';
+
+Future<IdentityPublicKeys> _publicKeys(IdentityKeyPair id) async {
+  final sign = await id.signPublicKey;
+  final agree = await id.agreePublicKey;
+  return IdentityPublicKeys(
+    signPublic: sign,
+    agreePublic: agree,
+    fingerprint: IdentityKeyPair.fingerprintFromPublicJson(
+      await id.toPublicJson(),
+    ),
+  );
+}
+
+void main() {
+  group('DirectMessageAuth', () {
+    test('locked path accepts valid dm-signed-1 as pendingAuth', () async {
+      final alice = await IdentityKeyPair.generate();
+      final bob = await IdentityKeyPair.generate();
+      final alicePub = await _publicKeys(alice);
+      final bobPub = await bob.agreePublicKey;
+
+      final wire = await CryptoWire.encryptSignedTextForPeer(
+        'locked pending',
+        alice,
+        bobPub,
+      );
+
+      final outcome = await DirectMessageAuth.authenticateInboundDirect(
+        senderId: 'alice.onion',
+        wire: wire,
+        type: 'text',
+        localUserId: 'bob.onion',
+        keyManager: KeyManager(),
+        resolveIdentity: (_) async => alicePub,
+        fullDecrypt: false,
+      );
+      expect(outcome, DirectAuthOutcome.pendingAuth);
+    });
+
+    test('locked path rejects forged dm-signed-1 when identity known', () async {
+      final alice = await IdentityKeyPair.generate();
+      final bob = await IdentityKeyPair.generate();
+      final attacker = await IdentityKeyPair.generate();
+      final alicePub = await _publicKeys(alice);
+      final bobPub = await bob.agreePublicKey;
+
+      final wire = await CryptoWire.encryptSignedTextForPeer(
+        'forged',
+        attacker,
+        bobPub,
+      );
+
+      final outcome = await DirectMessageAuth.authenticateInboundDirect(
+        senderId: 'alice.onion',
+        wire: wire,
+        type: 'text',
+        localUserId: 'bob.onion',
+        keyManager: KeyManager(),
+        resolveIdentity: (_) async => alicePub,
+        fullDecrypt: false,
+      );
+      expect(outcome, DirectAuthOutcome.rejected);
+    });
+
+    test('ratchet while locked stays pendingAuth', () async {
+      final alicePub = await _publicKeys(await IdentityKeyPair.generate());
+      final wire = jsonEncode({
+        'crypto': CryptoConstants.cryptoVersion,
+        'scheme': CryptoConstants.schemeRatchet1,
+        'nonce': 'abc',
+        'ciphertext': 'def',
+        'counter': 0,
+      });
+
+      final outcome = await DirectMessageAuth.authenticateInboundDirect(
+        senderId: 'alice.onion',
+        wire: wire,
+        type: 'text',
+        localUserId: 'bob.onion',
+        keyManager: KeyManager(),
+        resolveIdentity: (_) async => alicePub,
+        fullDecrypt: false,
+      );
+      expect(outcome, DirectAuthOutcome.pendingAuth);
+    });
+
+    test('unlocked path accepts valid dm-signed-1', () async {
+      final alice = await IdentityKeyPair.generate();
+      final bob = await IdentityKeyPair.generate();
+      final alicePub = await _publicKeys(alice);
+      final bobPub = await bob.agreePublicKey;
+      final keyManager = KeyManager.fromIdentity(bob);
+
+      final wire = await CryptoWire.encryptSignedTextForPeer(
+        'hello',
+        alice,
+        bobPub,
+      );
+
+      final outcome = await DirectMessageAuth.authenticateInboundDirect(
+        senderId: 'alice.onion',
+        wire: wire,
+        type: 'text',
+        localUserId: 'bob.onion',
+        keyManager: keyManager,
+        resolveIdentity: (_) async => alicePub,
+        fullDecrypt: true,
+      );
+      expect(outcome, DirectAuthOutcome.accepted);
+    });
+  });
+}

--- a/test/crypto/dm_signed_test.dart
+++ b/test/crypto/dm_signed_test.dart
@@ -1,0 +1,115 @@
+import 'dart:typed_data';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:prysm/crypto/crypto.dart';
+import 'package:prysm/util/key_manager.dart';
+
+Future<IdentityPublicKeys> _publicKeys(IdentityKeyPair id) async {
+  final sign = await id.signPublicKey;
+  final agree = await id.agreePublicKey;
+  return IdentityPublicKeys(
+    signPublic: sign,
+    agreePublic: agree,
+    fingerprint: IdentityKeyPair.fingerprintFromPublicJson(
+      await id.toPublicJson(),
+    ),
+  );
+}
+
+void main() {
+  group('dm-signed-1', () {
+    test('signed 1:1 text round trip', () async {
+      final alice = await IdentityKeyPair.generate();
+      final bob = await IdentityKeyPair.generate();
+      final bobPub = await bob.agreePublicKey;
+      final alicePub = await _publicKeys(alice);
+
+      final wire = await CryptoWire.encryptSignedTextForPeer(
+        'hello signed',
+        alice,
+        bobPub,
+      );
+      expect(CryptoEnvelope.isV2(wire), isTrue);
+      final parsed = CryptoEnvelope.tryParse(wire)!;
+      expect(parsed['scheme'], CryptoConstants.schemeDmSigned1);
+
+      final plain = await CryptoWire.decryptSignedTextFromPeer(
+        wire,
+        bob,
+        alicePub,
+      );
+      expect(plain, 'hello signed');
+    });
+
+    test('rejects forged sender signature', () async {
+      final alice = await IdentityKeyPair.generate();
+      final bob = await IdentityKeyPair.generate();
+      final attacker = await IdentityKeyPair.generate();
+      final bobPub = await bob.agreePublicKey;
+      final alicePub = await _publicKeys(alice);
+
+      final wire = await CryptoWire.encryptSignedTextForPeer(
+        'forged',
+        attacker,
+        bobPub,
+      );
+
+      expect(
+        () => CryptoWire.decryptSignedTextFromPeer(wire, bob, alicePub),
+        throwsFormatException,
+      );
+    });
+
+    test('rejects unsigned dh-aead-1 without legacy flag', () async {
+      final alice = await IdentityKeyPair.generate();
+      final bob = await IdentityKeyPair.generate();
+      final alicePub = await _publicKeys(alice);
+      final bobPub = await bob.agreePublicKey;
+
+      final wire = await CryptoWire.encryptTextForPeer('legacy', alice, bobPub);
+
+      expect(
+        () => RatchetService.instance.decryptText(
+          peerId: 'alice.onion',
+          wire: wire,
+          local: bob,
+          peer: alicePub,
+          allowLegacyUnsignedDhAead: false,
+        ),
+        throwsFormatException,
+      );
+    });
+
+    test('allows legacy unsigned dh-aead-1 for stored history', () async {
+      final alice = await IdentityKeyPair.generate();
+      final bob = await IdentityKeyPair.generate();
+      final alicePub = await _publicKeys(alice);
+      final bobPub = await bob.agreePublicKey;
+
+      final wire = await CryptoWire.encryptTextForPeer('legacy', alice, bobPub);
+
+      final plain = await RatchetService.instance.decryptText(
+        peerId: 'alice.onion',
+        wire: wire,
+        local: bob,
+        peer: alicePub,
+        allowLegacyUnsignedDhAead: true,
+      );
+      expect(plain, 'legacy');
+    });
+
+    test('encryptBytesForPeer produces dm-signed-1', () async {
+      final alice = await IdentityKeyPair.generate();
+      final bob = await IdentityKeyPair.generate();
+      final keyManager = KeyManager.fromIdentity(alice);
+      final bobPub = await _publicKeys(bob);
+
+      final wire = await keyManager.encryptBytesForPeer(
+        Uint8List.fromList([1, 2, 3]),
+        bobPub,
+      );
+      final parsed = CryptoEnvelope.tryParse(wire)!;
+      expect(parsed['scheme'], CryptoConstants.schemeDmSigned1);
+    });
+  });
+}

--- a/test/crypto/file_signed_test.dart
+++ b/test/crypto/file_signed_test.dart
@@ -1,0 +1,73 @@
+import 'dart:typed_data';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:prysm/crypto/crypto.dart';
+
+Future<IdentityPublicKeys> _publicKeys(IdentityKeyPair id) async {
+  final sign = await id.signPublicKey;
+  final agree = await id.agreePublicKey;
+  return IdentityPublicKeys(
+    signPublic: sign,
+    agreePublic: agree,
+    fingerprint: IdentityKeyPair.fingerprintFromPublicJson(
+      await id.toPublicJson(),
+    ),
+  );
+}
+
+void main() {
+  group('file-signed-1', () {
+    test('peer file round trip', () async {
+      final alice = await IdentityKeyPair.generate();
+      final bob = await IdentityKeyPair.generate();
+      final bobPub = await bob.agreePublicKey;
+      final alicePub = await _publicKeys(alice);
+      final bytes = Uint8List.fromList([1, 2, 3, 4, 5]);
+
+      final payloads = await CryptoWire.encryptFile(bytes, alice, bobPub);
+      final parsed = CryptoEnvelope.tryParse(payloads.peerPayload)!;
+      expect(parsed['scheme'], CryptoConstants.schemeFileSigned1);
+
+      final dec = await CryptoWire.decryptFileFromPeer(
+        payloads.peerPayload,
+        bob,
+        alicePub,
+      );
+      expect(dec, bytes);
+    });
+
+    test('rejects forged signed file wrap', () async {
+      final alice = await IdentityKeyPair.generate();
+      final bob = await IdentityKeyPair.generate();
+      final attacker = await IdentityKeyPair.generate();
+      final bobPub = await bob.agreePublicKey;
+      final alicePub = await _publicKeys(alice);
+      final bytes = Uint8List.fromList([9, 8, 7]);
+
+      final payloads = await CryptoWire.encryptFile(bytes, attacker, bobPub);
+
+      expect(
+        () => CryptoWire.decryptFileFromPeer(
+          payloads.peerPayload,
+          bob,
+          alicePub,
+        ),
+        throwsFormatException,
+      );
+    });
+
+    test('self payload remains unsigned file-aead-1', () async {
+      final alice = await IdentityKeyPair.generate();
+      final bob = await IdentityKeyPair.generate();
+      final bobPub = await bob.agreePublicKey;
+      final bytes = Uint8List.fromList([10, 20]);
+
+      final payloads = await CryptoWire.encryptFile(bytes, alice, bobPub);
+      final parsed = CryptoEnvelope.tryParse(payloads.selfPayload)!;
+      expect(parsed['scheme'], CryptoConstants.schemeFileAead1);
+
+      final dec = await CryptoWire.decryptFile(payloads.selfPayload, alice);
+      expect(dec, bytes);
+    });
+  });
+}

--- a/test/network_reachability_test.dart
+++ b/test/network_reachability_test.dart
@@ -27,11 +27,13 @@ void main() {
   final originalProbe = NetworkReachability.probe;
   final originalCheckConnectivity = NetworkReachability.checkConnectivity;
   final originalListNetworkInterfaces = NetworkReachability.listNetworkInterfaces;
+  final originalIsDesktop = NetworkReachability.isDesktop;
 
   tearDown(() {
     NetworkReachability.probe = originalProbe;
     NetworkReachability.checkConnectivity = originalCheckConnectivity;
     NetworkReachability.listNetworkInterfaces = originalListNetworkInterfaces;
+    NetworkReachability.isDesktop = originalIsDesktop;
   });
 
   group('hasInternet probe override', () {
@@ -67,7 +69,9 @@ void main() {
     Future<bool> runDefaultProbe({
       required List<ConnectivityResult> connectivity,
       required List<NetworkInterface> interfaces,
+      bool isDesktop = true,
     }) async {
+      NetworkReachability.isDesktop = isDesktop;
       NetworkReachability.checkConnectivity = () async => connectivity;
       NetworkReachability.listNetworkInterfaces = () async => interfaces;
       return NetworkReachability.hasInternet();
@@ -103,14 +107,37 @@ void main() {
       );
     });
 
-    test('no connectivity returns false', () async {
+    test('no connectivity returns false on mobile', () async {
       expect(
         await runDefaultProbe(
           connectivity: [ConnectivityResult.none],
           interfaces: _ifaces('192.168.1.5'),
+          isDesktop: false,
         ),
         isFalse,
       );
+    });
+
+    test('desktop falls back to interfaces when connectivity is none', () async {
+      expect(
+        await runDefaultProbe(
+          connectivity: [ConnectivityResult.none],
+          interfaces: _ifaces('192.168.1.71'),
+          isDesktop: true,
+        ),
+        isTrue,
+      );
+    });
+
+    test('desktop falls back to interfaces when connectivity throws', () async {
+      NetworkReachability.isDesktop = true;
+      NetworkReachability.checkConnectivity = () async {
+        throw Exception('NetworkManager unavailable');
+      };
+      NetworkReachability.listNetworkInterfaces =
+          () async => _ifaces('192.168.1.71');
+
+      expect(await NetworkReachability.hasInternet(), isTrue);
     });
 
     test('wifi with only loopback returns false', () async {
@@ -123,13 +150,25 @@ void main() {
       );
     });
 
-    test('vpn only with local IPv4 returns false', () async {
+    test('vpn only with local IPv4 returns false on mobile', () async {
       expect(
         await runDefaultProbe(
           connectivity: [ConnectivityResult.vpn],
           interfaces: _ifaces('192.168.1.5'),
+          isDesktop: false,
         ),
         isFalse,
+      );
+    });
+
+    test('desktop other with local IPv4 returns true', () async {
+      expect(
+        await runDefaultProbe(
+          connectivity: [ConnectivityResult.other],
+          interfaces: _ifaces('192.168.1.5'),
+          isDesktop: true,
+        ),
+        isTrue,
       );
     });
   });


### PR DESCRIPTION
…dling

- Introduced `dm-signed-1` scheme for signed direct messages, enhancing security.
- Added `PendingAuthMessageService` to manage direct messages received while the app is locked, promoting or quarantining them based on authentication.
- Updated `UnlockController` to promote pending messages upon unlocking.
- Enhanced `InboundMessageRouter` to handle direct message authentication and status updates.
- Implemented new utility functions for resolving peer identities and managing message statuses.
- Added tests for direct message authentication and signed message handling.