### PR TITLE
feat(contact): add customName field to Contact and update related logic

### DIFF
--- a/lib/services/call/call_foreground_session.dart
+++ b/lib/services/call/call_foreground_session.dart
@@ -187,7 +187,9 @@ class CallForegroundSession implements CallForegroundSessionPort {
 
   Future<String> _peerDisplayName(String peerOnion) async {
     final row = await DBHelper.getUserById(peerOnion);
+    final customName = row?['customName'] as String?;
     final name = row?['name'] as String?;
+    if (customName != null && customName.isNotEmpty) return customName;
     if (name != null && name.isNotEmpty) return name;
     if (peerOnion.length <= 16) return peerOnion;
     return '${peerOnion.substring(0, 16)}…';

--- a/lib/services/contact_add_service.dart
+++ b/lib/services/contact_add_service.dart
@@ -114,9 +114,10 @@ class ContactAddService {
 
     final newUser = Contact(
       id: onionId,
-      name: displayName,
+      name: '',
       avatarUrl: '',
       avatarBase64: null,
+      customName: displayName.isNotEmpty ? displayName : null,
       identityJson: identityJson,
     );
     await DBHelper.insertOrUpdateUser({
@@ -124,6 +125,7 @@ class ContactAddService {
       'name': newUser.name,
       'avatarUrl': newUser.avatarUrl,
       'avatarBase64': null,
+      'customName': newUser.customName,
       'identityJson': identityJson,
       'publicKeyPem': identityJson,
     });

--- a/test/contact_add_service_characterization_test.dart
+++ b/test/contact_add_service_characterization_test.dart
@@ -16,6 +16,7 @@ import 'dart:io';
 
 import 'package:flutter_test/flutter_test.dart';
 import 'package:prysm/crypto/identity.dart';
+import 'package:prysm/models/contact.dart';
 import 'package:prysm/services/block_service.dart';
 import 'package:prysm/services/contact_add_service.dart';
 import 'package:prysm/transport/transport_provider.dart';
@@ -176,7 +177,8 @@ void main() {
       final row = await DBHelper.getUserById(onionId);
       expect(row, isNotNull);
       expect(row!['id'], onionId);
-      expect(row['name'], 'Alice');
+      expect(row['name'], '');
+      expect(row['customName'], 'Alice');
       expect(row['avatarUrl'], '');
       expect(row['avatarBase64'], isNull);
       expect(row['identityJson'], peerIdentityJson);
@@ -253,8 +255,18 @@ void main() {
 
       expect(fetchProfileCalls, [onionId]);
       expect(row?['name'], 'Alice B.');
+      expect(row?['customName'], 'Alice');
       expect(row?['avatarBase64'], 'YWJj');
       expect(refreshCount, greaterThan(0));
+
+      final contact = Contact(
+        id: onionId,
+        name: row!['name'] as String,
+        avatarUrl: row['avatarUrl'] as String? ?? '',
+        customName: row['customName'] as String?,
+        identityJson: row['identityJson'] as String,
+      );
+      expect(contact.displayName, 'Alice');
     });
 
     test(
@@ -275,7 +287,8 @@ void main() {
       await Future.delayed(const Duration(milliseconds: 20));
 
       final row = await DBHelper.getUserById(onionId);
-      expect(row!['name'], 'Alice');
+      expect(row!['name'], '');
+      expect(row['customName'], 'Alice');
       expect(row['avatarBase64'], isNull);
     });
   });


### PR DESCRIPTION
- Updated Contact model to include customName, allowing for a display name fallback.
- Modified ContactAddService to set customName based on displayName input.
- Adjusted CallForegroundSession to prioritize customName when retrieving user display names.
- Updated tests to reflect changes in Contact model and ensure correct functionality.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Contact display names now prioritize a user-provided custom name.
  * Newly added contacts preserve custom names separately from profile-derived names.
  * Call screens display the custom contact name when available.

* **Bug Fixes**
  * Improved contact name resolution when profile information is incomplete.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->