### PR TITLE
feat: enhance prekey management with mutex protection

### DIFF
--- a/lib/crypto/ratchet/prekey_bundle.dart
+++ b/lib/crypto/ratchet/prekey_bundle.dart
@@ -2,6 +2,7 @@ import 'dart:convert';
 import 'dart:typed_data';
 
 import 'package:cryptography/cryptography.dart';
+import 'package:mutex/mutex.dart';
 import 'package:prysm/crypto/constants.dart';
 import 'package:prysm/crypto/identity.dart';
 import 'package:prysm/crypto/key_store.dart';
@@ -26,6 +27,8 @@ class PrekeyBundle {
   static const int _oneTimeReplenishThreshold = 4;
 
   static final X25519 _x25519 = X25519();
+
+  static final Mutex _poolMutex = Mutex();
 
   static Future<PrekeyBundle> generate(
     IdentityKeyPair identity, {
@@ -89,23 +92,25 @@ class PrekeyBundle {
   }
 
   static Future<void> _migrateLegacyOneTimeKey() async {
-    final legacy = await CryptoKeyStore.read(storageOneTimePreKeyPrivate);
-    if (legacy == null) return;
-    final poolRaw = await CryptoKeyStore.read(storageOneTimePreKeyPool);
-    if (poolRaw != null && poolRaw.isNotEmpty) {
+    await _poolMutex.protect(() async {
+      final legacy = await CryptoKeyStore.read(storageOneTimePreKeyPrivate);
+      if (legacy == null) return;
+      final poolRaw = await CryptoKeyStore.read(storageOneTimePreKeyPool);
+      if (poolRaw != null && poolRaw.isNotEmpty) {
+        await CryptoKeyStore.delete(storageOneTimePreKeyPrivate);
+        return;
+      }
+      final private = base64Decode(legacy);
+      final keyPair = await _x25519.newKeyPairFromSeed(private);
+      final public = await keyPair.extractPublicKey();
+      await _writeOneTimePool([
+        {
+          'pub': base64Encode(public.bytes),
+          'priv': legacy,
+        },
+      ]);
       await CryptoKeyStore.delete(storageOneTimePreKeyPrivate);
-      return;
-    }
-    final private = base64Decode(legacy);
-    final keyPair = await _x25519.newKeyPairFromSeed(private);
-    final public = await keyPair.extractPublicKey();
-    await _writeOneTimePool([
-      {
-        'pub': base64Encode(public.bytes),
-        'priv': legacy,
-      },
-    ]);
-    await CryptoKeyStore.delete(storageOneTimePreKeyPrivate);
+    });
   }
 
   static Future<List<Map<String, String>>> _readOneTimePool() async {
@@ -124,17 +129,19 @@ class PrekeyBundle {
   }
 
   static Future<void> _ensureOneTimePool(IdentityKeyPair identity) async {
-    var pool = await _readOneTimePool();
-    while (pool.length < _oneTimePoolSize) {
-      final oneTime = await _x25519.newKeyPair();
-      final oneTimePublic = await oneTime.extractPublicKey();
-      final oneTimePrivate = await oneTime.extractPrivateKeyBytes();
-      pool.add({
-        'pub': base64Encode(oneTimePublic.bytes),
-        'priv': base64Encode(oneTimePrivate),
-      });
-    }
-    await _writeOneTimePool(pool);
+    await _poolMutex.protect(() async {
+      var pool = await _readOneTimePool();
+      while (pool.length < _oneTimePoolSize) {
+        final oneTime = await _x25519.newKeyPair();
+        final oneTimePublic = await oneTime.extractPublicKey();
+        final oneTimePrivate = await oneTime.extractPrivateKeyBytes();
+        pool.add({
+          'pub': base64Encode(oneTimePublic.bytes),
+          'priv': base64Encode(oneTimePrivate),
+        });
+      }
+      await _writeOneTimePool(pool);
+    });
   }
 
   static Future<SimplePublicKey> _nextOneTimePublic() async {
@@ -147,28 +154,60 @@ class PrekeyBundle {
     return SimplePublicKey(pubBytes, type: KeyPairType.x25519);
   }
 
-  static Future<KeyPair?> _consumeOneTimePrivateForPublic(
+    /// Non-destructive lookup of the one-time prekey private key. The pool entry
+  /// is only removed by [commitOneTimePreKeyConsumption] once the handshake
+  /// message has been successfully decrypted.
+  static Future<(KeyPair, SimplePublicKey)?> _lookupOneTimePreKey(
+    SimplePublicKey? requestedPublic,
+  ) {
+    return _poolMutex.protect(() async {
+      final pool = await _readOneTimePool();
+      if (pool.isEmpty) return null;
+      final Map<String, String> entry;
+      if (requestedPublic == null) {
+        entry = pool.first;
+      } else {
+        final pubB64 = base64Encode(requestedPublic.bytes);
+        final index = pool.indexWhere((e) => e['pub'] == pubB64);
+        if (index < 0) return null;
+        entry = pool[index];
+      }
+      final keyPair = await _x25519.newKeyPairFromSeed(
+        base64Decode(entry['priv']!),
+      );
+      final public = SimplePublicKey(
+        base64Decode(entry['pub']!),
+        type: KeyPairType.x25519,
+      );
+      return (keyPair, public);
+    });
+  }
+
+  /// Removes a one-time prekey from the persistent pool only after its
+  /// handshake message has been successfully decrypted, then replenishes the
+  /// pool below the threshold. Idempotent: no-op if already consumed.
+  static Future<void> commitOneTimePreKeyConsumption(
     SimplePublicKey public,
-  ) async {
-    final pool = await _readOneTimePool();
-    final pubB64 = base64Encode(public.bytes);
-    final index = pool.indexWhere((e) => e['pub'] == pubB64);
-    if (index < 0) return null;
-    final entry = pool.removeAt(index);
-    await _writeOneTimePool(pool);
-  if (pool.length < _oneTimeReplenishThreshold) {
-      while (pool.length < _oneTimePoolSize) {
-        final oneTime = await _x25519.newKeyPair();
-        final oneTimePublic = await oneTime.extractPublicKey();
-        final oneTimePrivate = await oneTime.extractPrivateKeyBytes();
-        pool.add({
-          'pub': base64Encode(oneTimePublic.bytes),
-          'priv': base64Encode(oneTimePrivate),
-        });
+  ) {
+    return _poolMutex.protect(() async {
+      final pool = await _readOneTimePool();
+      final pubB64 = base64Encode(public.bytes);
+      final before = pool.length;
+      pool.removeWhere((e) => e['pub'] == pubB64);
+      if (pool.length == before) return;
+      if (pool.length < _oneTimeReplenishThreshold) {
+        while (pool.length < _oneTimePoolSize) {
+          final oneTime = await _x25519.newKeyPair();
+          final oneTimePublic = await oneTime.extractPublicKey();
+          final oneTimePrivate = await oneTime.extractPrivateKeyBytes();
+          pool.add({
+            'pub': base64Encode(oneTimePublic.bytes),
+            'priv': base64Encode(oneTimePrivate),
+          });
+        }
       }
       await _writeOneTimePool(pool);
-    }
-    return _x25519.newKeyPairFromSeed(base64Decode(entry['priv']!));
+    });
   }
 
   Map<String, dynamic> toJson() => {
@@ -255,7 +294,10 @@ class PrekeyBundle {
   }
 
   /// Responder-side shared secret using stored one-time prekey.
-  static Future<Uint8List?> sharedSecretAsResponder({
+  /// Non-destructive: the used one-time prekey remains in the pool until
+  /// [commitOneTimePreKeyConsumption] is called after a successful decrypt.
+  static Future<({Uint8List material, SimplePublicKey usedOneTimePreKeyPublic})?>
+      sharedSecretAsResponder({
     required IdentityKeyPair local,
     required IdentityPublicKeys peer,
     required SimplePublicKey initiatorEphemeralPublic,
@@ -271,11 +313,11 @@ class PrekeyBundle {
       base64Decode(signedPrivateB64),
     );
 
-    final oneTimePublic = usedOneTimePreKeyPublic ?? await _nextOneTimePublic();
-    final oneTimePreKey = await _consumeOneTimePrivateForPublic(oneTimePublic);
-    if (oneTimePreKey == null) {
+    final lookup = await _lookupOneTimePreKey(usedOneTimePreKeyPublic);
+    if (lookup == null) {
       return null;
     }
+    final (oneTimePreKey, oneTimePublic) = lookup;
 
     final dh1 = await _x25519.sharedSecretKey(
       keyPair: signedPreKey,
@@ -293,11 +335,14 @@ class PrekeyBundle {
       keyPair: oneTimePreKey,
       remotePublicKey: initiatorEphemeralPublic,
     );
-    return Uint8List.fromList([
-      ...await dh1.extractBytes(),
-      ...await dh2.extractBytes(),
-      ...await dh3.extractBytes(),
-      ...await dh4.extractBytes(),
-    ]);
+    return (
+      material: Uint8List.fromList([
+        ...await dh1.extractBytes(),
+        ...await dh2.extractBytes(),
+        ...await dh3.extractBytes(),
+        ...await dh4.extractBytes(),
+      ]),
+      usedOneTimePreKeyPublic: oneTimePublic,
+    );
   }
 }

--- a/lib/crypto/ratchet/ratchet_service.dart
+++ b/lib/crypto/ratchet/ratchet_service.dart
@@ -137,6 +137,7 @@ class RatchetService {
       throw FormatException('Unsupported ciphertext scheme: $scheme');
     }
 
+    SimplePublicKey? consumedOneTime;
     try {
       var session = await _store.load(peerId);
       if (session == null) {
@@ -167,11 +168,16 @@ class RatchetService {
         if (shared == null) {
           throw StateError('Cannot derive ratchet session for $peerId');
         }
-        session = await RatchetSession.initializeAsResponder(shared);
+        consumedOneTime = shared.usedOneTimePreKeyPublic;
+        session = await RatchetSession.initializeAsResponder(shared.material);
       }
 
       final plain = await session.decryptMessage(wire);
       await _store.save(peerId, session);
+      final consumed = consumedOneTime;
+      if (consumed != null) {
+        await PrekeyBundle.commitOneTimePreKeyConsumption(consumed);
+      }
       return plain;
     } on FormatException {
       rethrow;

--- a/test/crypto/ratchet_bootstrap_test.dart
+++ b/test/crypto/ratchet_bootstrap_test.dart
@@ -76,7 +76,7 @@ void main() {
     );
 
     expect(sharedResp, isNotNull);
-    expect(sharedInit, sharedResp);
+    expect(sharedInit, sharedResp!.material);
   });
 
   test('hkdf derives non-empty key', () async {
@@ -119,11 +119,11 @@ void main() {
       initiatorEphemeralPublic: ephemeralPub,
       usedOneTimePreKeyPublic: bobBundle.oneTimePreKeyPublic,
     );
-    expect(shared, sharedResp);
+    expect(shared, sharedResp!.material);
 
     final initSession = await RatchetSession.initializeAsInitiator(shared);
     final respSession =
-        await RatchetSession.initializeAsResponder(sharedResp!);
+        await RatchetSession.initializeAsResponder(sharedResp.material);
 
     final enc = await initSession.encryptMessage(utf8.encode('direct'));
     final plain = await respSession.decryptMessage(enc.wire);
@@ -201,5 +201,134 @@ void main() {
       peer: alicePub,
     );
     expect(plain2, 'second');
+  });
+
+  test('failed handshake does not burn the one-time prekey', () async {
+    final alice = await IdentityKeyPair.generate();
+    final bob = await IdentityKeyPair.generate();
+    final alicePub = await _publicKeys(alice);
+    final bobPub = await _publicKeys(bob);
+    const aliceOnion = 'alice.peer.onion';
+    const bobOnion = 'bob.peer.onion';
+
+    final bobBundle = await PrekeyBundle.generate(bob, persist: true);
+    final usedOtpB64 = base64Encode(bobBundle.oneTimePreKeyPublic.bytes);
+
+    final goodWire = await RatchetService.instance.encryptText(
+      peerId: bobOnion,
+      plaintext: 'ratchet hello',
+      local: alice,
+      peer: bobPub,
+      peerBundle: bobBundle,
+    );
+
+    final envelope = jsonDecode(goodWire) as Map<String, dynamic>;
+    final cipher = base64Decode(envelope['ciphertext'] as String);
+    cipher[0] ^= 0xff;
+    envelope['ciphertext'] = base64Encode(cipher);
+    final tamperedWire = jsonEncode(envelope);
+
+    await expectLater(
+      RatchetService.instance.decryptText(
+        peerId: aliceOnion,
+        wire: tamperedWire,
+        local: bob,
+        peer: alicePub,
+      ),
+      throwsA(anything),
+    );
+
+    final poolAfterFailure = jsonDecode(
+      (await CryptoKeyStore.read(PrekeyBundle.storageOneTimePreKeyPool))!,
+    ) as List;
+    expect(
+      poolAfterFailure.map((e) => (e as Map)['pub']),
+      contains(usedOtpB64),
+    );
+
+    final plain = await RatchetService.instance.decryptText(
+      peerId: aliceOnion,
+      wire: goodWire,
+      local: bob,
+      peer: alicePub,
+    );
+    expect(plain, 'ratchet hello');
+
+    final poolAfterSuccess = jsonDecode(
+      (await CryptoKeyStore.read(PrekeyBundle.storageOneTimePreKeyPool))!,
+    ) as List;
+    expect(
+      poolAfterSuccess.map((e) => (e as Map)['pub']),
+      isNot(contains(usedOtpB64)),
+    );
+  });
+
+  test('handshake without oneTimePreKey falls back to pool.first and consumes it',
+      () async {
+    final alice = await IdentityKeyPair.generate();
+    final bob = await IdentityKeyPair.generate();
+    final alicePub = await _publicKeys(alice);
+    final bobPub = await _publicKeys(bob);
+    const aliceOnion = 'alice.peer.onion';
+
+    final bobBundle = await PrekeyBundle.generate(bob, persist: true);
+    final bundleOtpB64 = base64Encode(bobBundle.oneTimePreKeyPublic.bytes);
+
+    final ephemeral = await X25519().newKeyPair();
+    final ephemeralPub = await ephemeral.extractPublicKey();
+    final shared = await PrekeyBundle.sharedSecretAsInitiator(
+      local: alice,
+      peer: bobPub,
+      peerBundle: bobBundle,
+      ephemeral: ephemeral,
+    );
+    final initSession = await RatchetSession.initializeAsInitiator(shared);
+    final handshake = {'ephemeralPub': base64Encode(ephemeralPub.bytes)};
+    final result = await initSession.encryptMessage(
+      utf8.encode('fallback'),
+      handshake: handshake,
+    );
+    final envelope = jsonDecode(result.wire) as Map<String, dynamic>;
+    envelope['handshake'] = handshake;
+    final wire = jsonEncode(envelope);
+
+    final plain = await RatchetService.instance.decryptText(
+      peerId: aliceOnion,
+      wire: wire,
+      local: bob,
+      peer: alicePub,
+    );
+    expect(plain, 'fallback');
+
+    final pool = jsonDecode(
+      (await CryptoKeyStore.read(PrekeyBundle.storageOneTimePreKeyPool))!,
+    ) as List;
+    expect((pool.first as Map)['pub'], isNot(bundleOtpB64));
+    expect(
+      pool.map((e) => (e as Map)['pub']),
+      isNot(contains(bundleOtpB64)),
+    );
+  });
+
+  test('commitOneTimePreKeyConsumption is idempotent', () async {
+    final bob = await IdentityKeyPair.generate();
+    final bobBundle = await PrekeyBundle.generate(bob, persist: true);
+    final otp = bobBundle.oneTimePreKeyPublic;
+
+    await PrekeyBundle.commitOneTimePreKeyConsumption(otp);
+    final afterFirst = jsonDecode(
+      (await CryptoKeyStore.read(PrekeyBundle.storageOneTimePreKeyPool))!,
+    ) as List;
+
+    await PrekeyBundle.commitOneTimePreKeyConsumption(otp);
+    final afterSecond = jsonDecode(
+      (await CryptoKeyStore.read(PrekeyBundle.storageOneTimePreKeyPool))!,
+    ) as List;
+
+    expect(afterSecond.length, afterFirst.length);
+    expect(
+      afterFirst.map((e) => (e as Map)['pub']),
+      isNot(contains(base64Encode(otp.bytes))),
+    );
   });
 }


### PR DESCRIPTION
- Introduced a Mutex to ensure thread-safe access to the one-time prekey pool.
- Updated methods for migrating legacy keys, ensuring one-time prekeys are consumed correctly after use.
- Modified shared secret generation to support non-destructive key lookups, maintaining prekey availability until explicitly consumed.
- Added tests to verify the correct handling of one-time prekeys during handshake failures and successful decryptions.