### PR TITLE
feat: introduce new cryptographic schemes and enhance message handling

### DIFF
--- a/lib/crypto/constants.dart
+++ b/lib/crypto/constants.dart
@@ -17,13 +17,16 @@ class CryptoConstants {
   static const int argon2Lanes = 1;
 
   static const String schemeDhAead1 = 'dh-aead-1';
+  static const String schemeDhAead2 = 'dh-aead-2';
   static const String schemeDmSigned1 = 'dm-signed-1';
+  static const String schemeDmSigned2 = 'dm-signed-2';
   static const String schemeGroupAead1 = 'group-aead-1';
   static const String schemeControlWrap1 = 'control-wrap-1';
   static const String schemeFileAead1 = 'file-aead-1';
   static const String schemeFileSigned1 = 'file-signed-1';
   static const String schemeCallAead1 = 'call-aead-1';
   static const String schemeRatchet1 = 'ratchet-1';
+  static const String schemeRatchet2 = 'ratchet-2';
   static const String schemeGroupSender1 = 'group-sender-1';
 
   static const String hkdfInfoDhAead = 'prysm/dh-aead-1';

--- a/lib/crypto/direct_message_auth.dart
+++ b/lib/crypto/direct_message_auth.dart
@@ -73,7 +73,8 @@ class DirectMessageAuth {
 
     final peerKeys = await resolveIdentity(senderId);
 
-    if (scheme == CryptoConstants.schemeDmSigned1) {
+    if (scheme == CryptoConstants.schemeDmSigned1 ||
+        scheme == CryptoConstants.schemeDmSigned2) {
       if (peerKeys == null) {
         return fullDecrypt
             ? DirectAuthOutcome.rejected
@@ -124,7 +125,8 @@ class DirectMessageAuth {
       }
     }
 
-    if (scheme == CryptoConstants.schemeRatchet1) {
+    if (scheme == CryptoConstants.schemeRatchet1 ||
+        scheme == CryptoConstants.schemeRatchet2) {
       if (!fullDecrypt || !keyManager.isUnlocked || peerKeys == null) {
         return DirectAuthOutcome.pendingAuth;
       }
@@ -142,7 +144,8 @@ class DirectMessageAuth {
       }
     }
 
-    if (scheme == CryptoConstants.schemeDhAead1) {
+    if (scheme == CryptoConstants.schemeDhAead1 ||
+        scheme == CryptoConstants.schemeDhAead2) {
       if (peerKeys != null) {
         return DirectAuthOutcome.rejected;
       }

--- a/lib/crypto/envelope.dart
+++ b/lib/crypto/envelope.dart
@@ -7,6 +7,45 @@ import 'package:prysm/crypto/constants.dart';
 class CryptoEnvelope {
   CryptoEnvelope._();
 
+  /// Canonical header AAD: "v2|scheme|alg"
+  static List<int> headerAad({
+    required String scheme,
+    String alg = 'aes-gcm',
+    String crypto = CryptoConstants.cryptoVersion,
+  }) =>
+      utf8.encode('$crypto|$scheme|$alg');
+
+  /// Ratchet AAD: header (wire scheme) + counter + optional bootstrap handshake.
+  static List<int> ratchetAad({
+    required String scheme,
+    required int counter,
+    String alg = 'aes-gcm',
+    String crypto = CryptoConstants.cryptoVersion,
+    Map<String, dynamic>? handshake,
+  }) {
+    final header = '$crypto|$scheme|$alg|$counter';
+    if (handshake == null || handshake.isEmpty) {
+      return utf8.encode(header);
+    }
+    final ephemeralPub = handshake['ephemeralPub'] as String? ?? '';
+    final oneTimePreKey = handshake['oneTimePreKey'] as String? ?? '';
+    return utf8.encode('$header|$ephemeralPub|$oneTimePreKey');
+  }
+
+  /// Returns header AAD for -2 DH-AEAD schemes; empty for legacy -1.
+  static List<int> dhAeadAssociatedData(Map<String, dynamic> envelope) {
+    final scheme = schemeOf(envelope);
+    if (scheme == CryptoConstants.schemeDhAead2 ||
+        scheme == CryptoConstants.schemeDmSigned2) {
+      return headerAad(
+        scheme: scheme,
+        alg: envelope['alg'] as String? ?? 'aes-gcm',
+        crypto: envelope['crypto'] as String? ?? CryptoConstants.cryptoVersion,
+      );
+    }
+    return const [];
+  }
+
   static Map<String, dynamic> dhAead1({
     required Uint8List ephemeralPublic,
     required Uint8List ciphertext,
@@ -16,6 +55,22 @@ class CryptoEnvelope {
     return {
       'crypto': CryptoConstants.cryptoVersion,
       'scheme': CryptoConstants.schemeDhAead1,
+      'alg': alg,
+      'ephemeralPub': base64Encode(ephemeralPublic),
+      'nonce': base64Encode(nonce),
+      'ciphertext': base64Encode(ciphertext),
+    };
+  }
+
+  static Map<String, dynamic> dhAead2({
+    required Uint8List ephemeralPublic,
+    required Uint8List ciphertext,
+    required Uint8List nonce,
+    String alg = 'aes-gcm',
+  }) {
+    return {
+      'crypto': CryptoConstants.cryptoVersion,
+      'scheme': CryptoConstants.schemeDhAead2,
       'alg': alg,
       'ephemeralPub': base64Encode(ephemeralPublic),
       'nonce': base64Encode(nonce),
@@ -33,6 +88,24 @@ class CryptoEnvelope {
     return {
       'crypto': CryptoConstants.cryptoVersion,
       'scheme': CryptoConstants.schemeDmSigned1,
+      'alg': alg,
+      'ephemeralPub': base64Encode(ephemeralPublic),
+      'nonce': base64Encode(nonce),
+      'ciphertext': base64Encode(ciphertext),
+      'sig': base64Encode(signature),
+    };
+  }
+
+  static Map<String, dynamic> dmSigned2({
+    required Uint8List ephemeralPublic,
+    required Uint8List ciphertext,
+    required Uint8List nonce,
+    required List<int> signature,
+    String alg = 'aes-gcm',
+  }) {
+    return {
+      'crypto': CryptoConstants.cryptoVersion,
+      'scheme': CryptoConstants.schemeDmSigned2,
       'alg': alg,
       'ephemeralPub': base64Encode(ephemeralPublic),
       'nonce': base64Encode(nonce),

--- a/lib/crypto/ratchet/ratchet_service.dart
+++ b/lib/crypto/ratchet/ratchet_service.dart
@@ -81,7 +81,10 @@ class RatchetService {
       };
     }
 
-    final result = await session.encryptMessage(plaintext);
+    final result = await session.encryptMessage(
+      plaintext,
+      handshake: handshake.isEmpty ? null : handshake,
+    );
     await _store.save(peerId, session);
     if (handshake.isEmpty) {
       return result.wire;
@@ -116,18 +119,21 @@ class RatchetService {
     final envelope = jsonDecode(wire) as Map<String, dynamic>;
     final scheme = envelope['scheme'] as String?;
 
-    if (scheme == CryptoConstants.schemeDmSigned1) {
+    if (scheme == CryptoConstants.schemeDmSigned1 ||
+        scheme == CryptoConstants.schemeDmSigned2) {
       return CryptoWire.decryptSignedFromPeer(wire, local, peer);
     }
 
-    if (scheme == CryptoConstants.schemeDhAead1) {
+    if (scheme == CryptoConstants.schemeDhAead1 ||
+        scheme == CryptoConstants.schemeDhAead2) {
       if (!allowLegacyUnsignedDhAead) {
         throw const FormatException('Unsigned peer message rejected');
       }
       return CryptoWire.decryptLegacyFromPeer(wire, local);
     }
 
-    if (scheme != CryptoConstants.schemeRatchet1) {
+    if (scheme != CryptoConstants.schemeRatchet1 &&
+        scheme != CryptoConstants.schemeRatchet2) {
       throw FormatException('Unsupported ciphertext scheme: $scheme');
     }
 

--- a/lib/crypto/ratchet/ratchet_session.dart
+++ b/lib/crypto/ratchet/ratchet_session.dart
@@ -3,6 +3,7 @@ import 'dart:typed_data';
 
 import 'package:prysm/crypto/aead.dart';
 import 'package:prysm/crypto/constants.dart';
+import 'package:prysm/crypto/envelope.dart';
 import 'package:prysm/crypto/kdf.dart';
 
 /// Simplified Double Ratchet session for 1:1 chats (Phase 2).
@@ -45,9 +46,12 @@ class RatchetSession {
   }
 
   Future<({String wire, Map<String, dynamic> handshake})> encryptMessage(
-    Uint8List plaintext,
-  ) async {
+    Uint8List plaintext, {
+    Map<String, dynamic>? handshake,
+  }) async {
     final counter = sendCounter;
+    final scheme = CryptoConstants.schemeRatchet2;
+    const alg = 'aes-gcm';
     final messageKey = await _messageKey(
       role: isInitiator ? 'send' : 'recv',
       counter: counter,
@@ -56,27 +60,39 @@ class RatchetSession {
     final aeadKey = await CryptoAead.secretKeyFromBytes(
       Uint8List.fromList(messageKey),
     );
-    final enc = await CryptoAead.encryptAesGcm(plaintext, key: aeadKey);
+    final aad = CryptoEnvelope.ratchetAad(
+      scheme: scheme,
+      counter: counter,
+      alg: alg,
+      handshake: handshake,
+    );
+    final enc = await CryptoAead.encryptAesGcm(
+      plaintext,
+      key: aeadKey,
+      associatedData: aad,
+    );
     final wire = jsonEncode({
       'crypto': CryptoConstants.cryptoVersion,
-      'scheme': CryptoConstants.schemeRatchet1,
+      'scheme': scheme,
+      'alg': alg,
       'nonce': base64Encode(enc.nonce),
       'ciphertext': base64Encode(enc.ciphertext),
       'counter': counter,
     });
-    return (wire: wire, handshake: <String, dynamic>{});
+    return (wire: wire, handshake: handshake ?? <String, dynamic>{});
   }
 
   Future<Uint8List> decryptMessage(String wire) async {
     final envelope = jsonDecode(wire) as Map<String, dynamic>;
-    if (envelope['scheme'] != CryptoConstants.schemeRatchet1) {
+    final scheme = envelope['scheme'] as String?;
+    if (scheme != CryptoConstants.schemeRatchet1 &&
+        scheme != CryptoConstants.schemeRatchet2) {
       throw FormatException('Not a ratchet message');
     }
     final counter = envelope['counter'] as int;
     if (counter <= recvCounter) {
       throw StateError('Replay detected');
     }
-    recvCounter = counter;
     final messageKey = await _messageKey(
       role: isInitiator ? 'recv' : 'send',
       counter: counter,
@@ -84,11 +100,24 @@ class RatchetSession {
     final aeadKey = await CryptoAead.secretKeyFromBytes(
       Uint8List.fromList(messageKey),
     );
-    return CryptoAead.decryptAesGcm(
+    final associatedData = scheme == CryptoConstants.schemeRatchet2
+        ? CryptoEnvelope.ratchetAad(
+            scheme: scheme!,
+            counter: counter,
+            alg: envelope['alg'] as String? ?? 'aes-gcm',
+            crypto: envelope['crypto'] as String? ??
+                CryptoConstants.cryptoVersion,
+            handshake: envelope['handshake'] as Map<String, dynamic>?,
+          )
+        : const <int>[];
+    final plain = await CryptoAead.decryptAesGcm(
       ciphertextWithTag: base64Decode(envelope['ciphertext'] as String),
       key: aeadKey,
       nonce: base64Decode(envelope['nonce'] as String),
+      associatedData: associatedData,
     );
+    recvCounter = counter;
+    return plain;
   }
 
   Future<List<int>> _messageKey({

--- a/lib/crypto/wire.dart
+++ b/lib/crypto/wire.dart
@@ -22,6 +22,73 @@ class CryptoWire {
   }) =>
       '$ephemeralPub|$nonce|$ciphertext';
 
+  static String _dmSignPayloadV2({
+    required String crypto,
+    required String scheme,
+    required String alg,
+    required String ephemeralPub,
+    required String nonce,
+    required String ciphertext,
+  }) =>
+      '$crypto|$scheme|$alg|$ephemeralPub|$nonce|$ciphertext';
+
+  static List<int> _signPayloadBytes(Map<String, dynamic> envelope) {
+    final ephemeralPubB64 = envelope['ephemeralPub'] as String;
+    final nonceB64 = envelope['nonce'] as String;
+    final ciphertextB64 = envelope['ciphertext'] as String;
+    final scheme = CryptoEnvelope.schemeOf(envelope);
+    if (scheme == CryptoConstants.schemeDmSigned2) {
+      return utf8.encode(
+        _dmSignPayloadV2(
+          crypto: envelope['crypto'] as String? ??
+              CryptoConstants.cryptoVersion,
+          scheme: scheme,
+          alg: envelope['alg'] as String? ?? 'aes-gcm',
+          ephemeralPub: ephemeralPubB64,
+          nonce: nonceB64,
+          ciphertext: ciphertextB64,
+        ),
+      );
+    }
+    return utf8.encode(
+      _dmSignPayload(
+        ephemeralPub: ephemeralPubB64,
+        nonce: nonceB64,
+        ciphertext: ciphertextB64,
+      ),
+    );
+  }
+
+  static Map<String, dynamic> _wrapMapFromEnvelope(
+    Map<String, dynamic> parsed,
+  ) =>
+      {
+        'crypto': parsed['crypto'],
+        'scheme': parsed['scheme'],
+        'alg': parsed['alg'] ?? 'aes-gcm',
+        'ephemeralPub': parsed['ephemeralPub'],
+        'nonce': parsed['nonce'],
+        'ciphertext': parsed['ciphertext'],
+      };
+
+  static Map<String, dynamic> _envelopeFromWrap(Map<String, dynamic> wrapped) {
+    final scheme = wrapped['scheme'] as String? ?? CryptoConstants.schemeDhAead1;
+    final envelope = <String, dynamic>{
+      'crypto':
+          wrapped['crypto'] as String? ?? CryptoConstants.cryptoVersion,
+      'scheme': scheme,
+      'alg': wrapped['alg'] as String? ?? 'aes-gcm',
+      'ephemeralPub': wrapped['ephemeralPub'],
+      'nonce': wrapped['nonce'],
+      'ciphertext': wrapped['ciphertext'],
+    };
+    final sig = wrapped['sig'];
+    if (sig != null) {
+      envelope['sig'] = sig;
+    }
+    return envelope;
+  }
+
   /// Ephemeral X25519 + HKDF + AES-GCM for 1:1 text/binary (unsigned).
   static Future<String> encryptForPeer(
     Uint8List plaintext,
@@ -40,8 +107,15 @@ class CryptoWire {
       info: utf8.encode(CryptoConstants.hkdfInfoDhAead),
       salt: ephemeralPublic.bytes,
     );
-    final enc = await CryptoAead.encryptAesGcm(plaintext, key: aeadKey);
-    final envelope = CryptoEnvelope.dhAead1(
+    const scheme = CryptoConstants.schemeDhAead2;
+    const alg = 'aes-gcm';
+    final aad = CryptoEnvelope.headerAad(scheme: scheme, alg: alg);
+    final enc = await CryptoAead.encryptAesGcm(
+      plaintext,
+      key: aeadKey,
+      associatedData: aad,
+    );
+    final envelope = CryptoEnvelope.dhAead2(
       ephemeralPublic: Uint8List.fromList(ephemeralPublic.bytes),
       ciphertext: enc.ciphertext,
       nonce: enc.nonce,
@@ -74,19 +148,29 @@ class CryptoWire {
       info: utf8.encode(CryptoConstants.hkdfInfoDhAead),
       salt: ephemeralPublic.bytes,
     );
-    final enc = await CryptoAead.encryptAesGcm(plaintext, key: aeadKey);
+    const scheme = CryptoConstants.schemeDmSigned2;
+    const alg = 'aes-gcm';
+    final aad = CryptoEnvelope.headerAad(scheme: scheme, alg: alg);
+    final enc = await CryptoAead.encryptAesGcm(
+      plaintext,
+      key: aeadKey,
+      associatedData: aad,
+    );
     final ephemeralPubB64 = base64Encode(ephemeralPublic.bytes);
     final nonceB64 = base64Encode(enc.nonce);
     final ciphertextB64 = base64Encode(enc.ciphertext);
     final signPayload = utf8.encode(
-      _dmSignPayload(
+      _dmSignPayloadV2(
+        crypto: CryptoConstants.cryptoVersion,
+        scheme: scheme,
+        alg: alg,
         ephemeralPub: ephemeralPubB64,
         nonce: nonceB64,
         ciphertext: ciphertextB64,
       ),
     );
     final signature = await sender.sign(signPayload);
-    final envelope = CryptoEnvelope.dmSigned1(
+    final envelope = CryptoEnvelope.dmSigned2(
       ephemeralPublic: Uint8List.fromList(ephemeralPublic.bytes),
       ciphertext: enc.ciphertext,
       nonce: enc.nonce,
@@ -110,16 +194,7 @@ class CryptoWire {
     if (sigRaw == null) {
       throw const FormatException('Missing DM signature');
     }
-    final ephemeralPubB64 = envelope['ephemeralPub'] as String;
-    final nonceB64 = envelope['nonce'] as String;
-    final ciphertextB64 = envelope['ciphertext'] as String;
-    final signPayload = utf8.encode(
-      _dmSignPayload(
-        ephemeralPub: ephemeralPubB64,
-        nonce: nonceB64,
-        ciphertext: ciphertextB64,
-      ),
-    );
+    final signPayload = _signPayloadBytes(envelope);
     final valid = await _ed25519.verify(
       signPayload,
       signature: Signature(
@@ -132,7 +207,7 @@ class CryptoWire {
     }
   }
 
-  static Future<Uint8List> _decryptDhAead1Envelope(
+  static Future<Uint8List> _decryptDhAeadEnvelope(
     Map<String, dynamic> envelope,
     IdentityKeyPair recipient,
   ) async {
@@ -157,10 +232,11 @@ class CryptoWire {
       ciphertextWithTag: ciphertext,
       key: aeadKey,
       nonce: nonce,
+      associatedData: CryptoEnvelope.dhAeadAssociatedData(envelope),
     );
   }
 
-  /// Decrypts a signed peer DM (`dm-signed-1`).
+  /// Decrypts a signed peer DM (`dm-signed-1` or `dm-signed-2`).
   static Future<Uint8List> decryptSignedFromPeer(
     String wire,
     IdentityKeyPair recipient,
@@ -170,11 +246,13 @@ class CryptoWire {
     if (envelope == null) {
       throw FormatException('Not a v2 crypto envelope');
     }
-    if (CryptoEnvelope.schemeOf(envelope) != CryptoConstants.schemeDmSigned1) {
+    final scheme = CryptoEnvelope.schemeOf(envelope);
+    if (scheme != CryptoConstants.schemeDmSigned1 &&
+        scheme != CryptoConstants.schemeDmSigned2) {
       throw FormatException('Unsupported scheme');
     }
     await _verifyDmSignedEnvelope(envelope, sender);
-    return _decryptDhAead1Envelope(envelope, recipient);
+    return _decryptDhAeadEnvelope(envelope, recipient);
   }
 
   static Future<String> decryptSignedTextFromPeer(
@@ -186,7 +264,7 @@ class CryptoWire {
     return utf8.decode(bytes);
   }
 
-  /// Legacy unsigned `dh-aead-1` decrypt (confidentiality only, no sender auth).
+  /// Legacy unsigned `dh-aead-1` / `dh-aead-2` decrypt (confidentiality only).
   static Future<Uint8List> decryptLegacyFromPeer(
     String wire,
     IdentityKeyPair recipient,
@@ -195,10 +273,12 @@ class CryptoWire {
     if (envelope == null) {
       throw FormatException('Not a v2 crypto envelope');
     }
-    if (CryptoEnvelope.schemeOf(envelope) != CryptoConstants.schemeDhAead1) {
+    final scheme = CryptoEnvelope.schemeOf(envelope);
+    if (scheme != CryptoConstants.schemeDhAead1 &&
+        scheme != CryptoConstants.schemeDhAead2) {
       throw FormatException('Unsupported scheme');
     }
-    return _decryptDhAead1Envelope(envelope, recipient);
+    return _decryptDhAeadEnvelope(envelope, recipient);
   }
 
   static Future<String> decryptLegacyTextFromPeer(
@@ -244,7 +324,16 @@ class CryptoWire {
     String wire,
     IdentityKeyPair identity,
   ) async {
-    return decryptLegacyFromPeer(wire, identity);
+    final envelope = CryptoEnvelope.tryParse(wire);
+    if (envelope == null) {
+      throw FormatException('Not a v2 crypto envelope');
+    }
+    final scheme = CryptoEnvelope.schemeOf(envelope);
+    if (scheme != CryptoConstants.schemeDhAead1 &&
+        scheme != CryptoConstants.schemeDhAead2) {
+      throw FormatException('Unsupported scheme');
+    }
+    return _decryptDhAeadEnvelope(envelope, identity);
   }
 
   static Future<String> decryptTextForSelf(
@@ -263,11 +352,7 @@ class CryptoWire {
   ) async {
     final wire = await encryptForPeer(keyBytes, sender, peerAgreePublic);
     final parsed = CryptoEnvelope.tryParse(wire)!;
-    return {
-      'ephemeralPub': parsed['ephemeralPub'],
-      'nonce': parsed['nonce'],
-      'ciphertext': parsed['ciphertext'],
-    };
+    return _wrapMapFromEnvelope(parsed);
   }
 
   /// Signed key wrap for authenticated peer file/binary payloads.
@@ -279,9 +364,7 @@ class CryptoWire {
     final wire = await encryptSignedForPeer(keyBytes, sender, peerAgreePublic);
     final parsed = CryptoEnvelope.tryParse(wire)!;
     return {
-      'ephemeralPub': parsed['ephemeralPub'],
-      'nonce': parsed['nonce'],
-      'ciphertext': parsed['ciphertext'],
+      ..._wrapMapFromEnvelope(parsed),
       'sig': parsed['sig'],
     };
   }
@@ -294,16 +377,19 @@ class CryptoWire {
     if (sigRaw == null) {
       throw const FormatException('Missing signed wrap signature');
     }
-    final ephemeralPubB64 = wrapped['ephemeralPub'] as String;
-    final nonceB64 = wrapped['nonce'] as String;
-    final ciphertextB64 = wrapped['ciphertext'] as String;
-    final signPayload = utf8.encode(
-      _dmSignPayload(
-        ephemeralPub: ephemeralPubB64,
-        nonce: nonceB64,
-        ciphertext: ciphertextB64,
-      ),
-    );
+    final scheme =
+        wrapped['scheme'] as String? ?? CryptoConstants.schemeDmSigned1;
+    final envelope = <String, dynamic>{
+      'crypto':
+          wrapped['crypto'] as String? ?? CryptoConstants.cryptoVersion,
+      'scheme': scheme,
+      'alg': wrapped['alg'] as String? ?? 'aes-gcm',
+      'ephemeralPub': wrapped['ephemeralPub'],
+      'nonce': wrapped['nonce'],
+      'ciphertext': wrapped['ciphertext'],
+      'sig': sigRaw,
+    };
+    final signPayload = _signPayloadBytes(envelope);
     final valid = await _ed25519.verify(
       signPayload,
       signature: Signature(
@@ -320,14 +406,7 @@ class CryptoWire {
     Map<String, dynamic> wrapped,
     IdentityKeyPair recipient,
   ) async {
-    final wire = CryptoEnvelope.encode({
-      'crypto': CryptoConstants.cryptoVersion,
-      'scheme': CryptoConstants.schemeDhAead1,
-      'alg': 'aes-gcm',
-      'ephemeralPub': wrapped['ephemeralPub'],
-      'nonce': wrapped['nonce'],
-      'ciphertext': wrapped['ciphertext'],
-    });
+    final wire = CryptoEnvelope.encode(_envelopeFromWrap(wrapped));
     return decryptLegacyFromPeer(wire, recipient);
   }
 
@@ -337,15 +416,7 @@ class CryptoWire {
     IdentityPublicKeys sender,
   ) async {
     await _verifySignedWrap(wrapped, sender);
-    final wire = CryptoEnvelope.encode({
-      'crypto': CryptoConstants.cryptoVersion,
-      'scheme': CryptoConstants.schemeDmSigned1,
-      'alg': 'aes-gcm',
-      'ephemeralPub': wrapped['ephemeralPub'],
-      'nonce': wrapped['nonce'],
-      'ciphertext': wrapped['ciphertext'],
-      'sig': wrapped['sig'],
-    });
+    final wire = CryptoEnvelope.encode(_envelopeFromWrap(wrapped));
     return decryptSignedFromPeer(wire, recipient, sender);
   }
 
@@ -460,14 +531,18 @@ class CryptoWire {
     await _verifySignedWrap(wrapped, sender);
   }
 
-  /// Verifies dm-signed-1 signature without decrypting plaintext.
+  /// Verifies dm-signed-1 / dm-signed-2 signature without decrypting plaintext.
   static Future<void> verifyDmSignedWire(
     String wire,
     IdentityPublicKeys sender,
   ) async {
     final envelope = CryptoEnvelope.tryParse(wire);
-    if (envelope == null ||
-        envelope['scheme'] != CryptoConstants.schemeDmSigned1) {
+    if (envelope == null) {
+      throw const FormatException('Not a dm-signed envelope');
+    }
+    final scheme = CryptoEnvelope.schemeOf(envelope);
+    if (scheme != CryptoConstants.schemeDmSigned1 &&
+        scheme != CryptoConstants.schemeDmSigned2) {
       throw const FormatException('Not a dm-signed envelope');
     }
     await _verifyDmSignedEnvelope(envelope, sender);

--- a/test/crypto/dm_signed_test.dart
+++ b/test/crypto/dm_signed_test.dart
@@ -17,7 +17,7 @@ Future<IdentityPublicKeys> _publicKeys(IdentityKeyPair id) async {
 }
 
 void main() {
-  group('dm-signed-1', () {
+  group('dm-signed', () {
     test('signed 1:1 text round trip', () async {
       final alice = await IdentityKeyPair.generate();
       final bob = await IdentityKeyPair.generate();
@@ -31,7 +31,7 @@ void main() {
       );
       expect(CryptoEnvelope.isV2(wire), isTrue);
       final parsed = CryptoEnvelope.tryParse(wire)!;
-      expect(parsed['scheme'], CryptoConstants.schemeDmSigned1);
+      expect(parsed['scheme'], CryptoConstants.schemeDmSigned2);
 
       final plain = await CryptoWire.decryptSignedTextFromPeer(
         wire,
@@ -98,7 +98,7 @@ void main() {
       expect(plain, 'legacy');
     });
 
-    test('encryptBytesForPeer produces dm-signed-1', () async {
+    test('encryptBytesForPeer produces dm-signed-2', () async {
       final alice = await IdentityKeyPair.generate();
       final bob = await IdentityKeyPair.generate();
       final keyManager = KeyManager.fromIdentity(alice);
@@ -109,7 +109,7 @@ void main() {
         bobPub,
       );
       final parsed = CryptoEnvelope.tryParse(wire)!;
-      expect(parsed['scheme'], CryptoConstants.schemeDmSigned1);
+      expect(parsed['scheme'], CryptoConstants.schemeDmSigned2);
     });
   });
 }

--- a/test/crypto/ratchet_bootstrap_test.dart
+++ b/test/crypto/ratchet_bootstrap_test.dart
@@ -150,7 +150,7 @@ void main() {
 
     final envelope = jsonDecode(wire) as Map<String, dynamic>;
     expect(envelope['handshake'], isNotNull);
-    expect(envelope['scheme'], CryptoConstants.schemeRatchet1);
+    expect(envelope['scheme'], CryptoConstants.schemeRatchet2);
 
     final plain = await RatchetService.instance.decryptText(
       peerId: aliceOnion,

--- a/test/crypto/ratchet_security_test.dart
+++ b/test/crypto/ratchet_security_test.dart
@@ -1,0 +1,117 @@
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:prysm/crypto/crypto.dart';
+
+Future<({RatchetSession init, RatchetSession resp})> _pairedSessions() async {
+  final shared = Uint8List.fromList(List.generate(32, (i) => i));
+  final init = await RatchetSession.initializeAsInitiator(shared);
+  final resp = await RatchetSession.initializeAsResponder(shared);
+  return (init: init, resp: resp);
+}
+
+Future<String> _legacyRatchet1Wire(
+  RatchetSession session,
+  Uint8List plaintext,
+) async {
+  final counter = session.sendCounter;
+  final role = session.isInitiator ? 'send' : 'recv';
+  final salt = Uint8List.fromList(utf8.encode('prysm/ratchet/root-salt'));
+  final messageKey = await CryptoKdf.hkdf(
+    sharedSecret: session.sharedMaterial,
+    info: utf8.encode('${CryptoConstants.hkdfInfoRatchet}/$role/msg/$counter'),
+    salt: salt,
+  );
+  session.sendCounter++;
+  final aeadKey = await CryptoAead.secretKeyFromBytes(
+    Uint8List.fromList(await messageKey.extractBytes()),
+  );
+  final enc = await CryptoAead.encryptAesGcm(plaintext, key: aeadKey);
+  return jsonEncode({
+    'crypto': CryptoConstants.cryptoVersion,
+    'scheme': CryptoConstants.schemeRatchet1,
+    'nonce': base64Encode(enc.nonce),
+    'ciphertext': base64Encode(enc.ciphertext),
+    'counter': counter,
+  });
+}
+
+void main() {
+  group('Ratchet security', () {
+    test('tampered counter does not advance recvCounter', () async {
+      final pair = await _pairedSessions();
+      final enc = await pair.init.encryptMessage(utf8.encode('hello'));
+      final envelope = jsonDecode(enc.wire) as Map<String, dynamic>;
+      envelope['counter'] = 999999;
+      envelope['ciphertext'] = base64Encode(List.filled(32, 0));
+
+      expect(
+        () => pair.resp.decryptMessage(jsonEncode(envelope)),
+        throwsA(isA<Exception>()),
+      );
+      expect(pair.resp.recvCounter, -1);
+
+      final enc2 = await pair.init.encryptMessage(utf8.encode('next'));
+      final plain = await pair.resp.decryptMessage(enc2.wire);
+      expect(utf8.decode(plain), 'next');
+    });
+
+    test('large counter gap decrypts successfully', () async {
+      final pair = await _pairedSessions();
+      pair.init.sendCounter = 500;
+      final enc = await pair.init.encryptMessage(utf8.encode('far ahead'));
+      final plain = await pair.resp.decryptMessage(enc.wire);
+      expect(utf8.decode(plain), 'far ahead');
+      expect(pair.resp.recvCounter, 500);
+    });
+
+    test('scheme relabel fails decrypt on ratchet-2', () async {
+      final pair = await _pairedSessions();
+      final enc = await pair.init.encryptMessage(utf8.encode('bound'));
+      final envelope = jsonDecode(enc.wire) as Map<String, dynamic>;
+      envelope['scheme'] = CryptoConstants.schemeRatchet1;
+
+      expect(
+        () => pair.resp.decryptMessage(jsonEncode(envelope)),
+        throwsA(isA<Exception>()),
+      );
+      expect(pair.resp.recvCounter, -1);
+    });
+
+    test('handshake rebind fails bootstrap decrypt', () async {
+      final pair = await _pairedSessions();
+      final handshake = {
+        'ephemeralPub': base64Encode(List.filled(32, 1)),
+        'oneTimePreKey': base64Encode(List.filled(32, 2)),
+      };
+      final enc = await pair.init.encryptMessage(
+        utf8.encode('bootstrap'),
+        handshake: handshake,
+      );
+      final envelope = jsonDecode(enc.wire) as Map<String, dynamic>;
+      envelope['handshake'] = {
+        ...handshake,
+        'ephemeralPub': base64Encode(List.filled(32, 9)),
+      };
+
+      expect(
+        () => pair.resp.decryptMessage(jsonEncode(envelope)),
+        throwsA(isA<Exception>()),
+      );
+      expect(pair.resp.recvCounter, -1);
+
+      final envelopeOk = jsonDecode(enc.wire) as Map<String, dynamic>;
+      envelopeOk['handshake'] = handshake;
+      final plain = await pair.resp.decryptMessage(jsonEncode(envelopeOk));
+      expect(utf8.decode(plain), 'bootstrap');
+    });
+
+    test('ratchet-1 legacy wire still decrypts', () async {
+      final pair = await _pairedSessions();
+      final wire = await _legacyRatchet1Wire(pair.init, utf8.encode('legacy'));
+      final plain = await pair.resp.decryptMessage(wire);
+      expect(utf8.decode(plain), 'legacy');
+    });
+  });
+}

--- a/test/crypto/wire_security_test.dart
+++ b/test/crypto/wire_security_test.dart
@@ -1,0 +1,195 @@
+import 'dart:convert';
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:cryptography/cryptography.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:prysm/crypto/crypto.dart';
+import 'package:prysm/crypto/direct_message_auth.dart';
+import 'package:prysm/util/key_manager.dart';
+
+Future<IdentityPublicKeys> _publicKeys(IdentityKeyPair id) async {
+  final sign = await id.signPublicKey;
+  final agree = await id.agreePublicKey;
+  return IdentityPublicKeys(
+    signPublic: sign,
+    agreePublic: agree,
+    fingerprint: IdentityKeyPair.fingerprintFromPublicJson(
+      await id.toPublicJson(),
+    ),
+  );
+}
+
+void main() {
+  group('Wire -2 security', () {
+    test('dm-signed-2 round trip with header AAD', () async {
+      final alice = await IdentityKeyPair.generate();
+      final bob = await IdentityKeyPair.generate();
+      final bobPub = await bob.agreePublicKey;
+      final alicePub = await _publicKeys(alice);
+
+      final wire = await CryptoWire.encryptSignedTextForPeer(
+        'signed v2',
+        alice,
+        bobPub,
+      );
+      final parsed = CryptoEnvelope.tryParse(wire)!;
+      expect(parsed['scheme'], CryptoConstants.schemeDmSigned2);
+
+      final plain = await CryptoWire.decryptSignedTextFromPeer(
+        wire,
+        bob,
+        alicePub,
+      );
+      expect(plain, 'signed v2');
+    });
+
+    test('dm-signed-1 legacy round trip still passes', () async {
+      final alice = await IdentityKeyPair.generate();
+      final bob = await IdentityKeyPair.generate();
+      final alicePub = await _publicKeys(alice);
+      final bobPub = await bob.agreePublicKey;
+
+      final legacyWire = jsonEncode({
+        'crypto': CryptoConstants.cryptoVersion,
+        'scheme': CryptoConstants.schemeDmSigned1,
+        'alg': 'aes-gcm',
+        'ephemeralPub': 'legacy',
+        'nonce': 'legacy',
+        'ciphertext': 'legacy',
+        'sig': base64Encode(List.filled(64, 1)),
+      });
+      expect(
+        () => CryptoWire.decryptSignedFromPeer(legacyWire, bob, alicePub),
+        throwsFormatException,
+      );
+
+      // Build a real dm-signed-1 wire via manual encrypt (no AAD).
+      final x25519 = X25519();
+      final ephemeral = await x25519.newKeyPair();
+      final ephemeralPublic = await ephemeral.extractPublicKey();
+      final shared = await x25519.sharedSecretKey(
+        keyPair: ephemeral,
+        remotePublicKey: bobPub,
+      );
+      final sharedBytes = await shared.extractBytes();
+      final aeadKey = await CryptoKdf.hkdf(
+        sharedSecret: sharedBytes,
+        info: utf8.encode(CryptoConstants.hkdfInfoDhAead),
+        salt: ephemeralPublic.bytes,
+      );
+      final enc = await CryptoAead.encryptAesGcm(
+        utf8.encode('legacy signed'),
+        key: aeadKey,
+      );
+      final ephemeralPubB64 = base64Encode(ephemeralPublic.bytes);
+      final nonceB64 = base64Encode(enc.nonce);
+      final ciphertextB64 = base64Encode(enc.ciphertext);
+      final signPayload = utf8.encode(
+        '$ephemeralPubB64|$nonceB64|$ciphertextB64',
+      );
+      final signature = await alice.sign(signPayload);
+      final wire = CryptoEnvelope.encode(
+        CryptoEnvelope.dmSigned1(
+          ephemeralPublic: Uint8List.fromList(ephemeralPublic.bytes),
+          ciphertext: enc.ciphertext,
+          nonce: enc.nonce,
+          signature: signature.bytes,
+        ),
+      );
+
+      final plain = await CryptoWire.decryptSignedTextFromPeer(
+        wire,
+        bob,
+        alicePub,
+      );
+      expect(plain, 'legacy signed');
+    });
+
+    test('signature replay fails when scheme relabeled', () async {
+      final alice = await IdentityKeyPair.generate();
+      final bob = await IdentityKeyPair.generate();
+      final bobPub = await bob.agreePublicKey;
+      final alicePub = await _publicKeys(alice);
+
+      final wire = await CryptoWire.encryptSignedTextForPeer(
+        'replay test',
+        alice,
+        bobPub,
+      );
+      final envelope = CryptoEnvelope.tryParse(wire)!;
+      envelope['scheme'] = CryptoConstants.schemeDmSigned1;
+      final relabeled = CryptoEnvelope.encode(envelope);
+
+      expect(
+        () => CryptoWire.decryptSignedFromPeer(relabeled, bob, alicePub),
+        throwsFormatException,
+      );
+    });
+
+    test('encryptFile self payload round-trips with dh-aead-2 wrap', () async {
+      final alice = await IdentityKeyPair.generate();
+      final bob = await IdentityKeyPair.generate();
+      final bobPub = await bob.agreePublicKey;
+      final bytes = Uint8List.fromList([1, 2, 3, 4, 5]);
+
+      final payloads = await CryptoWire.encryptFile(bytes, alice, bobPub);
+      final selfEnvelope = CryptoEnvelope.tryParse(payloads.selfPayload)!;
+      final wrapped = selfEnvelope['wrappedKey'] as Map<String, dynamic>;
+      expect(wrapped['scheme'], CryptoConstants.schemeDhAead2);
+
+      final dec = await CryptoWire.decryptFile(payloads.selfPayload, alice);
+      expect(dec, bytes);
+    });
+
+    test('legacy wrap map without scheme still unwraps as dh-aead-1', () async {
+      final alice = await IdentityKeyPair.generate();
+      final bob = await IdentityKeyPair.generate();
+      final bobPub = await bob.agreePublicKey;
+
+      final x25519 = X25519();
+      final ephemeral = await x25519.newKeyPair();
+      final ephemeralPublic = await ephemeral.extractPublicKey();
+      final shared = await x25519.sharedSecretKey(
+        keyPair: ephemeral,
+        remotePublicKey: bobPub,
+      );
+      final sharedBytes = await shared.extractBytes();
+      final aeadKey = await CryptoKdf.hkdf(
+        sharedSecret: sharedBytes,
+        info: utf8.encode(CryptoConstants.hkdfInfoDhAead),
+        salt: ephemeralPublic.bytes,
+      );
+      final keyBytes = CryptoKdf.randomBytes(32);
+      final enc = await CryptoAead.encryptAesGcm(keyBytes, key: aeadKey);
+      final legacyWrap = {
+        'ephemeralPub': base64Encode(ephemeralPublic.bytes),
+        'nonce': base64Encode(enc.nonce),
+        'ciphertext': base64Encode(enc.ciphertext),
+      };
+
+      final unwrapped = await CryptoWire.unwrapKeyFromPeer(legacyWrap, bob);
+      expect(unwrapped, keyBytes);
+    });
+
+    test('inbound dh-aead-2 from known peer is rejected', () async {
+      final alice = await IdentityKeyPair.generate();
+      final bob = await IdentityKeyPair.generate();
+      final alicePub = await _publicKeys(alice);
+      final bobPub = await bob.agreePublicKey;
+
+      final wire = await CryptoWire.encryptTextForPeer('unsigned', alice, bobPub);
+
+      final outcome = await DirectMessageAuth.authenticateInboundDirect(
+        senderId: 'alice.onion',
+        wire: wire,
+        type: 'text',
+        localUserId: 'bob.onion',
+        keyManager: KeyManager.fromIdentity(bob),
+        resolveIdentity: (_) async => alicePub,
+        fullDecrypt: false,
+      );
+      expect(outcome, DirectAuthOutcome.rejected);
+    });
+  });
+}

--- a/test/crypto/wire_security_test.dart
+++ b/test/crypto/wire_security_test.dart
@@ -1,11 +1,9 @@
 import 'dart:convert';
-import 'dart:convert';
 import 'dart:typed_data';
 
 import 'package:cryptography/cryptography.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:prysm/crypto/crypto.dart';
-import 'package:prysm/crypto/direct_message_auth.dart';
 import 'package:prysm/util/key_manager.dart';
 
 Future<IdentityPublicKeys> _publicKeys(IdentityKeyPair id) async {
@@ -143,7 +141,6 @@ void main() {
     });
 
     test('legacy wrap map without scheme still unwraps as dh-aead-1', () async {
-      final alice = await IdentityKeyPair.generate();
       final bob = await IdentityKeyPair.generate();
       final bobPub = await bob.agreePublicKey;
 


### PR DESCRIPTION
- Added `dh-aead-2` and `dm-signed-2` schemes to improve direct message authentication and encryption.
- Updated `CryptoEnvelope` and `CryptoWire` classes to support the new schemes, including associated data handling.
- Enhanced `RatchetService` and `RatchetSession` to accommodate the new ratchet scheme.
- Modified tests to validate the new schemes and ensure backward compatibility with existing functionality.