### PR TITLE
fix(security): critical crypto fixes — signed group control + forward-secret ratchet

### DIFF
--- a/lib/crypto/constants.dart
+++ b/lib/crypto/constants.dart
@@ -22,6 +22,7 @@ class CryptoConstants {
   static const String schemeDmSigned2 = 'dm-signed-2';
   static const String schemeGroupAead1 = 'group-aead-1';
   static const String schemeControlWrap1 = 'control-wrap-1';
+  static const String schemeControlWrap2 = 'control-wrap-2';
   static const String schemeFileAead1 = 'file-aead-1';
   static const String schemeFileSigned1 = 'file-signed-1';
   static const String schemeCallAead1 = 'call-aead-1';

--- a/lib/crypto/constants.dart
+++ b/lib/crypto/constants.dart
@@ -28,6 +28,7 @@ class CryptoConstants {
   static const String schemeCallAead1 = 'call-aead-1';
   static const String schemeRatchet1 = 'ratchet-1';
   static const String schemeRatchet2 = 'ratchet-2';
+  static const String schemeRatchet3 = 'ratchet-3';
   static const String schemeGroupSender1 = 'group-sender-1';
 
   static const String hkdfInfoDhAead = 'prysm/dh-aead-1';

--- a/lib/crypto/direct_message_auth.dart
+++ b/lib/crypto/direct_message_auth.dart
@@ -126,7 +126,8 @@ class DirectMessageAuth {
     }
 
     if (scheme == CryptoConstants.schemeRatchet1 ||
-        scheme == CryptoConstants.schemeRatchet2) {
+        scheme == CryptoConstants.schemeRatchet2 ||
+        scheme == CryptoConstants.schemeRatchet3) {
       if (!fullDecrypt || !keyManager.isUnlocked || peerKeys == null) {
         return DirectAuthOutcome.pendingAuth;
       }

--- a/lib/crypto/envelope.dart
+++ b/lib/crypto/envelope.dart
@@ -140,6 +140,20 @@ class CryptoEnvelope {
     };
   }
 
+  static Map<String, dynamic> controlWrap2({
+    required Map<String, dynamic> wrappedKey,
+    required Uint8List iv,
+    required Uint8List ciphertext,
+  }) {
+    return {
+      'crypto': CryptoConstants.cryptoVersion,
+      'scheme': CryptoConstants.schemeControlWrap2,
+      'wrappedKey': wrappedKey,
+      'iv': base64Encode(iv),
+      'ct': base64Encode(ciphertext),
+    };
+  }
+
   static Map<String, dynamic> fileAead1({
     required Map<String, dynamic> wrappedKey,
     required Uint8List nonce,

--- a/lib/crypto/group_crypto.dart
+++ b/lib/crypto/group_crypto.dart
@@ -56,12 +56,12 @@ class GroupCryptoV2 {
       utf8.encode(plaintextJson),
       key: aeadKey,
     );
-    final wrapped = await CryptoWire.wrapKeyForPeer(
+    final wrapped = await CryptoWire.wrapKeyForPeerSigned(
       sessionKey,
       sender,
       peerAgreePublic,
     );
-    return CryptoEnvelope.encode(CryptoEnvelope.controlWrap1(
+    return CryptoEnvelope.encode(CryptoEnvelope.controlWrap2(
       wrappedKey: wrapped,
       iv: enc.nonce,
       ciphertext: enc.ciphertext,
@@ -71,16 +71,27 @@ class GroupCryptoV2 {
   static Future<String> decryptControlPayload(
     String wire,
     IdentityKeyPair recipient,
+    IdentityPublicKeys sender,
   ) async {
     final envelope = CryptoEnvelope.tryParse(wire);
-    if (envelope == null ||
-        envelope['scheme'] != CryptoConstants.schemeControlWrap1) {
+    if (envelope == null) {
+      throw ArgumentError('Invalid control envelope');
+    }
+    final scheme = CryptoEnvelope.schemeOf(envelope);
+    if (scheme == CryptoConstants.schemeControlWrap1) {
+      throw const FormatException('Unsigned group control message rejected');
+    }
+    if (scheme != CryptoConstants.schemeControlWrap2) {
       throw ArgumentError('Invalid control envelope');
     }
     final wrapped = envelope['wrappedKey'] as Map<String, dynamic>;
     final iv = base64Decode(envelope['iv'] as String);
     final ct = base64Decode(envelope['ct'] as String);
-    final sessionKey = await CryptoWire.unwrapKeyFromPeer(wrapped, recipient);
+    final sessionKey = await CryptoWire.unwrapSignedKeyFromPeer(
+      wrapped,
+      recipient,
+      sender,
+    );
     final aeadKey = await CryptoAead.secretKeyFromBytes(sessionKey);
     final plain = await CryptoAead.decryptAesGcm(
       ciphertextWithTag: ct,

--- a/lib/crypto/ratchet/ratchet_service.dart
+++ b/lib/crypto/ratchet/ratchet_service.dart
@@ -79,7 +79,8 @@ class RatchetService {
             peerBundle: bundle,
             ephemeral: ephemeral,
           );
-          session = await RatchetSession.initializeAsInitiator(shared);
+          // New sessions always start as forward-secret v3.
+          session = await RatchetSession.initializeV3AsInitiator(shared);
           handshake = {
             'ephemeralPub': base64Encode(ephemeralPublic.bytes),
             'oneTimePreKey': base64Encode(bundle.oneTimePreKeyPublic.bytes),
@@ -138,7 +139,11 @@ class RatchetService {
     }
 
     if (scheme != CryptoConstants.schemeRatchet1 &&
-        scheme != CryptoConstants.schemeRatchet2) {
+        scheme != CryptoConstants.schemeRatchet2 &&
+        scheme != CryptoConstants.schemeRatchet3) {
+      // A peer running an older build rejects ratchet-3 here with this clean
+      // error; that is expected and safe (v3 is only spoken between updated
+      // peers that both bootstrap fresh v3 sessions).
       throw FormatException('Unsupported ciphertext scheme: $scheme');
     }
 
@@ -175,7 +180,13 @@ class RatchetService {
             throw StateError('Cannot derive ratchet session for $peerId');
           }
           consumedOneTime = shared.usedOneTimePreKeyPublic;
-          session = await RatchetSession.initializeAsResponder(shared.material);
+          // Pick the session version from the envelope: an updated peer
+          // bootstraps with ratchet-3 (forward-secret), a pre-v3 peer with
+          // ratchet-1/2 (legacy static KDF). Matching the scheme keeps
+          // cross-version chats working.
+          session = scheme == CryptoConstants.schemeRatchet3
+              ? await RatchetSession.initializeV3AsResponder(shared.material)
+              : await RatchetSession.initializeAsResponder(shared.material);
         }
 
         final plain = await session.decryptMessage(wire);

--- a/lib/crypto/ratchet/ratchet_session.dart
+++ b/lib/crypto/ratchet/ratchet_session.dart
@@ -7,28 +7,87 @@ import 'package:prysm/crypto/envelope.dart';
 import 'package:prysm/crypto/kdf.dart';
 
 /// Simplified Double Ratchet session for 1:1 chats (Phase 2).
+///
+/// Two session versions coexist:
+///  * v2 (legacy): message keys are derived statically from the root
+///    [sharedMaterial], which is persisted in the session JSON. Kept
+///    verbatim so existing chats survive an upgrade.
+///  * v3 (hash-chain): message keys come from a one-way ratchet over
+///    per-direction chain keys. Each step consumes the chain key (the old
+///    value is dropped) and only the *current* chain keys are persisted —
+///    past message keys are unrecoverable from a stolen session row.
 class RatchetSession {
-  RatchetSession({
+  /// Legacy session derived statically from [sharedMaterial].
+  RatchetSession.v2({
     required this.sharedMaterial,
     required this.isInitiator,
     required this.sendCounter,
     required this.recvCounter,
     Set<int>? skippedCounters,
-  }) : skippedCounters = skippedCounters ?? <int>{};
+  })  : version = 2,
+        sendChainKey = null,
+        recvChainKey = null,
+        recvSkippedKeys = const <int, String>{},
+        skippedCounters = skippedCounters ?? <int>{};
 
-  final Uint8List sharedMaterial;
+  /// Forward-secret session backed by one-way chain keys.
+  RatchetSession.v3({
+    required this.isInitiator,
+    required this.sendChainKey,
+    required this.recvChainKey,
+    required this.sendCounter,
+    required this.recvCounter,
+    Map<int, String>? recvSkippedKeys,
+  })  : version = 3,
+        sharedMaterial = null,
+        recvSkippedKeys = recvSkippedKeys ?? <int, String>{},
+        skippedCounters = const <int>{};
+
+  /// 2 for legacy sessions, 3 for hash-chain sessions.
+  final int version;
+
+  /// Static root material — v2 only; null on v3 sessions (never persisted).
+  final Uint8List? sharedMaterial;
+
+  /// Current outbound chain key — v3 only. Consumed on every send.
+  Uint8List? sendChainKey;
+
+  /// Current inbound chain key — v3 only. Consumed on every receive.
+  Uint8List? recvChainKey;
+
+  /// Message keys stashed for skipped (late) inbound counters, keyed by
+  /// counter — v3 only. Values are base64-encoded 32-byte keys. A skipped
+  /// key is deleted once used.
+  final Map<int, String> recvSkippedKeys;
+
   final bool isInitiator;
   int sendCounter;
   int recvCounter;
+
+  /// Skipped counters — v2 only.
   final Set<int> skippedCounters;
 
   static final Uint8List _ratchetSalt =
       Uint8List.fromList(utf8.encode('prysm/ratchet/root-salt'));
 
+  /// Two distinct chain-seed infos so initiator and responder derive
+  /// mirrored chains: init.send == resp.recv (info a) and
+  /// init.recv == resp.send (info b).
+  static final Uint8List _chainSeedInfoA =
+      Uint8List.fromList(utf8.encode('prysm/ratchet/chain/a'));
+  static final Uint8List _chainSeedInfoB =
+      Uint8List.fromList(utf8.encode('prysm/ratchet/chain/b'));
+  static final Uint8List _chainMsgInfo =
+      Uint8List.fromList(utf8.encode('prysm/ratchet/chain/msg'));
+  static final Uint8List _chainNextInfo =
+      Uint8List.fromList(utf8.encode('prysm/ratchet/chain/next'));
+
+  /// Legacy v2 session (static HKDF from [sharedMaterial]). Retained for
+  /// sessions already persisted in the DB.
   static Future<RatchetSession> initializeAsInitiator(
     Uint8List sharedMaterial,
   ) async {
-    return RatchetSession(
+    return RatchetSession.v2(
       sharedMaterial: sharedMaterial,
       isInitiator: true,
       sendCounter: 0,
@@ -39,9 +98,40 @@ class RatchetSession {
   static Future<RatchetSession> initializeAsResponder(
     Uint8List sharedMaterial,
   ) async {
-    return RatchetSession(
+    return RatchetSession.v2(
       sharedMaterial: sharedMaterial,
       isInitiator: false,
+      sendCounter: 0,
+      recvCounter: -1,
+    );
+  }
+
+  /// Forward-secret v3 session. Derives the two chain seeds from
+  /// [sharedMaterial] and does not retain it; the caller should drop its
+  /// own reference too.
+  static Future<RatchetSession> initializeV3AsInitiator(
+    Uint8List sharedMaterial,
+  ) async {
+    final send = await _chainSeed(sharedMaterial, _chainSeedInfoA);
+    final recv = await _chainSeed(sharedMaterial, _chainSeedInfoB);
+    return RatchetSession.v3(
+      isInitiator: true,
+      sendChainKey: send,
+      recvChainKey: recv,
+      sendCounter: 0,
+      recvCounter: -1,
+    );
+  }
+
+  static Future<RatchetSession> initializeV3AsResponder(
+    Uint8List sharedMaterial,
+  ) async {
+    final send = await _chainSeed(sharedMaterial, _chainSeedInfoB);
+    final recv = await _chainSeed(sharedMaterial, _chainSeedInfoA);
+    return RatchetSession.v3(
+      isInitiator: false,
+      sendChainKey: send,
+      recvChainKey: recv,
       sendCounter: 0,
       recvCounter: -1,
     );
@@ -52,13 +142,22 @@ class RatchetSession {
     Map<String, dynamic>? handshake,
   }) async {
     final counter = sendCounter;
-    final scheme = CryptoConstants.schemeRatchet2;
-    const alg = 'aes-gcm';
-    final messageKey = await _messageKey(
-      role: isInitiator ? 'send' : 'recv',
-      counter: counter,
-    );
+    final List<int> messageKey;
+    if (version == 3) {
+      messageKey = await _nextSendMessageKey();
+    } else {
+      messageKey = await _messageKey(
+        role: isInitiator ? 'send' : 'recv',
+        counter: counter,
+      );
+    }
     sendCounter++;
+    // v2 sessions keep emitting ratchet-2 so an unupgraded peer can still
+    // decrypt; only brand-new (v3) sessions speak ratchet-3.
+    final scheme = version == 3
+        ? CryptoConstants.schemeRatchet3
+        : CryptoConstants.schemeRatchet2;
+    const alg = 'aes-gcm';
     final aeadKey = await CryptoAead.secretKeyFromBytes(
       Uint8List.fromList(messageKey),
     );
@@ -88,9 +187,52 @@ class RatchetSession {
     final envelope = jsonDecode(wire) as Map<String, dynamic>;
     final scheme = envelope['scheme'] as String?;
     if (scheme != CryptoConstants.schemeRatchet1 &&
-        scheme != CryptoConstants.schemeRatchet2) {
+        scheme != CryptoConstants.schemeRatchet2 &&
+        scheme != CryptoConstants.schemeRatchet3) {
       throw FormatException('Not a ratchet message');
     }
+    if (version == 3) {
+      return _decryptV3(envelope, scheme!);
+    }
+    return _decryptV2(envelope, scheme!);
+  }
+
+  /// v3 inbound path: chain-ratchet (forward-secret) with skipped-key stash.
+  Future<Uint8List> _decryptV3(
+    Map<String, dynamic> envelope,
+    String scheme,
+  ) async {
+    // v3 sessions only ever speak to other v3 sessions.
+    if (scheme != CryptoConstants.schemeRatchet3) {
+      throw FormatException('Not a ratchet message');
+    }
+    final counter = envelope['counter'] as int;
+    // Consuming the chain (and stashing skipped keys) happens before the
+    // AEAD check: a hash chain cannot rewind, so a failed attempt still
+    // ratchets. Skipped keys survive (they are stashed, not consumed).
+    final messageKey = await _recvMessageKeyV3(counter);
+    final aeadKey = await CryptoAead.secretKeyFromBytes(
+      Uint8List.fromList(messageKey),
+    );
+    return CryptoAead.decryptAesGcm(
+      ciphertextWithTag: base64Decode(envelope['ciphertext'] as String),
+      key: aeadKey,
+      nonce: base64Decode(envelope['nonce'] as String),
+      associatedData: CryptoEnvelope.ratchetAad(
+        scheme: scheme,
+        counter: counter,
+        alg: envelope['alg'] as String? ?? 'aes-gcm',
+        crypto: envelope['crypto'] as String? ?? CryptoConstants.cryptoVersion,
+        handshake: envelope['handshake'] as Map<String, dynamic>?,
+      ),
+    );
+  }
+
+  /// Legacy v2 inbound path — exact prior behavior.
+  Future<Uint8List> _decryptV2(
+    Map<String, dynamic> envelope,
+    String scheme,
+  ) async {
     final counter = envelope['counter'] as int;
     final isLateSkipped = skippedCounters.contains(counter);
     if (counter <= recvCounter && !isLateSkipped) {
@@ -111,7 +253,7 @@ class RatchetSession {
     );
     final associatedData = scheme == CryptoConstants.schemeRatchet2
         ? CryptoEnvelope.ratchetAad(
-            scheme: scheme!,
+            scheme: scheme,
             counter: counter,
             alg: envelope['alg'] as String? ?? 'aes-gcm',
             crypto: envelope['crypto'] as String? ??
@@ -138,12 +280,60 @@ class RatchetSession {
     return plain;
   }
 
+  /// Resolves the inbound message key for [counter] under the v3 chain:
+  ///  * counter already stashed in [recvSkippedKeys] → return it and delete
+  ///    the stash entry (one-time use);
+  ///  * next in sequence → ratchet the chain one step;
+  ///  * gap ≤ `ratchetMaxSkip` → ratchet step by step, stashing the keys of
+  ///    every intermediate counter before advancing past it;
+  ///  * anything else → replay.
+  Future<List<int>> _recvMessageKeyV3(int counter) async {
+    final skippedKey = recvSkippedKeys.remove(counter);
+    if (skippedKey != null) {
+      return base64Decode(skippedKey);
+    }
+    if (counter <= recvCounter) {
+      throw StateError('Replay detected');
+    }
+    final gap = counter - (recvCounter + 1);
+    if (gap > CryptoConstants.ratchetMaxSkip) {
+      throw StateError('Counter too far ahead');
+    }
+    final steps = gap + 1;
+    var chain = recvChainKey!;
+    Uint8List? targetKey;
+    for (var i = 0; i < steps; i++) {
+      final msgKey = await _deriveMessageKeyFromChain(chain);
+      final current = recvCounter + 1 + i;
+      if (current == counter) {
+        targetKey = msgKey;
+      } else {
+        // The chain is about to ratchet past `current`: stash its message
+        // key now or the late message becomes undecryptable.
+        recvSkippedKeys[current] = base64Encode(msgKey);
+      }
+      chain = await _nextChainKey(chain);
+    }
+    recvChainKey = chain;
+    recvCounter = counter;
+    return targetKey!;
+  }
+
+  /// Ratchets the outbound chain one step and returns the message key for
+  /// the current position; the previous chain key is dropped.
+  Future<List<int>> _nextSendMessageKey() async {
+    final chain = sendChainKey!;
+    final messageKey = await _deriveMessageKeyFromChain(chain);
+    sendChainKey = await _nextChainKey(chain);
+    return messageKey;
+  }
+
   Future<List<int>> _messageKey({
     required String role,
     required int counter,
   }) async {
     final key = await CryptoKdf.hkdf(
-      sharedSecret: sharedMaterial,
+      sharedSecret: sharedMaterial!,
       info: utf8.encode(
         '${CryptoConstants.hkdfInfoRatchet}/$role/msg/$counter',
       ),
@@ -152,16 +342,84 @@ class RatchetSession {
     return await key.extractBytes();
   }
 
-  Map<String, dynamic> toJson() => {
-        'sharedMaterial': base64Encode(sharedMaterial),
+  static Future<Uint8List> _chainSeed(
+    Uint8List sharedMaterial,
+    Uint8List info,
+  ) async {
+    final key = await CryptoKdf.hkdf(
+      sharedSecret: sharedMaterial,
+      info: info,
+      salt: _ratchetSalt,
+    );
+    return Uint8List.fromList(await key.extractBytes());
+  }
+
+  static Future<Uint8List> _deriveMessageKeyFromChain(
+    Uint8List chainKey,
+  ) async {
+    final key = await CryptoKdf.hkdf(
+      sharedSecret: chainKey,
+      info: _chainMsgInfo,
+      salt: _ratchetSalt,
+    );
+    return Uint8List.fromList(await key.extractBytes());
+  }
+
+  static Future<Uint8List> _nextChainKey(Uint8List chainKey) async {
+    final key = await CryptoKdf.hkdf(
+      sharedSecret: chainKey,
+      info: _chainNextInfo,
+      salt: _ratchetSalt,
+    );
+    return Uint8List.fromList(await key.extractBytes());
+  }
+
+  Map<String, dynamic> toJson() {
+    if (version == 3) {
+      // Forward secrecy: persist only the current chain keys and the stashed
+      // skipped message keys — never the root material.
+      return {
+        'version': 3,
         'isInitiator': isInitiator,
+        'sendChainKey': base64Encode(sendChainKey!),
+        'recvChainKey': base64Encode(recvChainKey!),
+        'recvSkippedKeys': {
+          for (final entry in recvSkippedKeys.entries)
+            '${entry.key}': entry.value,
+        },
         'sendCounter': sendCounter,
         'recvCounter': recvCounter,
-        'skippedCounters': (skippedCounters.toList()..sort()),
       };
+    }
+    return {
+      'sharedMaterial': base64Encode(sharedMaterial!),
+      'isInitiator': isInitiator,
+      'sendCounter': sendCounter,
+      'recvCounter': recvCounter,
+      'skippedCounters': (skippedCounters.toList()..sort()),
+    };
+  }
 
   static RatchetSession fromJson(Map<String, dynamic> json) {
-    return RatchetSession(
+    // Rows persisted before v3 have no 'version' key — treat them as v2.
+    final version = json['version'] as int? ?? 2;
+    if (version == 3) {
+      return RatchetSession.v3(
+        isInitiator: json['isInitiator'] as bool? ?? true,
+        sendChainKey: base64Decode(json['sendChainKey'] as String),
+        recvChainKey: base64Decode(json['recvChainKey'] as String),
+        recvSkippedKeys: {
+          for (final entry
+              in (json['recvSkippedKeys'] as Map<String, dynamic>? ??
+                      const <String, dynamic>{})
+                  .entries)
+            int.parse(entry.key): entry.value as String,
+        },
+        sendCounter: json['sendCounter'] as int,
+        recvCounter: json['recvCounter'] as int,
+      );
+    }
+    return RatchetSession.v2(
       sharedMaterial: base64Decode(json['sharedMaterial'] as String),
       isInitiator: json['isInitiator'] as bool? ?? true,
       sendCounter: json['sendCounter'] as int,

--- a/lib/server/inbound_message_router.dart
+++ b/lib/server/inbound_message_router.dart
@@ -303,6 +303,7 @@ class InboundMessageRouter {
       await groupService.handleIncomingControlMessage(
         type,
         data['message'] as String,
+        data['senderId'] as String,
       );
     } catch (e) {
       Logging.error('Group control handling failed: $e', 'InboundMessageRouter');

--- a/lib/services/group_control_channel.dart
+++ b/lib/services/group_control_channel.dart
@@ -267,7 +267,8 @@ class GroupControlChannel {
       final parsed = jsonDecode(wire);
       return parsed is Map<String, dynamic> &&
           parsed['crypto'] == CryptoConstants.cryptoVersion &&
-          parsed['scheme'] == CryptoConstants.schemeControlWrap1;
+          (parsed['scheme'] == CryptoConstants.schemeControlWrap1 ||
+              parsed['scheme'] == CryptoConstants.schemeControlWrap2);
     } catch (_) {
       return false;
     }

--- a/lib/services/group_service.dart
+++ b/lib/services/group_service.dart
@@ -10,11 +10,14 @@ import 'package:prysm/services/conversation_preferences_service.dart';
 import 'package:prysm/services/disappearing_timer_service.dart';
 import 'package:prysm/services/group_control_channel.dart';
 import 'package:prysm/services/group_key_provider.dart';
+import 'package:prysm/services/peer_identity_resolver.dart';
 import 'package:prysm/util/db_helper.dart';
 import 'package:prysm/crypto/group_crypto.dart';
+import 'package:prysm/crypto/identity.dart';
 import 'package:prysm/util/group_sender_index_store.dart';
 import 'package:prysm/util/key_manager.dart';
 import 'package:prysm/util/group_membership_notifier.dart';
+import 'package:prysm/util/peer_identity_loader.dart';
 import 'package:prysm/util/pending_message_db_helper.dart';
 import 'package:uuid/uuid.dart';
 
@@ -348,13 +351,8 @@ class GroupService {
     );
 
     // Tell the removed member to drop the group (queued if they are offline).
-    await _controlChannel.sendKeyRotate(
-      groupId: groupId,
-      groupKey: newKey,
-      keyVersion: newVersion,
-      removedMemberId: memberOnion,
-      targetMemberId: memberOnion,
-    );
+    // Never send them the new key: doing so would let them decrypt the group
+    // forever (broken forward access revocation).
     await _controlChannel.sendMemberRemoved(
       groupId: groupId,
       removedMemberId: memberOnion,
@@ -463,12 +461,54 @@ class GroupService {
   }
 
   /// Handle incoming control messages (from PrysmServer).
-  Future<void> handleIncomingControlMessage(String type, String encryptedPayload) async {
-    final plaintext = await GroupCryptoV2.decryptControlPayload(
-      encryptedPayload,
-      keyManager.identity,
-    );
+  ///
+  /// Authenticates the sender before processing: the sender's identity is
+  /// resolved (cached user store, then Tor fetch) and [encryptedPayload]
+  /// must be a `control-wrap-2` envelope whose Ed25519 signature verifies
+  /// against that identity's signing key. Unsigned legacy envelopes and
+  /// forged signatures are dropped. For all types except invites the sender
+  /// must additionally be a member of the target group.
+  Future<void> handleIncomingControlMessage(
+    String type,
+    String encryptedPayload,
+    String senderId,
+  ) async {
+    final senderKeys = await _resolveSenderIdentity(senderId);
+    if (senderKeys == null) {
+      Logging.error(
+        'Dropping $type from $senderId: sender identity unresolvable',
+        'GroupService',
+      );
+      return;
+    }
+
+    final String plaintext;
+    try {
+      plaintext = await GroupCryptoV2.decryptControlPayload(
+        encryptedPayload,
+        keyManager.identity,
+        senderKeys,
+      );
+    } catch (e) {
+      Logging.error(
+        'Dropping $type from $senderId: control payload authentication failed: $e',
+        'GroupService',
+      );
+      return;
+    }
+
     final data = jsonDecode(plaintext) as Map<String, dynamic>;
+
+    if (type != groupInviteType) {
+      final groupId = data['groupId'] as String?;
+      if (groupId == null || !await DBHelper.isGroupMember(groupId, senderId)) {
+        Logging.error(
+          'Dropping $type from non-member $senderId for group $groupId',
+          'GroupService',
+        );
+        return;
+      }
+    }
 
     switch (type) {
       case groupInviteType:
@@ -487,6 +527,19 @@ class GroupService {
         await _handleDisappearingTimer(data);
         break;
     }
+  }
+
+  /// Resolves the sender's public identity (cached store first, then Tor).
+  Future<IdentityPublicKeys?> _resolveSenderIdentity(String senderId) async {
+    final resolver = PeerIdentityResolver(
+      peerId: senderId,
+      keyManager: keyManager,
+    );
+    return resolvePeerIdentityForIngress(
+      keyManager,
+      senderId,
+      fetchOverTor: () => resolver.fetchOverTor(),
+    );
   }
 
   Future<void> _handleDisappearingTimer(Map<String, dynamic> data) async {

--- a/test/crypto/ratchet_bootstrap_test.dart
+++ b/test/crypto/ratchet_bootstrap_test.dart
@@ -150,7 +150,7 @@ void main() {
 
     final envelope = jsonDecode(wire) as Map<String, dynamic>;
     expect(envelope['handshake'], isNotNull);
-    expect(envelope['scheme'], CryptoConstants.schemeRatchet2);
+    expect(envelope['scheme'], CryptoConstants.schemeRatchet3);
 
     final plain = await RatchetService.instance.decryptText(
       peerId: aliceOnion,
@@ -323,7 +323,7 @@ void main() {
       peerBundle: bobBundle,
       ephemeral: ephemeral,
     );
-    final initSession = await RatchetSession.initializeAsInitiator(shared);
+    final initSession = await RatchetSession.initializeV3AsInitiator(shared);
     final handshake = {'ephemeralPub': base64Encode(ephemeralPub.bytes)};
     final result = await initSession.encryptMessage(
       utf8.encode('fallback'),

--- a/test/crypto/ratchet_security_test.dart
+++ b/test/crypto/ratchet_security_test.dart
@@ -19,7 +19,7 @@ Future<String> _legacyRatchet1Wire(
   final role = session.isInitiator ? 'send' : 'recv';
   final salt = Uint8List.fromList(utf8.encode('prysm/ratchet/root-salt'));
   final messageKey = await CryptoKdf.hkdf(
-    sharedSecret: session.sharedMaterial,
+    sharedSecret: session.sharedMaterial!,
     info: utf8.encode('${CryptoConstants.hkdfInfoRatchet}/$role/msg/$counter'),
     salt: salt,
   );

--- a/test/crypto/ratchet_v3_test.dart
+++ b/test/crypto/ratchet_v3_test.dart
@@ -1,0 +1,186 @@
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:prysm/crypto/crypto.dart';
+import 'package:prysm/util/key_manager.dart';
+
+Future<IdentityPublicKeys> _publicKeys(IdentityKeyPair id) async {
+  final sign = await id.signPublicKey;
+  final agree = await id.agreePublicKey;
+  return IdentityPublicKeys(
+    signPublic: sign,
+    agreePublic: agree,
+    fingerprint: IdentityKeyPair.fingerprintFromPublicJson(
+      await id.toPublicJson(),
+    ),
+  );
+}
+
+Future<({RatchetSession init, RatchetSession resp})> _v3Pair() async {
+  final shared = Uint8List.fromList(List.generate(32, (i) => i));
+  final init = await RatchetSession.initializeV3AsInitiator(shared);
+  final resp = await RatchetSession.initializeV3AsResponder(shared);
+  return (init: init, resp: resp);
+}
+
+void main() {
+  group('Ratchet v3 (hash chain)', () {
+    test('roundtrip 10 crossed messages initiator<->responder', () async {
+      final pair = await _v3Pair();
+      for (var i = 0; i < 10; i++) {
+        final enc = await pair.init.encryptMessage(utf8.encode('i->r $i'));
+        expect(
+          utf8.decode(await pair.resp.decryptMessage(enc.wire)),
+          'i->r $i',
+        );
+        final encR = await pair.resp.encryptMessage(utf8.encode('r->i $i'));
+        expect(
+          utf8.decode(await pair.init.decryptMessage(encR.wire)),
+          'r->i $i',
+        );
+      }
+      expect(pair.init.sendCounter, 10);
+      expect(pair.init.recvCounter, 9);
+      expect(pair.resp.sendCounter, 10);
+      expect(pair.resp.recvCounter, 9);
+      expect(pair.resp.recvSkippedKeys, isEmpty);
+    });
+
+    test('out-of-order 5 then 3 ok, replay of 3 throws', () async {
+      final pair = await _v3Pair();
+      final wires = <String>[];
+      for (var i = 0; i < 6; i++) {
+        final enc = await pair.init.encryptMessage(utf8.encode('m$i'));
+        wires.add(enc.wire);
+      }
+
+      expect(utf8.decode(await pair.resp.decryptMessage(wires[5])), 'm5');
+      expect(pair.resp.recvCounter, 5);
+      expect(pair.resp.recvSkippedKeys.keys, {0, 1, 2, 3, 4});
+
+      expect(utf8.decode(await pair.resp.decryptMessage(wires[3])), 'm3');
+      expect(pair.resp.recvSkippedKeys.keys, {0, 1, 2, 4});
+
+      expect(
+        () => pair.resp.decryptMessage(wires[3]),
+        throwsA(isA<StateError>()),
+      );
+    });
+
+    test('gap of 257 is rejected without state change', () async {
+      final pair = await _v3Pair();
+      final enc0 = await pair.init.encryptMessage(utf8.encode('zero'));
+      expect(utf8.decode(await pair.resp.decryptMessage(enc0.wire)), 'zero');
+      expect(pair.resp.recvCounter, 0);
+
+      pair.init.sendCounter = 258; // gap = 258 - (0 + 1) = 257 > maxSkip
+      final enc = await pair.init.encryptMessage(utf8.encode('too far'));
+
+      expect(
+        () => pair.resp.decryptMessage(enc.wire),
+        throwsA(
+          predicate(
+            (e) => e is StateError && e.message == 'Counter too far ahead',
+          ),
+        ),
+      );
+      expect(pair.resp.recvCounter, 0);
+      expect(pair.resp.recvSkippedKeys, isEmpty);
+    });
+
+    test('forward secrecy: serialized v3 session cannot decrypt message 0',
+        () async {
+      final pair = await _v3Pair();
+      final wires = <String>[];
+      for (var i = 0; i < 10; i++) {
+        final enc = await pair.init.encryptMessage(utf8.encode('msg $i'));
+        wires.add(enc.wire);
+        await pair.resp.decryptMessage(enc.wire);
+      }
+      // Every message delivered in order — nothing skipped, no stash left.
+      expect(pair.resp.recvSkippedKeys, isEmpty);
+
+      final json = pair.resp.toJson();
+      // Root material must never be persisted for v3 sessions.
+      expect(json.containsKey('sharedMaterial'), isFalse);
+      expect(json['version'], 3);
+
+      final clone = RatchetSession.fromJson(json);
+      expect(
+        () => clone.decryptMessage(wires[0]),
+        throwsA(isA<StateError>()),
+      );
+      // The in-memory session is equally unable to rewind.
+      expect(
+        () => pair.resp.decryptMessage(wires[0]),
+        throwsA(isA<StateError>()),
+      );
+    });
+
+    test('skipped message key is deleted after use', () async {
+      final pair = await _v3Pair();
+      final enc0 = await pair.init.encryptMessage(utf8.encode('zero'));
+      final enc1 = await pair.init.encryptMessage(utf8.encode('one'));
+
+      await pair.resp.decryptMessage(enc1.wire);
+      expect(pair.resp.recvSkippedKeys.containsKey(0), isTrue);
+
+      expect(utf8.decode(await pair.resp.decryptMessage(enc0.wire)), 'zero');
+      expect(pair.resp.recvSkippedKeys, isEmpty);
+
+      expect(
+        () => pair.resp.decryptMessage(enc0.wire),
+        throwsA(isA<StateError>()),
+      );
+    });
+
+    test('v2 legacy session loads from old-format JSON and decrypts',
+        () async {
+      final shared = Uint8List.fromList(List.generate(32, (i) => i));
+      final init = await RatchetSession.initializeAsInitiator(shared);
+      final resp = await RatchetSession.initializeAsResponder(shared);
+      final enc0 = await init.encryptMessage(utf8.encode('legacy zero'));
+      final enc1 = await init.encryptMessage(utf8.encode('legacy one'));
+
+      await resp.decryptMessage(enc1.wire); // late-skips counter 0 (v2 style)
+      final json = resp.toJson();
+      // Old-format rows carry no 'version' key.
+      expect(json.containsKey('version'), isFalse);
+      expect(json.containsKey('sharedMaterial'), isTrue);
+
+      final restored = RatchetSession.fromJson(json);
+      expect(restored.version, 2);
+      expect(utf8.decode(await restored.decryptMessage(enc0.wire)),
+          'legacy zero');
+      expect(restored.recvCounter, 1);
+      expect(restored.skippedCounters, isEmpty);
+    });
+  });
+
+  group('DirectMessageAuth ratchet-3', () {
+    test('recognizes ratchet-3 as a ratchet scheme while locked', () async {
+      final alicePub = await _publicKeys(await IdentityKeyPair.generate());
+      final wire = jsonEncode({
+        'crypto': CryptoConstants.cryptoVersion,
+        'scheme': CryptoConstants.schemeRatchet3,
+        'nonce': 'abc',
+        'ciphertext': 'def',
+        'counter': 0,
+      });
+
+      final outcome = await DirectMessageAuth.authenticateInboundDirect(
+        senderId: 'alice.onion',
+        wire: wire,
+        type: 'text',
+        localUserId: 'bob.onion',
+        keyManager: KeyManager(),
+        resolveIdentity: (_) async => alicePub,
+        fullDecrypt: true,
+      );
+      // fullDecrypt + locked: an unknown scheme would be rejected; landing on
+      // pendingAuth proves the ratchet branch accepted ratchet-3.
+      expect(outcome, DirectAuthOutcome.pendingAuth);
+    });
+  });
+}

--- a/test/group_control_auth_test.dart
+++ b/test/group_control_auth_test.dart
@@ -1,0 +1,428 @@
+import 'dart:convert';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:prysm/constants/group_constants.dart';
+import 'package:prysm/crypto/aead.dart';
+import 'package:prysm/crypto/envelope.dart';
+import 'package:prysm/crypto/group_crypto.dart';
+import 'package:prysm/crypto/identity.dart';
+import 'package:prysm/crypto/ratchet/session_store.dart';
+import 'package:prysm/crypto/wire.dart';
+import 'package:prysm/database/messages.dart';
+import 'package:prysm/services/group_service.dart';
+import 'package:prysm/util/db_helper.dart';
+import 'package:prysm/util/group_sender_index_store.dart';
+import 'package:prysm/util/key_manager.dart';
+import 'package:sqflite_common_ffi/sqflite_ffi.dart';
+
+Future<Database> _openTestDb() async {
+  return databaseFactory.openDatabase(
+    inMemoryDatabasePath,
+    options: OpenDatabaseOptions(
+      version: 1,
+      onCreate: (db, version) async {
+        await db.execute('''
+          CREATE TABLE users (
+            id TEXT PRIMARY KEY,
+            name TEXT,
+            avatarUrl TEXT,
+            avatarBase64 TEXT,
+            customName TEXT,
+            publicKeyPem TEXT,
+            identityJson TEXT
+          )
+        ''');
+        await db.execute('''
+          CREATE TABLE groups (
+            id TEXT PRIMARY KEY,
+            name TEXT NOT NULL,
+            avatarBase64 TEXT,
+            createdBy TEXT NOT NULL,
+            createdAt INTEGER NOT NULL
+          )
+        ''');
+        await db.execute('''
+          CREATE TABLE group_members (
+            groupId TEXT NOT NULL,
+            memberId TEXT NOT NULL,
+            role TEXT NOT NULL,
+            joinedAt INTEGER NOT NULL,
+            PRIMARY KEY (groupId, memberId)
+          )
+        ''');
+        await db.execute('''
+          CREATE TABLE group_keys (
+            groupId TEXT PRIMARY KEY,
+            encryptedKey TEXT NOT NULL,
+            keyVersion INTEGER NOT NULL DEFAULT 1
+          )
+        ''');
+        await db.execute('''
+          CREATE TABLE pending_messages(
+            id TEXT PRIMARY KEY,
+            senderId TEXT,
+            receiverId TEXT,
+            message TEXT,
+            type TEXT,
+            fileName TEXT,
+            fileSize INTEGER,
+            timestamp INTEGER,
+            status TEXT,
+            replyTo TEXT,
+            viewOnce INTEGER DEFAULT 0,
+            groupId TEXT,
+            targetMemberId TEXT
+          )
+        ''');
+        await db.execute('''
+          CREATE TABLE messages (
+            id TEXT PRIMARY KEY,
+            senderId TEXT,
+            receiverId TEXT,
+            message TEXT,
+            timestamp INTEGER,
+            groupId TEXT
+          )
+        ''');
+        await GroupSenderIndexStore.ensureTable(db);
+        await RatchetSessionStore.ensureTable(db);
+      },
+    ),
+  );
+}
+
+Future<void> _insertIdentity(
+  Database db,
+  String peerId,
+  IdentityKeyPair pair,
+) async {
+  await db.insert('users', {
+    'id': peerId,
+    'identityJson': jsonEncode(await pair.toPublicJson()),
+  });
+}
+
+Future<void> _insertGroupWithMember(
+  Database db, {
+  required String groupId,
+  required String createdBy,
+  required List<String> memberIds,
+}) async {
+  await db.insert('groups', {
+    'id': groupId,
+    'name': 'Group $groupId',
+    'createdBy': createdBy,
+    'createdAt': 1000,
+  });
+  for (final memberId in memberIds) {
+    await db.insert('group_members', {
+      'groupId': groupId,
+      'memberId': memberId,
+      'role': memberId == createdBy ? 'admin' : 'member',
+      'joinedAt': 1000,
+    });
+  }
+}
+
+/// Builds a legacy unsigned `control-wrap-1` envelope the way the pre-fix
+/// encryptControlPayload did (ECDH key wrap without an Ed25519 signature).
+Future<String> _legacyControlWrap1(
+  String plaintextJson,
+  IdentityKeyPair sender,
+  IdentityKeyPair recipient,
+) async {
+  final sessionKey = GroupCryptoV2.generateGroupKey();
+  final wrapped = await CryptoWire.wrapKeyForPeer(
+    sessionKey,
+    sender,
+    await recipient.agreePublicKey,
+  );
+  final aeadKey = await CryptoAead.secretKeyFromBytes(sessionKey);
+  final enc = await CryptoAead.encryptAesGcm(
+    utf8.encode(plaintextJson),
+    key: aeadKey,
+  );
+  return CryptoEnvelope.encode(CryptoEnvelope.controlWrap1(
+    wrappedKey: wrapped,
+    iv: enc.nonce,
+    ciphertext: enc.ciphertext,
+  ));
+}
+
+Future<String> _keyRotatePayload(
+  IdentityKeyPair sender,
+  IdentityKeyPair recipient, {
+  required String groupId,
+  required int keyVersion,
+}) async {
+  final newKey = GroupCryptoV2.generateGroupKey();
+  final encryptedGroupKey = await GroupCryptoV2.encryptGroupKeyForStorage(
+    newKey,
+    sender,
+    peerAgreePublic: await recipient.agreePublicKey,
+  );
+  return jsonEncode({
+    'groupId': groupId,
+    'encryptedGroupKey': encryptedGroupKey,
+    'keyVersion': keyVersion,
+  });
+}
+
+void main() {
+  setUpAll(() {
+    TestWidgetsFlutterBinding.ensureInitialized();
+    sqfliteFfiInit();
+    databaseFactory = databaseFactoryFfi;
+  });
+
+  group('GroupCryptoV2 authenticated control payload', () {
+    test('signed control-wrap-2 round trip', () async {
+      final sender = await IdentityKeyPair.generate();
+      final recipient = await IdentityKeyPair.generate();
+      const plaintext = '{"groupId":"g1","keyVersion":2}';
+
+      final wire = await GroupCryptoV2.encryptControlPayload(
+        plaintext,
+        sender,
+        await recipient.agreePublicKey,
+      );
+      final envelope = CryptoEnvelope.tryParse(wire)!;
+      expect(envelope['scheme'], 'control-wrap-2');
+
+      final decrypted = await GroupCryptoV2.decryptControlPayload(
+        wire,
+        recipient,
+        IdentityPublicKeys(
+          signPublic: await sender.signPublicKey,
+          agreePublic: await sender.agreePublicKey,
+          fingerprint: (await sender.toPublicJson())['fingerprint'] as String,
+        ),
+      );
+      expect(decrypted, plaintext);
+    });
+
+    test('legacy control-wrap-1 is rejected as unsigned', () async {
+      final sender = await IdentityKeyPair.generate();
+      final recipient = await IdentityKeyPair.generate();
+      final wire = await _legacyControlWrap1(
+        '{"groupId":"g1"}',
+        sender,
+        recipient,
+      );
+      final senderKeys = IdentityPublicKeys(
+        signPublic: await sender.signPublicKey,
+        agreePublic: await sender.agreePublicKey,
+        fingerprint: (await sender.toPublicJson())['fingerprint'] as String,
+      );
+
+      await expectLater(
+        GroupCryptoV2.decryptControlPayload(wire, recipient, senderKeys),
+        throwsA(isA<FormatException>().having(
+          (e) => e.message,
+          'message',
+          contains('Unsigned group control message rejected'),
+        )),
+      );
+    });
+
+    test('control-wrap-2 signed by another identity is rejected', () async {
+      final realSender = await IdentityKeyPair.generate();
+      final attacker = await IdentityKeyPair.generate();
+      final recipient = await IdentityKeyPair.generate();
+
+      final wire = await GroupCryptoV2.encryptControlPayload(
+        '{"groupId":"g1"}',
+        attacker,
+        await recipient.agreePublicKey,
+      );
+      final realSenderKeys = IdentityPublicKeys(
+        signPublic: await realSender.signPublicKey,
+        agreePublic: await realSender.agreePublicKey,
+        fingerprint:
+            (await realSender.toPublicJson())['fingerprint'] as String,
+      );
+
+      await expectLater(
+        GroupCryptoV2.decryptControlPayload(wire, recipient, realSenderKeys),
+        throwsA(isA<FormatException>()),
+      );
+    });
+  });
+
+  group('GroupService authenticated inbound control messages', () {
+    const localUserId = 'me.onion';
+    const memberId = 'member.onion';
+    const outsiderId = 'outsider.onion';
+    const groupId = 'g1';
+
+    late Database db;
+    late KeyManager keyManager;
+    late GroupService service;
+
+    setUp(() async {
+      db = await _openTestDb();
+      DBHelper.setDatabaseForTest(db);
+      MessagesDb.setDatabaseForTest(db);
+      keyManager = KeyManager.fromIdentity(await IdentityKeyPair.generate());
+      service = GroupService(userId: localUserId, keyManager: keyManager);
+
+      await _insertGroupWithMember(
+        db,
+        groupId: groupId,
+        createdBy: localUserId,
+        memberIds: [localUserId, memberId],
+      );
+      final v1Key = GroupCryptoV2.generateGroupKey();
+      final encryptedForSelf =
+          await GroupCryptoV2.encryptGroupKeyForStorage(v1Key, keyManager.identity);
+      await DBHelper.upsertGroupKey(
+        groupId: groupId,
+        encryptedKey: encryptedForSelf,
+        keyVersion: 1,
+      );
+    });
+
+    tearDown(() async {
+      await db.close();
+      DBHelper.setDatabaseForTest(null);
+      MessagesDb.setDatabaseForTest(null);
+    });
+
+    test('valid signed keyRotate from a member is accepted and processed', () async {
+      final sender = await IdentityKeyPair.generate();
+      await _insertIdentity(db, memberId, sender);
+      final newKey = GroupCryptoV2.generateGroupKey();
+      final encryptedGroupKey = await GroupCryptoV2.encryptGroupKeyForStorage(
+        newKey,
+        sender,
+        peerAgreePublic: await keyManager.identity.agreePublicKey,
+      );
+      final wire = await GroupCryptoV2.encryptControlPayload(
+        jsonEncode({
+          'groupId': groupId,
+          'encryptedGroupKey': encryptedGroupKey,
+          'keyVersion': 2,
+        }),
+        sender,
+        await keyManager.identity.agreePublicKey,
+      );
+
+      await service.handleIncomingControlMessage(
+        groupKeyRotateType,
+        wire,
+        memberId,
+      );
+
+      expect(await service.getDecryptedGroupKey(groupId), newKey);
+      expect((await DBHelper.getGroupKey(groupId))!['keyVersion'], 2);
+    });
+
+    test('legacy control-wrap-1 keyRotate is dropped', () async {
+      final sender = await IdentityKeyPair.generate();
+      await _insertIdentity(db, memberId, sender);
+      final wire = await _legacyControlWrap1(
+        await _keyRotatePayload(
+          sender,
+          keyManager.identity,
+          groupId: groupId,
+          keyVersion: 2,
+        ),
+        sender,
+        keyManager.identity,
+      );
+
+      await service.handleIncomingControlMessage(
+        groupKeyRotateType,
+        wire,
+        memberId,
+      );
+
+      expect((await DBHelper.getGroupKey(groupId))!['keyVersion'], 1);
+    });
+
+    test('keyRotate signed by another identity is dropped', () async {
+      final sender = await IdentityKeyPair.generate();
+      final attacker = await IdentityKeyPair.generate();
+      await _insertIdentity(db, memberId, sender);
+      final wire = await GroupCryptoV2.encryptControlPayload(
+        await _keyRotatePayload(
+          attacker,
+          keyManager.identity,
+          groupId: groupId,
+          keyVersion: 2,
+        ),
+        attacker,
+        await keyManager.identity.agreePublicKey,
+      );
+
+      await service.handleIncomingControlMessage(
+        groupKeyRotateType,
+        wire,
+        memberId,
+      );
+
+      expect((await DBHelper.getGroupKey(groupId))!['keyVersion'], 1);
+    });
+
+    test('keyRotate from a non-member is dropped', () async {
+      final outsider = await IdentityKeyPair.generate();
+      await _insertIdentity(db, outsiderId, outsider);
+      final wire = await GroupCryptoV2.encryptControlPayload(
+        await _keyRotatePayload(
+          outsider,
+          keyManager.identity,
+          groupId: groupId,
+          keyVersion: 2,
+        ),
+        outsider,
+        await keyManager.identity.agreePublicKey,
+      );
+
+      await service.handleIncomingControlMessage(
+        groupKeyRotateType,
+        wire,
+        outsiderId,
+      );
+
+      expect((await DBHelper.getGroupKey(groupId))!['keyVersion'], 1);
+    });
+
+    test('invite signed by a non-member is accepted (signature suffices)', () async {
+      const inviterId = 'inviter.onion';
+      final inviter = await IdentityKeyPair.generate();
+      await _insertIdentity(db, inviterId, inviter);
+
+      final groupKey = GroupCryptoV2.generateGroupKey();
+      final encryptedGroupKey = await GroupCryptoV2.encryptGroupKeyForStorage(
+        groupKey,
+        inviter,
+        peerAgreePublic: await keyManager.identity.agreePublicKey,
+      );
+      final wire = await GroupCryptoV2.encryptControlPayload(
+        jsonEncode({
+          'groupId': 'g9',
+          'name': 'Invited Group',
+          'createdBy': inviterId,
+          'members': [
+            {'id': localUserId, 'role': 'member'},
+            {'id': inviterId, 'role': 'admin'},
+          ],
+          'encryptedGroupKey': encryptedGroupKey,
+          'keyVersion': 1,
+        }),
+        inviter,
+        await keyManager.identity.agreePublicKey,
+      );
+
+      await service.handleIncomingControlMessage(
+        groupInviteType,
+        wire,
+        inviterId,
+      );
+
+      expect(await DBHelper.getGroupById('g9'), isNotNull);
+      expect(await service.getDecryptedGroupKey('g9'), groupKey);
+      expect(await DBHelper.isGroupMember('g9', localUserId), isTrue);
+    });
+  });
+}

--- a/test/group_service_test.dart
+++ b/test/group_service_test.dart
@@ -1,4 +1,5 @@
 import 'dart:convert';
+import 'dart:typed_data';
 
 import 'package:flutter_test/flutter_test.dart';
 import 'package:prysm/constants/group_constants.dart';
@@ -117,6 +118,77 @@ class _FakePostman implements SideChannelPostman {
   void clear() => groupCalls.clear();
 }
 
+/// Records control-channel calls at method level so tests can assert on
+/// exactly which member receives a key rotation vs. a member-removed notice.
+class _FakeGroupControlChannel implements GroupControlChannel {
+  _FakeGroupControlChannel({
+    required this.keyManager,
+    required this.keyProvider,
+  });
+
+  @override
+  String get userId => '';
+  @override
+  final KeyManager keyManager;
+  @override
+  final GroupKeyProvider keyProvider;
+
+  final List<Map<String, String>> keyRotateCalls = [];
+  final List<Map<String, String>> memberRemovedCalls = [];
+
+  @override
+  Future<void> sendInvite({
+    required String groupId,
+    required String name,
+    String? avatarBase64,
+    required List<Map<String, String>> members,
+    required Uint8List groupKey,
+    required int keyVersion,
+    required String targetMemberId,
+  }) async {}
+
+  @override
+  Future<void> sendKeyRotate({
+    required String groupId,
+    required Uint8List groupKey,
+    required int keyVersion,
+    required String removedMemberId,
+    required String targetMemberId,
+  }) async {
+    keyRotateCalls.add({'targetMemberId': targetMemberId});
+  }
+
+  @override
+  Future<void> sendProfileUpdate({
+    required String groupId,
+    required String name,
+    String? avatarBase64,
+    required String targetMemberId,
+  }) async {}
+
+  @override
+  Future<void> sendDisappearingTimer({
+    required String groupId,
+    required int? timerSeconds,
+    required int updatedAt,
+    required String updatedBy,
+    required String targetMemberId,
+  }) async {}
+
+  @override
+  Future<void> sendMemberRemoved({
+    required String groupId,
+    required String removedMemberId,
+    required int keyVersion,
+    required String targetMemberId,
+  }) async {
+    memberRemovedCalls.add({'targetMemberId': targetMemberId});
+  }
+
+  @override
+  Future<bool> processPendingControlMessages({int maxPerCycle = 20}) async => false;
+}
+
 void main() {
   setUpAll(() {
     TestWidgetsFlutterBinding.ensureInitialized();
@@ -222,7 +294,7 @@ void main() {
       }
     });
 
-    test('removeMember sends key rotate + member removed to the removed and remaining members', () async {
+    test('removeMember rotates the key only to remaining members, never the removed one', () async {
       await _insertPeerIdentity(db, peerId);
       const otherMemberId = 'other.onion';
       await _insertPeerIdentity(db, otherMemberId);
@@ -232,11 +304,50 @@ void main() {
 
       await service.removeMember(group.id, peerId);
 
-      final types = postman.groupCalls.map((c) => (c['payload'] as Map)['type']).toSet();
-      expect(types, {groupKeyRotateType, groupMemberRemovedType});
-      final targets = postman.groupCalls.map((c) => c['targetMemberId']).toSet();
-      // Removed member is told directly, and the remaining member is updated.
-      expect(targets, {peerId, otherMemberId});
+      final rotateTargets = postman.groupCalls
+          .where((c) => (c['payload'] as Map)['type'] == groupKeyRotateType)
+          .map((c) => c['targetMemberId'])
+          .toSet();
+      // The removed member never receives the new group key.
+      expect(rotateTargets, isNot(contains(peerId)));
+      expect(rotateTargets, {otherMemberId});
+
+      final removedTargets = postman.groupCalls
+          .where((c) => (c['payload'] as Map)['type'] == groupMemberRemovedType)
+          .map((c) => c['targetMemberId'])
+          .toSet();
+      // Removed member is told to drop the group; remaining member is updated.
+      expect(removedTargets, {peerId, otherMemberId});
+    });
+
+    test('removeMember never delivers the new group key to the removed member (forward access revocation)', () async {
+      await _insertPeerIdentity(db, peerId);
+      const otherMemberId = 'other.onion';
+      await _insertPeerIdentity(db, otherMemberId);
+
+      final group = await service.createGroup('Squad', [peerId, otherMemberId]);
+
+      final fakeChannel = _FakeGroupControlChannel(
+        keyManager: keyManager,
+        keyProvider: keyProvider,
+      );
+      final serviceWithFakeChannel = GroupService(
+        userId: userId,
+        keyManager: keyManager,
+        keyProvider: keyProvider,
+        controlChannel: fakeChannel,
+      );
+
+      await serviceWithFakeChannel.removeMember(group.id, peerId);
+
+      // Key rotations reach every remaining member, never the removed one.
+      final rotateTargets = fakeChannel.keyRotateCalls.map((c) => c['targetMemberId']).toSet();
+      expect(rotateTargets, isNot(contains(peerId)));
+      expect(rotateTargets, {otherMemberId});
+
+      // The removed member is still told to drop the group.
+      final removedTargets = fakeChannel.memberRemovedCalls.map((c) => c['targetMemberId']).toSet();
+      expect(removedTargets, contains(peerId));
     });
 
     test('updateGroupName sends a profile update to other members', () async {


### PR DESCRIPTION
Two commits fixing the critical findings from the security scan (2026-08-04).

## fix(groups) — 52c5cd1
- **C1**: group control messages (invite/keyRotate/memberRemoved/profileUpdate) were wrapped with anonymous ephemeral ECDH — anyone knowing a victim's onion could forge a keyRotate and impose an attacker-chosen group key. Now wrapped with control-wrap-2 (Ed25519-signed via wrapKeyForPeerSigned); unsigned control-wrap-1 is rejected; sender identity is resolved (cached store, then Tor) and membership is required for every type except invites.
- **C3**: removeMember delivered the rotated epoch key to the very member being removed (broken forward access revocation). Only memberRemoved is now sent to them.

## feat(ratchet) — d08619e
- **C2**: the 1:1 session derived every message key from a static sharedMaterial persisted in plaintext — a DB theft decrypted the entire history. Introduces ratchet-3: one-way hash chain (msg key = HKDF(chain, msg); chain evolves per message), consumed keys discarded, skipped-counter keys stashed (bounded by ratchetMaxSkip) and deleted on first use. Serialized v3 sessions persist only chain keys — never the X3DH root material.