### PR TITLE
refactor(group_chat): update message filtering logic to use isPending…

### DIFF
--- a/lib/services/group_chat_service.dart
+++ b/lib/services/group_chat_service.dart
@@ -397,7 +397,7 @@ class GroupChatService {
       while (!_disposed) {
         await _refreshSession();
         final pending = (await PendingMessageDbHelper.getPendingMessages(groupId: groupId))
-            .where((m) => !isGroupControlType(m['type'] as String))
+            .where((m) => isPendingOutboundChatType(m['type'] as String? ?? ''))
             .toList();
         if (pending.isEmpty) break;
 
@@ -477,7 +477,7 @@ class GroupChatService {
         }
 
         final remaining = (await PendingMessageDbHelper.getPendingMessages(groupId: groupId))
-            .where((m) => !isGroupControlType(m['type'] as String))
+            .where((m) => isPendingOutboundChatType(m['type'] as String? ?? ''))
             .toList();
         if (remaining.isEmpty) break;
 
@@ -614,7 +614,7 @@ class GroupChatService {
 
   Future<void> _checkAllTargetsDelivered(String messageId) async {
     final remaining = (await PendingMessageDbHelper.getPendingMessages(groupId: groupId))
-        .where((m) => !isGroupControlType(m['type'] as String))
+        .where((m) => isPendingOutboundChatType(m['type'] as String? ?? ''))
         .where((m) => _messageIdFromPendingId(m['id'] as String) == messageId)
         .toList();
     if (remaining.isEmpty) {
@@ -632,8 +632,7 @@ class GroupChatService {
       senderId: userId,
       limit: maxPerCycle,
     ))
-        .where((m) => !isGroupControlType(m['type'] as String))
-        .where((m) => m['type'] != groupHistoryRelayType)
+        .where((m) => isPendingOutboundChatType(m['type'] as String? ?? ''))
         .toList();
     if (pending.isEmpty) return false;
 
@@ -659,8 +658,7 @@ class GroupChatService {
     _isSending = true;
     try {
       final pending = (await PendingMessageDbHelper.getPendingMessages(groupId: groupId))
-          .where((m) => !isGroupControlType(m['type'] as String))
-          .where((m) => m['type'] != groupHistoryRelayType)
+          .where((m) => isPendingOutboundChatType(m['type'] as String? ?? ''))
           .toList();
       if (pending.isEmpty) return;
 

--- a/test/group_chat_service_test.dart
+++ b/test/group_chat_service_test.dart
@@ -419,5 +419,119 @@ void main() {
       );
       expect(remaining, isEmpty);
     });
+
+    test('startSendQueue ignores side-channel pending rows', () async {
+      TorRuntimeGate.resetForTest();
+      final postman = _FakePostman();
+      const eventId = 'msg1::$userId';
+
+      await PendingMessageDbHelper.insertPendingMessage({
+        'id': '${eventId}__$memberA',
+        'senderId': userId,
+        'receiverId': memberA,
+        'message': 'encrypted-reaction',
+        'type': groupReactionType,
+        'timestamp': 1,
+        'status': 'pending',
+        'groupId': groupId,
+        'targetMemberId': memberA,
+      });
+
+      final fakeGroupService = _FakeGroupService(
+        userId: userId,
+        keyManager: keyManager,
+        groupKey: Uint8List.fromList(List.generate(32, (i) => i)),
+        members: [
+          GroupMember(
+            groupId: groupId,
+            memberId: userId,
+            role: GroupRole.admin,
+            joinedAt: 0,
+          ),
+          GroupMember(
+            groupId: groupId,
+            memberId: memberA,
+            role: GroupRole.member,
+            joinedAt: 0,
+          ),
+        ],
+      );
+      final injectedService = GroupChatService(
+        userId: userId,
+        groupId: groupId,
+        keyManager: keyManager,
+        groupService: fakeGroupService,
+        postman: postman,
+      );
+      addTearDown(injectedService.dispose);
+      await injectedService.initialize();
+
+      injectedService.startSendQueue();
+      await Future<void>.delayed(const Duration(milliseconds: 50));
+
+      expect(postman.groupCalls, isEmpty);
+      final remaining = await PendingMessageDbHelper.getPendingMessages(
+        groupId: groupId,
+      );
+      expect(remaining, hasLength(1));
+      expect(remaining.first['type'], groupReactionType);
+    });
+
+    test('startSendQueue ignores group_history_relay pending rows', () async {
+      TorRuntimeGate.resetForTest();
+      final postman = _FakePostman();
+      const relayId = 'history-relay-1';
+
+      await PendingMessageDbHelper.insertPendingMessage({
+        'id': '${relayId}__$memberA',
+        'senderId': userId,
+        'receiverId': memberA,
+        'message': 'encrypted-relay',
+        'type': groupHistoryRelayType,
+        'timestamp': 1,
+        'status': 'pending',
+        'groupId': groupId,
+        'targetMemberId': memberA,
+      });
+
+      final fakeGroupService = _FakeGroupService(
+        userId: userId,
+        keyManager: keyManager,
+        groupKey: Uint8List.fromList(List.generate(32, (i) => i)),
+        members: [
+          GroupMember(
+            groupId: groupId,
+            memberId: userId,
+            role: GroupRole.admin,
+            joinedAt: 0,
+          ),
+          GroupMember(
+            groupId: groupId,
+            memberId: memberA,
+            role: GroupRole.member,
+            joinedAt: 0,
+          ),
+        ],
+      );
+      final injectedService = GroupChatService(
+        userId: userId,
+        groupId: groupId,
+        keyManager: keyManager,
+        groupService: fakeGroupService,
+        postman: postman,
+      );
+      addTearDown(injectedService.dispose);
+      await injectedService.initialize();
+
+      injectedService.startSendQueue();
+      await Future<void>.delayed(const Duration(milliseconds: 50));
+
+      expect(postman.groupCalls, isEmpty);
+      final remaining = await PendingMessageDbHelper.getPendingMessages(
+        groupId: groupId,
+      );
+      expect(remaining, hasLength(1));
+      expect(remaining.first['type'], groupHistoryRelayType);
+    });
   });
 }

--- a/test/message_modify_offline_test.dart
+++ b/test/message_modify_offline_test.dart
@@ -60,6 +60,14 @@ void main() {
       expect(isPendingOutboundChatType(messageModifyType), isFalse);
       expect(isPendingOutboundChatType(reactionType), isFalse);
       expect(isPendingOutboundChatType(readReceiptType), isFalse);
+      expect(isPendingOutboundChatType(groupReactionType), isFalse);
+      expect(isPendingOutboundChatType(groupMessageModifyType), isFalse);
+      expect(isPendingOutboundChatType(groupReadWaterlineType), isFalse);
+    });
+
+    test('excludes group control and history relay types', () {
+      expect(isPendingOutboundChatType(groupInviteType), isFalse);
+      expect(isPendingOutboundChatType(groupHistoryRelayType), isFalse);
     });
   });
 


### PR DESCRIPTION
…OutboundChatType

- Replaced instances of isGroupControlType with isPendingOutboundChatType for better clarity in message handling.
- Added tests to ensure that side-channel and group history relay messages are correctly ignored in the send queue.