### PR TITLE
feat: enhance ratchet session handling with skipped counters

### DIFF
--- a/lib/crypto/constants.dart
+++ b/lib/crypto/constants.dart
@@ -34,6 +34,9 @@ class CryptoConstants {
   static const String hkdfInfoCall = 'prysm/call-session';
   static const String hkdfInfoRatchet = 'prysm/ratchet';
 
+  /// Max message counters that may be skipped when receiving out of order.
+  static const int ratchetMaxSkip = 256;
+
   static const int backupVersion = 2;
   static const int cryptoGeneration = 2;
 }

--- a/lib/crypto/ratchet/ratchet_session.dart
+++ b/lib/crypto/ratchet/ratchet_session.dart
@@ -13,12 +13,14 @@ class RatchetSession {
     required this.isInitiator,
     required this.sendCounter,
     required this.recvCounter,
-  });
+    Set<int>? skippedCounters,
+  }) : skippedCounters = skippedCounters ?? <int>{};
 
   final Uint8List sharedMaterial;
   final bool isInitiator;
   int sendCounter;
   int recvCounter;
+  final Set<int> skippedCounters;
 
   static final Uint8List _ratchetSalt =
       Uint8List.fromList(utf8.encode('prysm/ratchet/root-salt'));
@@ -90,8 +92,15 @@ class RatchetSession {
       throw FormatException('Not a ratchet message');
     }
     final counter = envelope['counter'] as int;
-    if (counter <= recvCounter) {
+    final isLateSkipped = skippedCounters.contains(counter);
+    if (counter <= recvCounter && !isLateSkipped) {
       throw StateError('Replay detected');
+    }
+    if (!isLateSkipped && counter > recvCounter + 1) {
+      final gap = counter - (recvCounter + 1);
+      if (gap > CryptoConstants.ratchetMaxSkip) {
+        throw StateError('Counter too far ahead');
+      }
     }
     final messageKey = await _messageKey(
       role: isInitiator ? 'recv' : 'send',
@@ -116,7 +125,16 @@ class RatchetSession {
       nonce: base64Decode(envelope['nonce'] as String),
       associatedData: associatedData,
     );
-    recvCounter = counter;
+    if (isLateSkipped) {
+      skippedCounters.remove(counter);
+    } else if (counter > recvCounter + 1) {
+      for (var i = recvCounter + 1; i < counter; i++) {
+        skippedCounters.add(i);
+      }
+      recvCounter = counter;
+    } else {
+      recvCounter = counter;
+    }
     return plain;
   }
 
@@ -139,6 +157,7 @@ class RatchetSession {
         'isInitiator': isInitiator,
         'sendCounter': sendCounter,
         'recvCounter': recvCounter,
+        'skippedCounters': (skippedCounters.toList()..sort()),
       };
 
   static RatchetSession fromJson(Map<String, dynamic> json) {
@@ -147,6 +166,9 @@ class RatchetSession {
       isInitiator: json['isInitiator'] as bool? ?? true,
       sendCounter: json['sendCounter'] as int,
       recvCounter: json['recvCounter'] as int,
+      skippedCounters: Set<int>.from(
+        (json['skippedCounters'] as List<dynamic>?) ?? const [],
+      ),
     );
   }
 }

