### PR TITLE
feat: implement mutex protection for concurrent encryptions in Ratche…

### DIFF
--- a/lib/crypto/ratchet/ratchet_service.dart
+++ b/lib/crypto/ratchet/ratchet_service.dart
@@ -2,6 +2,7 @@ import 'dart:convert';
 import 'dart:typed_data';
 
 import 'package:cryptography/cryptography.dart';
+import 'package:mutex/mutex.dart';
 import 'package:prysm/crypto/constants.dart';
 import 'package:prysm/crypto/identity.dart';
 import 'package:prysm/crypto/ratchet/prekey_bundle.dart';
@@ -17,6 +18,9 @@ class RatchetService {
   static final RatchetService instance = RatchetService._();
 
   RatchetSessionStore? _sessionStore;
+  final Map<String, Mutex> _peerLocks = {};
+
+  Mutex _lockFor(String peerId) => _peerLocks.putIfAbsent(peerId, Mutex.new);
 
   /// Injects the [RatchetSessionStore] used for persistence.
   /// The wiring is performed by the application database helper.
@@ -57,42 +61,43 @@ class RatchetService {
     required IdentityKeyPair local,
     required IdentityPublicKeys peer,
     PrekeyBundle? peerBundle,
-  }) async {
-    var session = await _store.load(peerId);
-    Map<String, dynamic> handshake = {};
+  }) =>
+      _lockFor(peerId).protect(() async {
+        var session = await _store.load(peerId);
+        Map<String, dynamic> handshake = {};
 
-    if (session == null) {
-      final bundle = peerBundle;
-      if (bundle == null) {
-        throw StateError('Missing prekey bundle for $peerId');
-      }
-      final ephemeral = await _x25519.newKeyPair();
-      final ephemeralPublic = await ephemeral.extractPublicKey();
-      final shared = await PrekeyBundle.sharedSecretAsInitiator(
-        local: local,
-        peer: peer,
-        peerBundle: bundle,
-        ephemeral: ephemeral,
-      );
-      session = await RatchetSession.initializeAsInitiator(shared);
-      handshake = {
-        'ephemeralPub': base64Encode(ephemeralPublic.bytes),
-        'oneTimePreKey': base64Encode(bundle.oneTimePreKeyPublic.bytes),
-      };
-    }
+        if (session == null) {
+          final bundle = peerBundle;
+          if (bundle == null) {
+            throw StateError('Missing prekey bundle for $peerId');
+          }
+          final ephemeral = await _x25519.newKeyPair();
+          final ephemeralPublic = await ephemeral.extractPublicKey();
+          final shared = await PrekeyBundle.sharedSecretAsInitiator(
+            local: local,
+            peer: peer,
+            peerBundle: bundle,
+            ephemeral: ephemeral,
+          );
+          session = await RatchetSession.initializeAsInitiator(shared);
+          handshake = {
+            'ephemeralPub': base64Encode(ephemeralPublic.bytes),
+            'oneTimePreKey': base64Encode(bundle.oneTimePreKeyPublic.bytes),
+          };
+        }
 
-    final result = await session.encryptMessage(
-      plaintext,
-      handshake: handshake.isEmpty ? null : handshake,
-    );
-    await _store.save(peerId, session);
-    if (handshake.isEmpty) {
-      return result.wire;
-    }
-    final envelope = jsonDecode(result.wire) as Map<String, dynamic>;
-    envelope['handshake'] = handshake;
-    return jsonEncode(envelope);
-  }
+        final result = await session.encryptMessage(
+          plaintext,
+          handshake: handshake.isEmpty ? null : handshake,
+        );
+        await _store.save(peerId, session);
+        if (handshake.isEmpty) {
+          return result.wire;
+        }
+        final envelope = jsonDecode(result.wire) as Map<String, dynamic>;
+        envelope['handshake'] = handshake;
+        return jsonEncode(envelope);
+      });
 
   Future<String> decryptText({
     required String peerId,
@@ -137,52 +142,54 @@ class RatchetService {
       throw FormatException('Unsupported ciphertext scheme: $scheme');
     }
 
-    SimplePublicKey? consumedOneTime;
-    try {
-      var session = await _store.load(peerId);
-      if (session == null) {
-        final handshake = envelope['handshake'] as Map<String, dynamic>?;
-        if (handshake == null) {
-          throw StateError('Missing ratchet handshake for $peerId');
-        }
-        final ephemeralBytes =
-            base64Decode(handshake['ephemeralPub'] as String);
-        final ephemeralPublic = SimplePublicKey(
-          ephemeralBytes,
-          type: KeyPairType.x25519,
-        );
-        SimplePublicKey? usedOneTime;
-        final oneTimeRaw = handshake['oneTimePreKey'] as String?;
-        if (oneTimeRaw != null) {
-          usedOneTime = SimplePublicKey(
-            base64Decode(oneTimeRaw),
+    return _lockFor(peerId).protect(() async {
+      SimplePublicKey? consumedOneTime;
+      try {
+        var session = await _store.load(peerId);
+        if (session == null) {
+          final handshake = envelope['handshake'] as Map<String, dynamic>?;
+          if (handshake == null) {
+            throw StateError('Missing ratchet handshake for $peerId');
+          }
+          final ephemeralBytes =
+              base64Decode(handshake['ephemeralPub'] as String);
+          final ephemeralPublic = SimplePublicKey(
+            ephemeralBytes,
             type: KeyPairType.x25519,
           );
+          SimplePublicKey? usedOneTime;
+          final oneTimeRaw = handshake['oneTimePreKey'] as String?;
+          if (oneTimeRaw != null) {
+            usedOneTime = SimplePublicKey(
+              base64Decode(oneTimeRaw),
+              type: KeyPairType.x25519,
+            );
+          }
+          final shared = await PrekeyBundle.sharedSecretAsResponder(
+            local: local,
+            peer: peer,
+            initiatorEphemeralPublic: ephemeralPublic,
+            usedOneTimePreKeyPublic: usedOneTime,
+          );
+          if (shared == null) {
+            throw StateError('Cannot derive ratchet session for $peerId');
+          }
+          consumedOneTime = shared.usedOneTimePreKeyPublic;
+          session = await RatchetSession.initializeAsResponder(shared.material);
         }
-        final shared = await PrekeyBundle.sharedSecretAsResponder(
-          local: local,
-          peer: peer,
-          initiatorEphemeralPublic: ephemeralPublic,
-          usedOneTimePreKeyPublic: usedOneTime,
-        );
-        if (shared == null) {
-          throw StateError('Cannot derive ratchet session for $peerId');
-        }
-        consumedOneTime = shared.usedOneTimePreKeyPublic;
-        session = await RatchetSession.initializeAsResponder(shared.material);
-      }
 
-      final plain = await session.decryptMessage(wire);
-      await _store.save(peerId, session);
-      final consumed = consumedOneTime;
-      if (consumed != null) {
-        await PrekeyBundle.commitOneTimePreKeyConsumption(consumed);
+        final plain = await session.decryptMessage(wire);
+        await _store.save(peerId, session);
+        final consumed = consumedOneTime;
+        if (consumed != null) {
+          await PrekeyBundle.commitOneTimePreKeyConsumption(consumed);
+        }
+        return plain;
+      } on FormatException {
+        rethrow;
+      } on StateError {
+        rethrow;
       }
-      return plain;
-    } on FormatException {
-      rethrow;
-    } on StateError {
-      rethrow;
-    }
+    });
   }
 }

--- a/test/crypto/ratchet_bootstrap_test.dart
+++ b/test/crypto/ratchet_bootstrap_test.dart
@@ -203,6 +203,47 @@ void main() {
     expect(plain2, 'second');
   });
 
+  test('concurrent encrypts assign unique counters', () async {
+    final alice = await IdentityKeyPair.generate();
+    final bob = await IdentityKeyPair.generate();
+    final bobPub = await _publicKeys(bob);
+    const bobOnion = 'bob.peer.onion';
+
+    final bobBundle = await PrekeyBundle.generate(bob, persist: true);
+
+    await RatchetService.instance.encryptText(
+      peerId: bobOnion,
+      plaintext: 'bootstrap',
+      local: alice,
+      peer: bobPub,
+      peerBundle: bobBundle,
+    );
+
+    const batchSize = 12;
+    final wires = await Future.wait(
+      List.generate(
+        batchSize,
+        (i) => RatchetService.instance.encryptText(
+          peerId: bobOnion,
+          plaintext: 'msg-$i',
+          local: alice,
+          peer: bobPub,
+          peerBundle: bobBundle,
+        ),
+      ),
+    );
+
+    final counters = wires
+        .map((w) => (jsonDecode(w) as Map<String, dynamic>)['counter'] as int)
+        .toList();
+    expect(counters.toSet().length, batchSize);
+    expect(counters, containsAll(List.generate(batchSize, (i) => i + 1)));
+
+    final session = await RatchetSessionStore(await DBHelper.database)
+        .load(bobOnion);
+    expect(session!.sendCounter, batchSize + 1);
+  });
+
   test('failed handshake does not burn the one-time prekey', () async {
     final alice = await IdentityKeyPair.generate();
     final bob = await IdentityKeyPair.generate();


### PR DESCRIPTION
…tService

- Added a Mutex to ensure thread-safe access during message encryption and decryption processes.
- Updated the encryptText and decryptText methods to utilize mutex locks, preventing race conditions in concurrent operations.
- Introduced a test to verify that concurrent encryptions assign unique counters, ensuring proper session state management.