### PR TITLE
feat: streamline peer identity handling with new utility methods

### DIFF
--- a/lib/crypto/identity.dart
+++ b/lib/crypto/identity.dart
@@ -111,6 +111,21 @@ class IdentityKeyPair {
     }
   }
 
+  /// First non-empty stored identity payload from [identityJson] or legacy
+  /// [publicKeyPem] column values.
+  static String? storedPeerIdentityRaw(
+    String? identityJson,
+    String? publicKeyPem,
+  ) {
+    for (final raw in [identityJson, publicKeyPem]) {
+      if (raw == null) continue;
+      final trimmed = raw.trim();
+      if (trimmed.isEmpty || trimmed == 'NONE') continue;
+      return raw;
+    }
+    return null;
+  }
+
   Future<Map<String, dynamic>> toPrivateJson() async {
     final signPrivate = await signKeyPair.extractPrivateKeyBytes();
     final agreePrivate = await agreeKeyPair.extractPrivateKeyBytes();

--- a/lib/services/call/call_transport.dart
+++ b/lib/services/call/call_transport.dart
@@ -62,12 +62,12 @@ class DbCallKeyResolver implements CallKeyResolver {
   @override
   Future<IdentityPublicKeys?> resolve(String peerOnion) async {
     final user = await DBHelper.getUserById(peerOnion);
-    final cached = (user?['identityJson'] as String?) ??
-        (user?['publicKeyPem'] as String?);
-    if (cached != null && cached.isNotEmpty && cached != 'NONE') {
-      try {
-        return _keyManager.importPeerIdentity(cached);
-      } catch (_) {}
+    final cached = _keyManager.tryImportStoredPeerIdentity(
+      identityJson: user?['identityJson'] as String?,
+      publicKeyPem: user?['publicKeyPem'] as String?,
+    );
+    if (cached != null) {
+      return cached;
     }
 
     try {

--- a/lib/services/contact_add_service.dart
+++ b/lib/services/contact_add_service.dart
@@ -124,8 +124,10 @@ class ContactAddService {
     try {
       final profileBody = await _fetchProfile(onionId);
       final profileData = jsonDecode(profileBody) as Map<String, dynamic>;
-      final identityJson = (profileData['identityJson'] as String?)?.trim() ??
-          (profileData['publicKeyPem'] as String?)?.trim();
+      final identityJson = IdentityKeyPair.storedPeerIdentityRaw(
+        (profileData['identityJson'] as String?)?.trim(),
+        (profileData['publicKeyPem'] as String?)?.trim(),
+      );
       if (identityJson == null || identityJson.isEmpty) {
         return;
       }

--- a/lib/services/file_attachment_resolver.dart
+++ b/lib/services/file_attachment_resolver.dart
@@ -113,12 +113,13 @@ class FileAttachmentResolver {
         localUserId != null &&
         senderId != localUserId) {
       final user = await DBHelper.getUserById(senderId);
-      final identityJson = (user?['identityJson'] as String?) ??
-          (user?['publicKeyPem'] as String?);
-      if (identityJson == null || identityJson.isEmpty) {
+      final peerKey = keyManager.tryImportStoredPeerIdentity(
+        identityJson: user?['identityJson'] as String?,
+        publicKeyPem: user?['publicKeyPem'] as String?,
+      );
+      if (peerKey == null) {
         throw const FormatException('Missing peer identity');
       }
-      final peerKey = keyManager.importPeerIdentity(identityJson);
       return CryptoWire.decryptFileFromPeer(
         encryptedJson,
         keyManager.identity,

--- a/lib/services/group_control_channel.dart
+++ b/lib/services/group_control_channel.dart
@@ -421,14 +421,12 @@ class GroupControlChannel {
 
   Future<IdentityPublicKeys?> _fetchPeerPublicKey(String peerId) async {
     final cached = await DBHelper.getUserById(peerId);
-    final pem = (cached?['identityJson'] as String?) ??
-        (cached?['publicKeyPem'] as String?);
-    if (pem != null && pem.isNotEmpty && pem != 'NONE') {
-      try {
-        return keyManager.importPeerIdentity(pem);
-      } catch (e) {
-        Logging.error('Invalid cached peer public key for $peerId: $e', 'GroupControlChannel');
-      }
+    final stored = keyManager.tryImportStoredPeerIdentity(
+      identityJson: cached?['identityJson'] as String?,
+      publicKeyPem: cached?['publicKeyPem'] as String?,
+    );
+    if (stored != null) {
+      return stored;
     }
 
     try {

--- a/lib/services/message_modify_service.dart
+++ b/lib/services/message_modify_service.dart
@@ -414,10 +414,11 @@ class MessageModifyService {
     try {
       if (type == messageModifyType) {
         final user = await DBHelper.getUserById(senderId);
-        final identityJson = (user?['identityJson'] as String?) ??
-            (user?['publicKeyPem'] as String?);
-        if (identityJson == null || identityJson.isEmpty) return null;
-        final peerKey = keyManager.importPeerIdentity(identityJson);
+        final peerKey = keyManager.tryImportStoredPeerIdentity(
+          identityJson: user?['identityJson'] as String?,
+          publicKeyPem: user?['publicKeyPem'] as String?,
+        );
+        if (peerKey == null) return null;
         return keyManager.decryptPeerMessage(
           peerId: senderId,
           wire: encryptedBody,
@@ -457,10 +458,11 @@ class MessageModifyService {
     try {
       if (type == messageModifyType) {
         final user = await DBHelper.getUserById(senderId);
-        final identityJson = (user?['identityJson'] as String?) ??
-            (user?['publicKeyPem'] as String?);
-        if (identityJson == null || identityJson.isEmpty) return null;
-        final peerKey = keyManager.importPeerIdentity(identityJson);
+        final peerKey = keyManager.tryImportStoredPeerIdentity(
+          identityJson: user?['identityJson'] as String?,
+          publicKeyPem: user?['publicKeyPem'] as String?,
+        );
+        if (peerKey == null) return null;
         return keyManager.decryptPeerMessage(
           peerId: senderId,
           wire: encrypted,

--- a/lib/services/message_view_mapper.dart
+++ b/lib/services/message_view_mapper.dart
@@ -60,12 +60,13 @@ class MessageViewMapper {
     }
 
     final user = await DBHelper.getUserById(senderId);
-    final identityJson = (user?['identityJson'] as String?) ??
-        (user?['publicKeyPem'] as String?);
-    if (identityJson == null || identityJson.isEmpty) {
+    final peerKey = keyManager.tryImportStoredPeerIdentity(
+      identityJson: user?['identityJson'] as String?,
+      publicKeyPem: user?['publicKeyPem'] as String?,
+    );
+    if (peerKey == null) {
       throw const FormatException('Missing peer identity');
     }
-    final peerKey = keyManager.importPeerIdentity(identityJson);
     return keyManager.decryptPeerMessage(
       peerId: senderId,
       wire: wire,

--- a/lib/services/peer_identity_resolver.dart
+++ b/lib/services/peer_identity_resolver.dart
@@ -45,8 +45,10 @@ class PeerIdentityResolver {
   Future<String?> getCachedIdentityJson() async {
     try {
       final user = await DBHelper.getUserById(peerId);
-      return (user?['identityJson'] as String?) ??
-          (user?['publicKeyPem'] as String?);
+      return IdentityKeyPair.storedPeerIdentityRaw(
+        user?['identityJson'] as String?,
+        user?['publicKeyPem'] as String?,
+      );
     } catch (_) {
       return null;
     }
@@ -75,8 +77,10 @@ class PeerIdentityResolver {
       try {
         final profileBody = await _fetchProfile(peerId);
         final data = jsonDecode(profileBody) as Map<String, dynamic>;
-        identityJson = (data['identityJson'] as String?)?.trim() ??
-            (data['publicKeyPem'] as String?)?.trim();
+        identityJson = IdentityKeyPair.storedPeerIdentityRaw(
+          (data['identityJson'] as String?)?.trim(),
+          (data['publicKeyPem'] as String?)?.trim(),
+        );
         final prekeyRaw = data['prekeyBundle'];
         identity = keyManager.importPeerIdentity(identityJson!);
         onIdentityResolved?.call(identity);

--- a/lib/services/reaction_service.dart
+++ b/lib/services/reaction_service.dart
@@ -302,10 +302,11 @@ class ReactionService {
     try {
       if (type == reactionType) {
         final user = await DBHelper.getUserById(senderId);
-        final identityJson = (user?['identityJson'] as String?) ??
-            (user?['publicKeyPem'] as String?);
-        if (identityJson == null || identityJson.isEmpty) return null;
-        final peerKey = keyManager.importPeerIdentity(identityJson);
+        final peerKey = keyManager.tryImportStoredPeerIdentity(
+          identityJson: user?['identityJson'] as String?,
+          publicKeyPem: user?['publicKeyPem'] as String?,
+        );
+        if (peerKey == null) return null;
         return keyManager.decryptPeerMessage(
           peerId: senderId,
           wire: encrypted,

--- a/lib/services/read_receipt_service.dart
+++ b/lib/services/read_receipt_service.dart
@@ -390,10 +390,11 @@ class ReadReceiptService {
     try {
       if (type == readReceiptType || type == readWaterlineType) {
         final user = await DBHelper.getUserById(senderId);
-        final identityJson = (user?['identityJson'] as String?) ??
-            (user?['publicKeyPem'] as String?);
-        if (identityJson == null || identityJson.isEmpty) return null;
-        final peerKey = keyManager.importPeerIdentity(identityJson);
+        final peerKey = keyManager.tryImportStoredPeerIdentity(
+          identityJson: user?['identityJson'] as String?,
+          publicKeyPem: user?['publicKeyPem'] as String?,
+        );
+        if (peerKey == null) return null;
         return keyManager.decryptPeerMessage(
           peerId: senderId,
           wire: encrypted,

--- a/lib/util/direct_chat_message_decrypt.dart
+++ b/lib/util/direct_chat_message_decrypt.dart
@@ -27,12 +27,13 @@ class DirectChatMessageDecrypt {
     }
 
     final user = await DBHelper.getUserById(senderId);
-    final identityJson =
-        (user?['identityJson'] as String?) ?? (user?['publicKeyPem'] as String?);
-    if (identityJson == null || identityJson.isEmpty) {
+    final peerKey = keyManager.tryImportStoredPeerIdentity(
+      identityJson: user?['identityJson'] as String?,
+      publicKeyPem: user?['publicKeyPem'] as String?,
+    );
+    if (peerKey == null) {
       throw const FormatException('Missing peer identity');
     }
-    final peerKey = keyManager.importPeerIdentity(identityJson);
     return keyManager.decryptPeerMessage(
       peerId: senderId,
       wire: wire,

--- a/lib/util/key_manager.dart
+++ b/lib/util/key_manager.dart
@@ -276,8 +276,33 @@ class KeyManager {
   static bool isHybridEnvelope(String encrypted) =>
       CryptoEnvelope.isV2(encrypted);
 
+  IdentityPublicKeys? tryImportPeerIdentity(String? jsonOrPem) =>
+      IdentityKeyPair.tryParsePublicJsonString(jsonOrPem);
+
+  IdentityPublicKeys? tryImportStoredPeerIdentity({
+    String? identityJson,
+    String? publicKeyPem,
+  }) =>
+      tryImportPeerIdentity(
+        IdentityKeyPair.storedPeerIdentityRaw(identityJson, publicKeyPem),
+      );
+
   IdentityPublicKeys importPeerIdentity(String jsonOrPem) {
-    final keys = IdentityKeyPair.tryParsePublicJsonString(jsonOrPem);
+    final keys = tryImportPeerIdentity(jsonOrPem);
+    if (keys == null) {
+      throw FormatException('Expected v2 identity JSON');
+    }
+    return keys;
+  }
+
+  IdentityPublicKeys importStoredPeerIdentity({
+    String? identityJson,
+    String? publicKeyPem,
+  }) {
+    final keys = tryImportStoredPeerIdentity(
+      identityJson: identityJson,
+      publicKeyPem: publicKeyPem,
+    );
     if (keys == null) {
       throw FormatException('Expected v2 identity JSON');
     }

--- a/lib/util/peer_identity_loader.dart
+++ b/lib/util/peer_identity_loader.dart
@@ -8,14 +8,10 @@ Future<IdentityPublicKeys?> loadPeerIdentityFromDb(
   String peerId,
 ) async {
   final user = await DBHelper.getUserById(peerId);
-  final json = (user?['identityJson'] as String?) ??
-      (user?['publicKeyPem'] as String?);
-  if (json == null || json.isEmpty) return null;
-  try {
-    return keyManager.importPeerIdentity(json);
-  } catch (_) {
-    return null;
-  }
+  return keyManager.tryImportStoredPeerIdentity(
+    identityJson: user?['identityJson'] as String?,
+    publicKeyPem: user?['publicKeyPem'] as String?,
+  );
 }
 
 /// Resolves peer identity for ingress: local DB first, then awaited Tor fetch.

--- a/test/peer_identity_loader_test.dart
+++ b/test/peer_identity_loader_test.dart
@@ -1,0 +1,78 @@
+import 'dart:convert';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:prysm/crypto/identity.dart';
+import 'package:prysm/util/db_helper.dart';
+import 'package:prysm/util/key_manager.dart';
+import 'package:prysm/util/peer_identity_loader.dart';
+import 'package:sqflite_common_ffi/sqflite_ffi.dart';
+
+Future<Database> _openUsersDb() async {
+  final db = await databaseFactory.openDatabase(inMemoryDatabasePath);
+  await db.execute('''
+    CREATE TABLE users (
+      id TEXT PRIMARY KEY,
+      name TEXT,
+      avatarUrl TEXT,
+      avatarBase64 TEXT,
+      customName TEXT,
+      publicKeyPem TEXT,
+      identityJson TEXT
+    )
+  ''');
+  return db;
+}
+
+void main() {
+  setUpAll(() {
+    TestWidgetsFlutterBinding.ensureInitialized();
+    sqfliteFfiInit();
+    databaseFactory = databaseFactoryFfi;
+  });
+
+  late Database db;
+  late KeyManager keyManager;
+
+  setUp(() async {
+    db = await _openUsersDb();
+    DBHelper.setDatabaseForTest(db);
+    keyManager = KeyManager.fromIdentity(await IdentityKeyPair.generate());
+  });
+
+  tearDown(() async {
+    await db.close();
+    DBHelper.setDatabaseForTest(null);
+  });
+
+  test('loadPeerIdentityFromDb uses publicKeyPem when identityJson empty',
+      () async {
+    final peer = await IdentityKeyPair.generate();
+    final identityJson = jsonEncode(await peer.toPublicJson());
+
+    await DBHelper.insertOrUpdateUser({
+      'id': 'peer.onion',
+      'name': 'Peer',
+      'identityJson': '',
+      'publicKeyPem': identityJson,
+    });
+
+    final loaded = await loadPeerIdentityFromDb(keyManager, 'peer.onion');
+
+    expect(loaded, isNotNull);
+    expect(
+      loaded!.fingerprint,
+      IdentityKeyPair.fingerprintFromPublicJson(await peer.toPublicJson()),
+    );
+  });
+
+  test('storedPeerIdentityRaw ignores legacy PEM payloads', () {
+    expect(
+      IdentityKeyPair.storedPeerIdentityRaw('-----BEGIN PUBLIC KEY-----', null),
+      '-----BEGIN PUBLIC KEY-----',
+    );
+    expect(
+      keyManager.tryImportPeerIdentity('-----BEGIN PUBLIC KEY-----'),
+      isNull,
+    );
+  });
+}

--- a/test/peer_identity_resolver_test.dart
+++ b/test/peer_identity_resolver_test.dart
@@ -83,6 +83,33 @@ void main() {
       expect(cached, 'legacy-pem');
     });
 
+    test('falls back to publicKeyPem when identityJson is empty', () async {
+      final peerKeyPair = await IdentityKeyPair.generate();
+      final peerIdentityJson = jsonEncode(await peerKeyPair.toPublicJson());
+
+      await DBHelper.insertOrUpdateUser({
+        'id': peerId,
+        'name': 'Peer',
+        'identityJson': '',
+        'publicKeyPem': peerIdentityJson,
+      });
+
+      final cached = await resolver.getCachedIdentityJson();
+      final imported = keyManager.tryImportStoredPeerIdentity(
+        identityJson: '',
+        publicKeyPem: peerIdentityJson,
+      );
+
+      expect(cached, peerIdentityJson);
+      expect(imported, isNotNull);
+      expect(
+        imported!.fingerprint,
+        IdentityKeyPair.fingerprintFromPublicJson(
+          await peerKeyPair.toPublicJson(),
+        ),
+      );
+    });
+
     test('returns null when no user row exists', () async {
       final cached = await resolver.getCachedIdentityJson();
       expect(cached, isNull);


### PR DESCRIPTION
- Introduced `storedPeerIdentityRaw` method in `IdentityKeyPair` to simplify retrieval of non-empty identity data from JSON or PEM formats.
- Updated various services to utilize the new method for importing peer identities, enhancing code readability and maintainability.
- Added tests to ensure correct fallback behavior when identity data is empty.