--- a/test/crypto/ratchet_security_test.dart
+++ b/test/crypto/ratchet_security_test.dart
@@ -43,7 +43,7 @@ void main() {
       final pair = await _pairedSessions();
       final enc = await pair.init.encryptMessage(utf8.encode('hello'));
       final envelope = jsonDecode(enc.wire) as Map<String, dynamic>;
-      envelope['counter'] = 999999;
+      envelope['counter'] = 10;
       envelope['ciphertext'] = base64Encode(List.filled(32, 0));
 
       expect(
@@ -59,11 +59,12 @@ void main() {
 
     test('large counter gap decrypts successfully', () async {
       final pair = await _pairedSessions();
-      pair.init.sendCounter = 500;
+      pair.init.sendCounter = 200;
       final enc = await pair.init.encryptMessage(utf8.encode('far ahead'));
       final plain = await pair.resp.decryptMessage(enc.wire);
       expect(utf8.decode(plain), 'far ahead');
-      expect(pair.resp.recvCounter, 500);
+      expect(pair.resp.recvCounter, 200);
+      expect(pair.resp.skippedCounters.length, 200);
     });
 
     test('scheme relabel fails decrypt on ratchet-2', () async {
@@ -112,6 +113,91 @@ void main() {
       final wire = await _legacyRatchet1Wire(pair.init, utf8.encode('legacy'));
       final plain = await pair.resp.decryptMessage(wire);
       expect(utf8.decode(plain), 'legacy');
+    });
+
+    test('out-of-order 1 then 0 decrypts both', () async {
+      final pair = await _pairedSessions();
+      final enc0 = await pair.init.encryptMessage(utf8.encode('zero'));
+      final enc1 = await pair.init.encryptMessage(utf8.encode('one'));
+
+      final plain1 = await pair.resp.decryptMessage(enc1.wire);
+      expect(utf8.decode(plain1), 'one');
+      expect(pair.resp.recvCounter, 1);
+      expect(pair.resp.skippedCounters, {0});
+
+      final plain0 = await pair.resp.decryptMessage(enc0.wire);
+      expect(utf8.decode(plain0), 'zero');
+      expect(pair.resp.recvCounter, 1);
+      expect(pair.resp.skippedCounters, isEmpty);
+    });
+
+    test('out-of-order 2 then 0 then 1 decrypts all', () async {
+      final pair = await _pairedSessions();
+      final enc0 = await pair.init.encryptMessage(utf8.encode('zero'));
+      final enc1 = await pair.init.encryptMessage(utf8.encode('one'));
+      final enc2 = await pair.init.encryptMessage(utf8.encode('two'));
+
+      expect(utf8.decode(await pair.resp.decryptMessage(enc2.wire)), 'two');
+      expect(utf8.decode(await pair.resp.decryptMessage(enc0.wire)), 'zero');
+      expect(utf8.decode(await pair.resp.decryptMessage(enc1.wire)), 'one');
+      expect(pair.resp.recvCounter, 2);
+      expect(pair.resp.skippedCounters, isEmpty);
+    });
+
+    test('replay after in-order decrypt is rejected', () async {
+      final pair = await _pairedSessions();
+      final enc = await pair.init.encryptMessage(utf8.encode('once'));
+
+      await pair.resp.decryptMessage(enc.wire);
+      expect(
+        () => pair.resp.decryptMessage(enc.wire),
+        throwsA(isA<StateError>()),
+      );
+    });
+
+    test('replay after late fill is rejected', () async {
+      final pair = await _pairedSessions();
+      final enc0 = await pair.init.encryptMessage(utf8.encode('zero'));
+      final enc1 = await pair.init.encryptMessage(utf8.encode('one'));
+
+      await pair.resp.decryptMessage(enc1.wire);
+      await pair.resp.decryptMessage(enc0.wire);
+      expect(
+        () => pair.resp.decryptMessage(enc0.wire),
+        throwsA(isA<StateError>()),
+      );
+    });
+
+    test('gap larger than maxSkip is rejected without state change', () async {
+      final pair = await _pairedSessions();
+      pair.init.sendCounter = CryptoConstants.ratchetMaxSkip + 2;
+      final enc = await pair.init.encryptMessage(utf8.encode('too far'));
+
+      expect(
+        () => pair.resp.decryptMessage(enc.wire),
+        throwsA(
+          predicate(
+            (e) => e is StateError && e.message == 'Counter too far ahead',
+          ),
+        ),
+      );
+      expect(pair.resp.recvCounter, -1);
+      expect(pair.resp.skippedCounters, isEmpty);
+    });
+
+    test('skipped counters survive json round trip', () async {
+      final pair = await _pairedSessions();
+      final enc0 = await pair.init.encryptMessage(utf8.encode('zero'));
+      final enc1 = await pair.init.encryptMessage(utf8.encode('one'));
+
+      await pair.resp.decryptMessage(enc1.wire);
+      expect(pair.resp.skippedCounters, {0});
+
+      final restored = RatchetSession.fromJson(pair.resp.toJson());
+      final plain0 = await restored.decryptMessage(enc0.wire);
+      expect(utf8.decode(plain0), 'zero');
+      expect(restored.recvCounter, 1);
+      expect(restored.skippedCounters, isEmpty);
     });
   });
 }

--- a/test/ratchet_session_store_test.dart
+++ b/test/ratchet_session_store_test.dart
@@ -6,6 +6,13 @@ import 'package:prysm/crypto/ratchet/ratchet_session.dart';
 import 'package:prysm/crypto/ratchet/session_store.dart';
 import 'package:sqflite_common_ffi/sqflite_ffi.dart';
 
+Future<({RatchetSession init, RatchetSession resp})> _pairedSessions() async {
+  final shared = Uint8List.fromList(List.generate(32, (i) => i));
+  final init = await RatchetSession.initializeAsInitiator(shared);
+  final resp = await RatchetSession.initializeAsResponder(shared);
+  return (init: init, resp: resp);
+}
+
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
 
@@ -55,6 +62,25 @@ void main() {
     expect(loaded.recvCounter, session.recvCounter);
     expect(loaded.isInitiator, session.isInitiator);
     expect(loaded.sharedMaterial, session.sharedMaterial);
+    expect(loaded.skippedCounters, session.skippedCounters);
+  });
+
+  test('skipped counters survive save and load', () async {
+    final pair = await _pairedSessions();
+    final enc0 = await pair.init.encryptMessage(utf8.encode('zero'));
+    final enc1 = await pair.init.encryptMessage(utf8.encode('one'));
+
+    await pair.resp.decryptMessage(enc1.wire);
+    expect(pair.resp.skippedCounters, {0});
+
+    await store.save('peer.onion', pair.resp);
+    final loaded = await store.load('peer.onion');
+    expect(loaded!.skippedCounters, {0});
+
+    final plain0 = await loaded.decryptMessage(enc0.wire);
+    expect(utf8.decode(plain0), 'zero');
+    expect(loaded.recvCounter, 1);
+    expect(loaded.skippedCounters, isEmpty);
   });
 
   test('save overwrites existing session', () async {


### PR DESCRIPTION
- Introduced a mechanism to track and manage skipped message counters in the RatchetSession class, allowing for better handling of out-of-order messages.
- Added a constant for the maximum number of message counters that can be skipped.
- Updated the decryptMessage method to incorporate skipped counters, ensuring proper state management and error handling for late or out-of-order messages.
- Enhanced tests to verify the functionality of skipped counters, including persistence across session saves and loads.