### PR TITLE
refactor: improve direct message authentication logic

### DIFF
--- a/lib/crypto/direct_message_auth.dart
+++ b/lib/crypto/direct_message_auth.dart
@@ -146,27 +146,16 @@ class DirectMessageAuth {
 
     if (scheme == CryptoConstants.schemeDhAead1 ||
         scheme == CryptoConstants.schemeDhAead2) {
-      if (peerKeys != null) {
+      if (peerKeys == null) {
+        return fullDecrypt
+            ? DirectAuthOutcome.rejected
+            : DirectAuthOutcome.pendingAuth;
+      }
+      if (!allowLegacyUnsignedDhAead) {
         return DirectAuthOutcome.rejected;
       }
-      return DirectAuthOutcome.pendingAuth;
-    }
-
-    if (_isDirectMediaType(type) &&
-        scheme == CryptoConstants.schemeFileAead1) {
-      if (peerKeys != null) {
-        return DirectAuthOutcome.rejected;
-      }
-      return DirectAuthOutcome.pendingAuth;
-    }
-
-    if (!fullDecrypt) {
-      return DirectAuthOutcome.pendingAuth;
-    }
-
-    if (type == 'text' && scheme == CryptoConstants.schemeDhAead1) {
-      if (!allowLegacyUnsignedDhAead || peerKeys == null) {
-        return DirectAuthOutcome.rejected;
+      if (!fullDecrypt || !keyManager.isUnlocked) {
+        return DirectAuthOutcome.pendingAuth;
       }
       try {
         await keyManager.decryptPeerMessage(
@@ -182,10 +171,18 @@ class DirectMessageAuth {
     }
 
     if (_isDirectMediaType(type) &&
-        scheme == CryptoConstants.schemeFileAead1 &&
-        allowLegacyUnsignedFile &&
-        peerKeys != null &&
-        keyManager.isUnlocked) {
+        scheme == CryptoConstants.schemeFileAead1) {
+      if (peerKeys == null) {
+        return fullDecrypt
+            ? DirectAuthOutcome.rejected
+            : DirectAuthOutcome.pendingAuth;
+      }
+      if (!allowLegacyUnsignedFile) {
+        return DirectAuthOutcome.rejected;
+      }
+      if (!fullDecrypt || !keyManager.isUnlocked) {
+        return DirectAuthOutcome.pendingAuth;
+      }
       try {
         await CryptoWire.decryptFileFromPeer(
           wire,
@@ -197,6 +194,10 @@ class DirectMessageAuth {
       } catch (_) {
         return DirectAuthOutcome.rejected;
       }
+    }
+
+    if (!fullDecrypt) {
+      return DirectAuthOutcome.pendingAuth;
     }
 
     return DirectAuthOutcome.rejected;

--- a/test/crypto/direct_message_auth_test.dart
+++ b/test/crypto/direct_message_auth_test.dart
@@ -113,5 +113,68 @@ void main() {
       );
       expect(outcome, DirectAuthOutcome.accepted);
     });
+
+    test('rejects dh-aead-2 from known peer without legacy flag', () async {
+      final alice = await IdentityKeyPair.generate();
+      final bob = await IdentityKeyPair.generate();
+      final alicePub = await _publicKeys(alice);
+      final bobPub = await bob.agreePublicKey;
+
+      final wire = await CryptoWire.encryptTextForPeer('unsigned', alice, bobPub);
+
+      final outcome = await DirectMessageAuth.authenticateInboundDirect(
+        senderId: 'alice.onion',
+        wire: wire,
+        type: 'text',
+        localUserId: 'bob.onion',
+        keyManager: KeyManager.fromIdentity(bob),
+        resolveIdentity: (_) async => alicePub,
+        fullDecrypt: true,
+      );
+      expect(outcome, DirectAuthOutcome.rejected);
+    });
+
+    test('accepts dh-aead-2 from known peer with legacy flag when unlocked',
+        () async {
+      final alice = await IdentityKeyPair.generate();
+      final bob = await IdentityKeyPair.generate();
+      final alicePub = await _publicKeys(alice);
+      final bobPub = await bob.agreePublicKey;
+
+      final wire = await CryptoWire.encryptTextForPeer('legacy', alice, bobPub);
+
+      final outcome = await DirectMessageAuth.authenticateInboundDirect(
+        senderId: 'alice.onion',
+        wire: wire,
+        type: 'text',
+        localUserId: 'bob.onion',
+        keyManager: KeyManager.fromIdentity(bob),
+        resolveIdentity: (_) async => alicePub,
+        fullDecrypt: true,
+        allowLegacyUnsignedDhAead: true,
+      );
+      expect(outcome, DirectAuthOutcome.accepted);
+    });
+
+    test('dh-aead-2 with legacy flag stays pendingAuth while locked', () async {
+      final alice = await IdentityKeyPair.generate();
+      final bob = await IdentityKeyPair.generate();
+      final alicePub = await _publicKeys(alice);
+      final bobPub = await bob.agreePublicKey;
+
+      final wire = await CryptoWire.encryptTextForPeer('legacy', alice, bobPub);
+
+      final outcome = await DirectMessageAuth.authenticateInboundDirect(
+        senderId: 'alice.onion',
+        wire: wire,
+        type: 'text',
+        localUserId: 'bob.onion',
+        keyManager: KeyManager(),
+        resolveIdentity: (_) async => alicePub,
+        fullDecrypt: false,
+        allowLegacyUnsignedDhAead: true,
+      );
+      expect(outcome, DirectAuthOutcome.pendingAuth);
+    });
   });
 }


### PR DESCRIPTION
- Simplified conditions for rejecting and pending authentication outcomes based on peer keys and decryption status.
- Enhanced handling of legacy flags for `dh-aead-2` scheme, ensuring proper rejection or pending states when keys are locked or missing.
- Added comprehensive tests to validate new authentication scenarios, including legacy flag behavior and pending states.