### PR TITLE
Group invite mode (1/3): setting and bounded pending-invite store

### DIFF
--- a/docs/superpowers/plans/2026-08-07-group-invite-mode.md
+++ b/docs/superpowers/plans/2026-08-07-group-invite-mode.md
@@ -1,0 +1,1565 @@
+# Group Invite Mode Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Let the user choose, in Privacy Settings, whether a group invite from someone not in
+their contacts is discarded on arrival (today's merged behaviour) or held as a pending request
+they can accept — with both modes explained by a subtitle at the point of choice.
+
+**Architecture:** A two-value enum setting read synchronously by `GroupService` at the existing
+unknown-sender drop branch. In hold mode the raw, still-encrypted control envelope is written to
+a new bounded table in `chat_app.db` and nothing else happens: no decryption, no outbound
+traffic, same `200 received` ack. The user accepts from a dedicated screen, which runs the
+existing user-initiated contact-add (the only fetch in the whole flow) and then replays the
+stored envelope through the normal authenticated path.
+
+**Tech Stack:** Flutter/Dart, `sqflite` (+ `sqflite_common_ffi` in tests), `mutex`,
+`shared_preferences`. No new dependencies.
+
+**Spec:** `docs/superpowers/specs/2026-08-07-group-invite-mode-design.md`
+
+## Global Constraints
+
+- No new dependencies, in neither `dependencies` nor `dev_dependencies`.
+- `flutter analyze` must report **0 issues** and `flutter test` must stay green before every
+  commit. Baseline on this branch: `935 passed, 1 skipped`.
+- User-facing strings are hardcoded English (the app has no i18n layer). Comments and commit
+  messages in English; conventional one-line commit subjects.
+- Reuse existing patterns; a second convention beside an existing one is prohibited. The
+  patterns this plan follows are named per task with `path:line`.
+- Tests: hand-written fakes, `sqflite_common_ffi` in-memory databases, the
+  `setDatabaseForTest` / `resetForTest` seams. Every test must be seen failing before the
+  implementation makes it pass.
+- **The security boundary does not move.** `_resolveSenderIdentity` stays DB-only; nothing in
+  this plan may introduce an outbound fetch triggered by inbound traffic. The existing
+  `POLICY:` tests in `test/security/group_profile_fetch_gate_test.dart` must stay green with
+  their assertions unchanged.
+- A pending invite is **never decrypted while pending**. No field of an unauthenticated
+  payload may reach the UI or be parsed into the database.
+- Onion addresses in logs go through `Logging.redactOnion`.
+- Subagents do not run git commands that mutate state and do not run the full suite; the
+  controller commits and runs the gate.
+
+## File Structure
+
+| File | Responsibility | Task |
+|---|---|---|
+| `lib/models/group_invite_mode.dart` (new) | The two-value enum plus the user-facing `label`/`description` for each mode | 1 |
+| `lib/models/settings.dart` | Carries `groupInviteMode` through the settings JSON | 1 |
+| `lib/services/settings_service.dart` | Synchronous getter + persisting setter | 1 |
+| `lib/util/group_pending_invite_store.dart` (new) | The bounded pending table and its whole API | 2 |
+| `lib/util/db_helper.dart` | Schema version 14 + create/upgrade wiring | 2 |
+| `lib/services/group_service.dart` | Holds the invite at the existing drop branch; comment fix | 3 |
+| `lib/services/group_invite_promoter.dart` (new) | Replays a held envelope through the authenticated path | 4 |
+| `lib/screens/home/home_screen.dart` | One-shot promotion sweep; sidebar footer row | 4, 6 |
+| `lib/screens/privacy_settings_screen.dart` | The two radio rows with both subtitles | 5 |
+| `lib/screens/invite_requests_screen.dart` (new) | The list of pending requests with accept/discard | 6 |
+| `lib/screens/settings_screen.dart` | Navigation tile into the new screen | 6 |
+
+---
+
+### Task 1: The setting
+
+**Files:**
+- Create: `lib/models/group_invite_mode.dart`
+- Modify: `lib/models/settings.dart` (field, ctor default, `toJson`, `fromJson`, `copyWith`, `==`, `hashCode`)
+- Modify: `lib/services/settings_service.dart` (getter near `:59`, setter after `:219`)
+- Test: `test/group_invite_mode_settings_test.dart`
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces: `enum GroupInviteMode { holdAsRequest, contactsOnly }` with `String get label`,
+  `String get description`, `static GroupInviteMode fromJson(String?)`;
+  `Settings.groupInviteMode`; `SettingsService().groupInviteMode` (sync getter) and
+  `Future<void> SettingsService().setGroupInviteMode(GroupInviteMode)`.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `test/group_invite_mode_settings_test.dart`:
+
+```dart
+import 'package:flutter_test/flutter_test.dart';
+import 'package:prysm/models/group_invite_mode.dart';
+import 'package:prysm/models/settings.dart';
+import 'package:prysm/services/settings_service.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  test('the default mode holds invites from unknown senders', () {
+    expect(Settings().groupInviteMode, GroupInviteMode.holdAsRequest);
+  });
+
+  test('the mode survives a JSON round trip', () {
+    final restored = Settings.fromJson(
+      Settings(groupInviteMode: GroupInviteMode.contactsOnly).toJson(),
+    );
+    expect(restored.groupInviteMode, GroupInviteMode.contactsOnly);
+  });
+
+  test('an unknown stored value falls back to the default', () {
+    expect(
+      Settings.fromJson({'groupInviteMode': 'whatever-a-future-build-wrote'})
+          .groupInviteMode,
+      GroupInviteMode.holdAsRequest,
+    );
+  });
+
+  test('both modes carry a label and an explanatory description', () {
+    for (final mode in GroupInviteMode.values) {
+      expect(mode.label, isNotEmpty);
+      expect(mode.description, isNotEmpty);
+      expect(mode.description.length, greaterThan(40));
+    }
+  });
+
+  test('the setter persists the mode through SettingsService', () async {
+    SharedPreferences.setMockInitialValues({});
+    final service = SettingsService();
+    addTearDown(
+      () => service.setGroupInviteMode(GroupInviteMode.holdAsRequest),
+    );
+
+    await service.setGroupInviteMode(GroupInviteMode.contactsOnly);
+    expect(service.groupInviteMode, GroupInviteMode.contactsOnly);
+
+    await service.load();
+    expect(service.groupInviteMode, GroupInviteMode.contactsOnly);
+  });
+}
+```
+
+- [ ] **Step 2: Run the test and watch it fail**
+
+Run: `flutter test test/group_invite_mode_settings_test.dart`
+Expected: compile failure — `Error: Couldn't resolve the package 'prysm/models/group_invite_mode.dart'`.
+
+- [ ] **Step 3: Create the enum**
+
+Create `lib/models/group_invite_mode.dart` (shape copied verbatim from
+`lib/models/panic_action.dart:1-23`):
+
+```dart
+/// What happens to a group invite whose sender's identity is not in the
+/// local user store.
+///
+/// The security boundary is the same in both modes: the sender is never
+/// resolved over the network on an inbound message (M2). The choice is only
+/// whether the invite is kept for the user to decide on, or dropped.
+enum GroupInviteMode {
+  holdAsRequest,
+  contactsOnly;
+
+  String get label => switch (this) {
+        GroupInviteMode.holdAsRequest => 'Hold invites from unknown senders',
+        GroupInviteMode.contactsOnly => 'Only accept invites from contacts',
+      };
+
+  String get description => switch (this) {
+        GroupInviteMode.holdAsRequest =>
+          'An invite from someone who is not in your contacts is kept as a '
+              "request. Your device never contacts them, and you don't join "
+              'the group until you accept.',
+        GroupInviteMode.contactsOnly =>
+          'Invites from anyone else are discarded the moment they arrive: '
+              'nothing is stored, nothing is shown.',
+      };
+
+  static GroupInviteMode fromJson(String? value) {
+    return GroupInviteMode.values.firstWhere(
+      (m) => m.name == value,
+      orElse: () => GroupInviteMode.holdAsRequest,
+    );
+  }
+}
+```
+
+- [ ] **Step 4: Thread the field through `Settings`**
+
+In `lib/models/settings.dart`, six edits, each mirroring the `panicAction` line beside it:
+
+1. import, after `import 'package:prysm/models/appearance_settings.dart';`:
+
+```dart
+import 'package:prysm/models/group_invite_mode.dart';
+```
+
+2. field, in the `// Privacy` block after `final PanicAction panicAction;`:
+
+```dart
+  final GroupInviteMode groupInviteMode;
+```
+
+3. constructor default, after `this.panicAction = PanicAction.decoy,`:
+
+```dart
+    this.groupInviteMode = GroupInviteMode.holdAsRequest,
+```
+
+4. `toJson`, after `'panicAction': panicAction.name,`:
+
+```dart
+    'groupInviteMode': groupInviteMode.name,
+```
+
+5. `fromJson`, after `panicAction: PanicAction.fromJson(json['panicAction'] as String?),`:
+
+```dart
+    groupInviteMode: GroupInviteMode.fromJson(
+      json['groupInviteMode'] as String?,
+    ),
+```
+
+6. `copyWith` — parameter after `PanicAction? panicAction,`:
+
+```dart
+    GroupInviteMode? groupInviteMode,
+```
+
+and mapping after `panicAction: panicAction ?? this.panicAction,`:
+
+```dart
+    groupInviteMode: groupInviteMode ?? this.groupInviteMode,
+```
+
+7. `operator ==`, after `other.panicAction == panicAction &&`:
+
+```dart
+        other.groupInviteMode == groupInviteMode &&
+```
+
+8. `hashCode`, after `panicAction.hashCode ^`:
+
+```dart
+        groupInviteMode.hashCode ^
+```
+
+- [ ] **Step 5: Add the getter and setter**
+
+In `lib/services/settings_service.dart`, import `package:prysm/models/group_invite_mode.dart`,
+then add the getter directly under `PanicAction get panicAction => _settings.panicAction;`:
+
+```dart
+  GroupInviteMode get groupInviteMode => _settings.groupInviteMode;
+```
+
+and the setter directly under the closing brace of `setPanicAction`:
+
+```dart
+  Future<void> setGroupInviteMode(GroupInviteMode value) async {
+    _settings = _settings.copyWith(groupInviteMode: value);
+    await save();
+  }
+```
+
+- [ ] **Step 6: Run the test and watch it pass**
+
+Run: `flutter test test/group_invite_mode_settings_test.dart`
+Expected: `+5: All tests passed!`
+
+- [ ] **Step 7: Commit (controller)**
+
+```bash
+git add lib/models/group_invite_mode.dart lib/models/settings.dart \
+        lib/services/settings_service.dart test/group_invite_mode_settings_test.dart
+git commit -m "feat(settings): add the group invite mode setting"
+```
+
+---
+
+### Task 2: The bounded pending store and schema v14
+
+**Files:**
+- Create: `lib/util/group_pending_invite_store.dart`
+- Modify: `lib/util/db_helper.dart` (`version: 13` → `14` at `:64`; `_createCryptoTables` at `:99-102`; a new ladder step at the end of `_onUpgradeImpl`, after the `oldVersion < 13` block that ends at `:217`)
+- Test: `test/security/group_pending_invite_store_test.dart`
+- Test: `test/security/chat_db_v13_v14_upgrade_test.dart`
+
+**Interfaces:**
+- Consumes: nothing from Task 1.
+- Produces:
+  - `GroupPendingInviteStore.ensureTable(Database db) -> Future<void>`
+  - `GroupPendingInviteStore.hold({required String senderId, required String wire}) -> Future<bool>`
+  - `GroupPendingInviteStore.pending() -> Future<List<Map<String, Object?>>>` — rows
+    `{senderId: String, wire: String, receivedAt: int}`, newest first
+  - `GroupPendingInviteStore.count() -> Future<int>`
+  - `GroupPendingInviteStore.take(String senderId) -> Future<String?>` — the wire, deleted
+  - `GroupPendingInviteStore.discard(String senderId) -> Future<void>`
+  - constants `maxPendingSenders = 20`, `retention = Duration(days: 7)`
+
+- [ ] **Step 1: Write the failing store test**
+
+Create `test/security/group_pending_invite_store_test.dart`:
+
+```dart
+// The pending-invite table is written by UNAUTHENTICATED inbound traffic:
+// POST /message authenticates nobody and its only rate limit is keyed on the
+// sender-claimed senderId (PrysmServer.dart:223-228). These tests pin the
+// three bounds that keep it from being a remote write primitive.
+import 'package:flutter_test/flutter_test.dart';
+import 'package:prysm/util/db_helper.dart';
+import 'package:prysm/util/group_pending_invite_store.dart';
+import 'package:sqflite_common_ffi/sqflite_ffi.dart';
+
+Future<Database> _openDb() async {
+  final db = await databaseFactory.openDatabase(
+    '${inMemoryDatabasePath}_${DateTime.now().microsecondsSinceEpoch}',
+    options: OpenDatabaseOptions(version: 1),
+  );
+  await GroupPendingInviteStore.ensureTable(db);
+  return db;
+}
+
+void main() {
+  late Database db;
+
+  setUpAll(() {
+    TestWidgetsFlutterBinding.ensureInitialized();
+    sqfliteFfiInit();
+    databaseFactory = databaseFactoryFfi;
+  });
+
+  setUp(() async {
+    db = await _openDb();
+    DBHelper.setDatabaseForTest(db);
+  });
+
+  tearDown(() async {
+    await db.close();
+    DBHelper.setDatabaseForTest(null);
+  });
+
+  test('a held invite comes back, newest first', () async {
+    expect(await GroupPendingInviteStore.hold(
+      senderId: 'a.onion',
+      wire: 'wire-a',
+    ), isTrue);
+    expect(await GroupPendingInviteStore.hold(
+      senderId: 'b.onion',
+      wire: 'wire-b',
+    ), isTrue);
+
+    final rows = await GroupPendingInviteStore.pending();
+    expect(rows, hasLength(2));
+    expect(rows.first['senderId'], 'b.onion');
+    expect(rows.first['wire'], 'wire-b');
+    expect(await GroupPendingInviteStore.count(), 2);
+  });
+
+  test('a second invite from the same sender replaces the first', () async {
+    await GroupPendingInviteStore.hold(senderId: 'a.onion', wire: 'first');
+    await GroupPendingInviteStore.hold(senderId: 'a.onion', wire: 'second');
+
+    final rows = await GroupPendingInviteStore.pending();
+    expect(rows, hasLength(1));
+    expect(rows.single['wire'], 'second');
+  });
+
+  test('the 21st distinct sender is refused and changes nothing', () async {
+    for (var i = 0; i < GroupPendingInviteStore.maxPendingSenders; i++) {
+      expect(
+        await GroupPendingInviteStore.hold(senderId: 's$i.onion', wire: 'w$i'),
+        isTrue,
+      );
+    }
+
+    expect(
+      await GroupPendingInviteStore.hold(
+        senderId: 'one-too-many.onion',
+        wire: 'w',
+      ),
+      isFalse,
+    );
+    expect(await GroupPendingInviteStore.count(),
+        GroupPendingInviteStore.maxPendingSenders);
+    // An existing sender may still refresh its own slot at capacity.
+    expect(
+      await GroupPendingInviteStore.hold(senderId: 's0.onion', wire: 'fresh'),
+      isTrue,
+    );
+  });
+
+  test('a row past the retention window is pruned, a fresh one is kept',
+      () async {
+    final now = DateTime.now().millisecondsSinceEpoch;
+    final expired = now - GroupPendingInviteStore.retention.inMilliseconds - 1;
+    final fresh = now - GroupPendingInviteStore.retention.inMilliseconds ~/ 2;
+    await db.insert('group_pending_invites', {
+      'senderId': 'old.onion',
+      'wire': 'old',
+      'receivedAt': expired,
+    });
+    await db.insert('group_pending_invites', {
+      'senderId': 'recent.onion',
+      'wire': 'recent',
+      'receivedAt': fresh,
+    });
+
+    expect(await GroupPendingInviteStore.count(), 1);
+    final rows = await GroupPendingInviteStore.pending();
+    expect(rows.single['senderId'], 'recent.onion');
+  });
+
+  test('take returns the wire once and deletes the row', () async {
+    await GroupPendingInviteStore.hold(senderId: 'a.onion', wire: 'wire-a');
+
+    expect(await GroupPendingInviteStore.take('a.onion'), 'wire-a');
+    expect(await GroupPendingInviteStore.take('a.onion'), isNull);
+    expect(await GroupPendingInviteStore.count(), 0);
+  });
+
+  test('discard removes the row without returning it', () async {
+    await GroupPendingInviteStore.hold(senderId: 'a.onion', wire: 'wire-a');
+
+    await GroupPendingInviteStore.discard('a.onion');
+    expect(await GroupPendingInviteStore.count(), 0);
+  });
+}
+```
+
+- [ ] **Step 2: Run it and watch it fail**
+
+Run: `flutter test test/security/group_pending_invite_store_test.dart`
+Expected: compile failure — `Couldn't resolve the package 'prysm/util/group_pending_invite_store.dart'`.
+
+- [ ] **Step 3: Write the store**
+
+Create `lib/util/group_pending_invite_store.dart`. Structure (private ctor, one static `Mutex`,
+`ensureTable` with `CREATE TABLE IF NOT EXISTS`) copied from
+`lib/util/group_sender_index_store.dart:7-70`:
+
+```dart
+import 'package:mutex/mutex.dart';
+import 'package:prysm/util/db_helper.dart';
+import 'package:sqflite_common_ffi/sqflite_ffi.dart';
+
+/// Group invites received from a sender whose identity is not in the local
+/// user store, kept so the user can decide instead of losing them silently.
+///
+/// The stored [wire] is the raw `control-wrap-2` envelope and is NEVER
+/// decrypted while pending: it is unauthenticated, attacker-controlled input,
+/// so nothing from it may reach the UI or be parsed into the database. It is
+/// only ever replayed through the normal authenticated path once the sender's
+/// identity is locally known.
+///
+/// This table is written by unauthenticated traffic — `POST /message`
+/// authenticates nobody and its only rate limit is keyed on the
+/// sender-claimed `senderId` — so all three bounds below are load-bearing,
+/// not tuning.
+class GroupPendingInviteStore {
+  GroupPendingInviteStore._();
+
+  static final Mutex _mutex = Mutex();
+
+  /// How many distinct senders may hold a pending invite at once.
+  ///
+  /// At capacity a NEW sender is refused rather than evicting the oldest
+  /// row: eviction would let an attacker with cheap throwaway onions delete
+  /// a genuine request, while refusal only degrades to the drop that was the
+  /// accepted behaviour before this feature existed.
+  static const int maxPendingSenders = 20;
+
+  /// How long a pending invite survives without a decision. Bounds the table
+  /// in time as well as in rows, so one filled by an attacker frees itself
+  /// with no user action.
+  static const Duration retention = Duration(days: 7);
+
+  static Future<void> ensureTable(Database db) async {
+    await db.execute('''
+      CREATE TABLE IF NOT EXISTS group_pending_invites (
+        senderId TEXT PRIMARY KEY,
+        wire TEXT NOT NULL,
+        receivedAt INTEGER NOT NULL
+      )
+    ''');
+  }
+
+  /// Keeps [wire] as the pending invite for [senderId], replacing any
+  /// previous one from the same sender. Returns false when the global cap
+  /// refuses a new sender; the caller drops the invite exactly as it would
+  /// with the feature off.
+  static Future<bool> hold({
+    required String senderId,
+    required String wire,
+  }) async {
+    return _mutex.protect(() async {
+      final db = await DBHelper.database;
+      await _pruneExpired(db);
+
+      final existing = await db.query(
+        'group_pending_invites',
+        columns: ['senderId'],
+        where: 'senderId = ?',
+        whereArgs: [senderId],
+        limit: 1,
+      );
+      if (existing.isEmpty && await _count(db) >= maxPendingSenders) {
+        return false;
+      }
+
+      await db.insert(
+        'group_pending_invites',
+        {
+          'senderId': senderId,
+          'wire': wire,
+          'receivedAt': DateTime.now().millisecondsSinceEpoch,
+        },
+        conflictAlgorithm: ConflictAlgorithm.replace,
+      );
+      return true;
+    });
+  }
+
+  /// Pending invites, newest first. Expired rows are pruned first, so a
+  /// caller never sees a row it must filter itself.
+  static Future<List<Map<String, Object?>>> pending() async {
+    return _mutex.protect(() async {
+      final db = await DBHelper.database;
+      await _pruneExpired(db);
+      return db.query('group_pending_invites', orderBy: 'receivedAt DESC');
+    });
+  }
+
+  static Future<int> count() async {
+    return _mutex.protect(() async {
+      final db = await DBHelper.database;
+      await _pruneExpired(db);
+      return _count(db);
+    });
+  }
+
+  /// Returns the held envelope for [senderId] and deletes the row in the
+  /// same critical section, so a second caller cannot replay it.
+  static Future<String?> take(String senderId) async {
+    return _mutex.protect(() async {
+      final db = await DBHelper.database;
+      final rows = await db.query(
+        'group_pending_invites',
+        where: 'senderId = ?',
+        whereArgs: [senderId],
+        limit: 1,
+      );
+      if (rows.isEmpty) return null;
+      await db.delete(
+        'group_pending_invites',
+        where: 'senderId = ?',
+        whereArgs: [senderId],
+      );
+      return rows.first['wire'] as String?;
+    });
+  }
+
+  static Future<void> discard(String senderId) async {
+    await _mutex.protect(() async {
+      final db = await DBHelper.database;
+      await db.delete(
+        'group_pending_invites',
+        where: 'senderId = ?',
+        whereArgs: [senderId],
+      );
+    });
+  }
+
+  static Future<int> _count(Database db) async {
+    return Sqflite.firstIntValue(
+          await db.rawQuery('SELECT COUNT(*) FROM group_pending_invites'),
+        ) ??
+        0;
+  }
+
+  static Future<void> _pruneExpired(Database db) async {
+    final cutoff =
+        DateTime.now().millisecondsSinceEpoch - retention.inMilliseconds;
+    await db.delete(
+      'group_pending_invites',
+      where: 'receivedAt < ?',
+      whereArgs: [cutoff],
+    );
+  }
+}
+```
+
+- [ ] **Step 4: Wire the schema**
+
+In `lib/util/db_helper.dart`:
+
+1. import `package:prysm/util/group_pending_invite_store.dart` beside the
+   `group_sender_index_store.dart` import;
+2. `version: 13,` at `:64` becomes `version: 14,`;
+3. `_createCryptoTables` gains the new table:
+
+```dart
+  static Future<void> _createCryptoTables(Database db) async {
+    await RatchetSessionStore.ensureTable(db);
+    await GroupSenderIndexStore.ensureTable(db);
+    await GroupPendingInviteStore.ensureTable(db);
+  }
+```
+
+4. a new ladder step, appended immediately after the `if (oldVersion < 13) { ... }` block that
+   ends at `:217`, in the same shape as its neighbour:
+
+```dart
+      if (oldVersion < 14) {
+        // group_pending_invites (the bounded store for invites from senders
+        // whose identity is not local yet) is created by
+        // GroupPendingInviteStore.ensureTable. Every ensureTable in
+        // _createCryptoTables is CREATE TABLE IF NOT EXISTS, so replaying
+        // the step on a database that already has the other crypto tables
+        // only adds the missing one.
+        await _createCryptoTables(db);
+      }
+```
+
+- [ ] **Step 5: Run the store test and watch it pass**
+
+Run: `flutter test test/security/group_pending_invite_store_test.dart`
+Expected: `+6: All tests passed!`
+
+- [ ] **Step 6: Write the failing upgrade test**
+
+Create `test/security/chat_db_v13_v14_upgrade_test.dart` by copying
+`test/security/chat_db_v10_v11_upgrade_test.dart` and adapting it:
+
+- keep `setUpAll` (`sqfliteFfiInit`, `databaseFactory = databaseFactoryFfi`), `setUp` (temp dir,
+  `CryptoKeyStore.setUseInMemoryStorageOnly(true)`, the `path_provider` MethodChannel mock) and
+  `tearDown` (`DBHelper.closeForWipe()`, `DBHelper.setDatabaseForTest(null)`, delete temp dir)
+  **verbatim** from the existing file;
+- write a `buildV13Fixture` modelled on that file's `buildV11Fixture`: open the file directly
+  with `databaseFactory.openDatabase(path, options: OpenDatabaseOptions(singleInstance: false))`,
+  create every table the v13 schema has by calling the real helpers
+  (`DBHelper` group tables DDL copied as the existing fixture does,
+  `ConversationPreferencesDb.createTable`, `BlockedUsersDb.createTable`,
+  `CallLogsDb.createTable`, `RatchetSessionStore.ensureTable`,
+  `GroupSenderIndexStore.ensureTable`), seed one `users` row and one
+  `group_sender_index` row with `nextIndex = 7`, set `PRAGMA user_version = 13`;
+- fixture guards, each its own `expect` (a single `isNot(containsAll([...]))` is satisfied by
+  the absence of one element and would be vacuous — this is the CN4 lesson from PR #128):
+
+```dart
+    final tables = await db.rawQuery(
+      "SELECT name FROM sqlite_master WHERE type='table' AND name=?",
+      ['group_pending_invites'],
+    );
+    expect(tables, isEmpty, reason: 'the v13 fixture must not have the table');
+    expect(
+      Sqflite.firstIntValue(await db.rawQuery('PRAGMA user_version')),
+      13,
+    );
+```
+
+- the test body:
+
+```dart
+  test('v13 -> v14 adds group_pending_invites and keeps existing rows',
+      () async {
+    await buildV13Fixture();
+
+    final db = await DBHelper.database;
+
+    expect(Sqflite.firstIntValue(await db.rawQuery('PRAGMA user_version')), 14);
+    expect(
+      await db.rawQuery(
+        "SELECT name FROM sqlite_master WHERE type='table' AND name=?",
+        ['group_pending_invites'],
+      ),
+      hasLength(1),
+    );
+    // The upgrade is not allowed to lose what was already there.
+    expect(await db.query('users'), hasLength(1));
+    expect(
+      (await db.query('group_sender_index')).single['nextIndex'],
+      7,
+    );
+    // The upgraded file works with the real store, not just the schema.
+    expect(
+      await GroupPendingInviteStore.hold(
+        senderId: 'a.onion',
+        wire: 'wire-a',
+      ),
+      isTrue,
+    );
+    expect(await GroupPendingInviteStore.count(), 1);
+  });
+```
+
+- [ ] **Step 7: Run the upgrade test and watch it pass**
+
+Run: `flutter test test/security/chat_db_v13_v14_upgrade_test.dart`
+Expected: `+1: All tests passed!`
+
+Then prove the fixture guard bites: temporarily add
+`await GroupPendingInviteStore.ensureTable(db);` to `buildV13Fixture`, re-run, and confirm the
+guard fails with `the v13 fixture must not have the table`. Remove it and re-run green. A guard
+that cannot fail is worse than no guard.
+
+- [ ] **Step 8: Commit (controller)**
+
+```bash
+git add lib/util/group_pending_invite_store.dart lib/util/db_helper.dart \
+        test/security/group_pending_invite_store_test.dart \
+        test/security/chat_db_v13_v14_upgrade_test.dart
+git commit -m "feat(group): add a bounded store for pending first-contact invites"
+```
+
+---
+
+### Task 3: Hold the invite at the drop branch
+
+**Files:**
+- Modify: `lib/services/group_service.dart` (`:481-499` — the comment block and the `senderKeys == null` branch)
+- Test: `test/security/group_invite_mode_test.dart`
+
+**Interfaces:**
+- Consumes: `SettingsService().groupInviteMode` (Task 1),
+  `GroupPendingInviteStore.hold(...)` / `.count()` / `.pending()` (Task 2).
+- Produces: no new API. Behavioural contract: in `holdAsRequest` mode a `group_invite` from an
+  unresolvable sender leaves exactly one `group_pending_invites` row; everything else about the
+  drop is unchanged.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `test/security/group_invite_mode_test.dart`. Copy the harness from
+`test/security/group_profile_fetch_gate_test.dart` — `_publicKeys`, `_openMessagesDb`,
+`_openDbHelperDb` (add `await GroupPendingInviteStore.ensureTable(db);` next to the
+`GroupSenderIndexStore.ensureTable(db)` call), `_inviteMessage`, the `_ProfileNetworkOverrides`
+fake HTTP layer, and the `setUpAll`/`setUp`/`tearDown` blocks — then:
+
+```dart
+  group('group invite mode', () {
+    setUp(() {
+      SharedPreferences.setMockInitialValues({});
+    });
+
+    tearDown(() async {
+      await SettingsService().setGroupInviteMode(GroupInviteMode.holdAsRequest);
+    });
+
+    test(
+      'contactsOnly: an invite from an unresolvable sender is dropped and '
+      'nothing is stored', () async {
+        await SettingsService().setGroupInviteMode(
+          GroupInviteMode.contactsOnly,
+        );
+        final inviter = await IdentityKeyPair.generate();
+        peerProfiles['stranger.onion'] =
+            jsonEncode(await inviter.toPublicJson());
+
+        final result = await router.handleMessage(await _inviteMessage(
+          id: 'm1',
+          inviterId: 'stranger.onion',
+          inviter: inviter,
+          recipient: localIdentity,
+          groupId: 'g1',
+        ));
+
+        expect(result.statusCode, 200);
+        expect(await GroupPendingInviteStore.count(), 0);
+        expect(await dbHelperDb.query('groups'), isEmpty);
+        expect(fetched, isEmpty);
+      },
+    );
+
+    test(
+      'holdAsRequest: the same invite is held exactly once, and still creates '
+      'no group and no fetch', () async {
+        final inviter = await IdentityKeyPair.generate();
+        peerProfiles['stranger.onion'] =
+            jsonEncode(await inviter.toPublicJson());
+        final invite = await _inviteMessage(
+          id: 'm1',
+          inviterId: 'stranger.onion',
+          inviter: inviter,
+          recipient: localIdentity,
+          groupId: 'g1',
+        );
+
+        final result = await router.handleMessage(invite);
+        // A retry of the same envelope must not create a second row.
+        await router.handleMessage({...invite, 'id': 'm2'});
+
+        expect(result.statusCode, 200);
+        final rows = await GroupPendingInviteStore.pending();
+        expect(rows, hasLength(1));
+        expect(rows.single['senderId'], 'stranger.onion');
+        expect(rows.single['wire'], invite['message']);
+        expect(await dbHelperDb.query('groups'), isEmpty);
+        expect(await dbHelperDb.query('group_members'), isEmpty);
+        expect(await dbHelperDb.query('group_keys'), isEmpty);
+        expect(fetched, isEmpty);
+      },
+    );
+
+    test(
+      'holdAsRequest holds invites only: a key rotate from an unresolvable '
+      'sender is dropped and stored nowhere', () async {
+        final stranger = await IdentityKeyPair.generate();
+        final result = await router.handleMessage({
+          'id': 'm1',
+          'senderId': 'stranger.onion',
+          'receiverId': 'local.onion',
+          'message': await GroupCryptoV2.encryptControlPayload(
+            jsonEncode({'groupId': 'g1', 'keyVersion': 2}),
+            stranger,
+            await localIdentity.agreePublicKey,
+          ),
+          'type': groupKeyRotateType,
+          'timestamp': 1000,
+        });
+
+        expect(result.statusCode, 200);
+        expect(await GroupPendingInviteStore.count(), 0);
+      },
+    );
+  });
+```
+
+- [ ] **Step 2: Run it and watch it fail**
+
+Run: `flutter test test/security/group_invite_mode_test.dart`
+Expected: the `holdAsRequest` test fails with `Expected: an object with length of <1> / Actual:
+[] (length 0)` — nothing is held yet. The other two already pass; that is correct, they are the
+guards that the change does not overreach.
+
+- [ ] **Step 3: Implement the hold**
+
+In `lib/services/group_service.dart`, add the imports
+(`package:prysm/models/group_invite_mode.dart`, `package:prysm/services/settings_service.dart`,
+`package:prysm/util/group_pending_invite_store.dart`), add the settings field to the class body
+beside the other fields — the convention is `ReadReceiptService`'s
+(`lib/services/read_receipt_service.dart:94`):
+
+```dart
+  final SettingsService _settings = SettingsService();
+```
+
+then replace the comment block and the null branch (`:482-499`) with:
+
+```dart
+    // Accepted policy (option 1, PR #128): a control message from a sender
+    // whose identity is not in the local store is not processed. The
+    // identity is required to *authenticate* it: decryptControlPayload
+    // below verifies the control-wrap-2 signature against it, so without it
+    // the payload can only be read unverified — which is exactly what must
+    // not happen. Do not "fix" this by resolving the sender over the network
+    // on cache-miss: that would reopen the M2 profile-fetch oracle (an
+    // unauthenticated sender forcing GET /profile as an implicit delivery
+    // receipt) before any signature check.
+    //
+    // What the user can choose (GroupInviteMode) is only what happens to an
+    // *invite* afterwards: dropped outright, or held opaque and bounded for
+    // the user to accept — never processed, never decrypted, and never a
+    // reason to send anything.
+    if (senderKeys == null) {
+      if (type == groupInviteType &&
+          _settings.groupInviteMode == GroupInviteMode.holdAsRequest) {
+        final held = await GroupPendingInviteStore.hold(
+          senderId: senderId,
+          wire: encryptedPayload,
+        );
+        if (!held) {
+          Logging.error(
+            'Pending invite store full, dropping invite from '
+            '${Logging.redactOnion(senderId)}',
+            'GroupService',
+          );
+        }
+      }
+      Logging.error(
+        'Dropping $type from ${Logging.redactOnion(senderId)}: '
+        'sender identity unresolvable',
+        'GroupService',
+      );
+      return false;
+    }
+```
+
+- [ ] **Step 4: Run the test and watch it pass**
+
+Run: `flutter test test/security/group_invite_mode_test.dart`
+Expected: `+3: All tests passed!`
+
+- [ ] **Step 5: Prove the merged policy tests still hold**
+
+Run: `flutter test test/security/group_profile_fetch_gate_test.dart`
+Expected: `+9: All tests passed!` — with their assertions unchanged. If a `POLICY:` test needed
+editing, the change overreached: stop and report.
+
+- [ ] **Step 6: Commit (controller)**
+
+```bash
+git add lib/services/group_service.dart test/security/group_invite_mode_test.dart
+git commit -m "feat(group): hold first-contact invites when the user asked for it"
+```
+
+---
+
+### Task 4: Promotion
+
+**Files:**
+- Create: `lib/services/group_invite_promoter.dart`
+- Modify: `lib/screens/home/home_screen.dart` (one-shot sweep in `initState`, after the
+  `loadUsers()` chain that ends at `:397` and before `_startAutoRefresh();` at `:404`)
+- Test: `test/security/group_invite_mode_test.dart` (extend)
+
+**Interfaces:**
+- Consumes: `GroupPendingInviteStore.take/pending/discard` (Task 2),
+  `GroupService.handleIncomingControlMessage` (existing).
+- Produces:
+  - `GroupInvitePromoter({required String userId, required KeyManager keyManager, GroupService? groupService})`
+  - `Future<bool> promote(String senderId)` — true when the invite authenticated and applied
+  - `Future<int> promoteResolvable()` — promotes every pending row whose sender is now in the
+    local user store; returns how many applied
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `test/security/group_invite_mode_test.dart`:
+
+```dart
+  group('promotion', () {
+    test(
+      'once the inviter identity is stored, the held invite applies and the '
+      'row is gone', () async {
+        final inviter = await IdentityKeyPair.generate();
+        final invite = await _inviteMessage(
+          id: 'm1',
+          inviterId: 'stranger.onion',
+          inviter: inviter,
+          recipient: localIdentity,
+          groupId: 'g1',
+        );
+        await router.handleMessage(invite);
+        expect(await GroupPendingInviteStore.count(), 1);
+
+        // What "the user added the contact" leaves behind.
+        final json = jsonEncode(await inviter.toPublicJson());
+        await DBHelper.insertOrUpdateUser({
+          'id': 'stranger.onion',
+          'name': 'Stranger',
+          'identityJson': json,
+          'publicKeyPem': json,
+        });
+
+        final promoter = GroupInvitePromoter(
+          userId: 'local.onion',
+          keyManager: KeyManager.fromIdentity(localIdentity),
+        );
+        expect(await promoter.promote('stranger.onion'), isTrue);
+
+        expect(await GroupPendingInviteStore.count(), 0);
+        expect((await dbHelperDb.query('groups')).single['id'], 'g1');
+        expect(await dbHelperDb.query('group_members'), hasLength(2));
+      },
+    );
+
+    test('a tampered held envelope is discarded and creates no group',
+        () async {
+      final inviter = await IdentityKeyPair.generate();
+      final json = jsonEncode(await inviter.toPublicJson());
+      await DBHelper.insertOrUpdateUser({
+        'id': 'stranger.onion',
+        'name': 'Stranger',
+        'identityJson': json,
+        'publicKeyPem': json,
+      });
+      await GroupPendingInviteStore.hold(
+        senderId: 'stranger.onion',
+        wire: 'not-a-control-envelope',
+      );
+
+      final promoter = GroupInvitePromoter(
+        userId: 'local.onion',
+        keyManager: KeyManager.fromIdentity(localIdentity),
+      );
+      expect(await promoter.promote('stranger.onion'), isFalse);
+
+      expect(await GroupPendingInviteStore.count(), 0);
+      expect(await dbHelperDb.query('groups'), isEmpty);
+    });
+
+    test('the sweep promotes only the senders that became resolvable',
+        () async {
+      final known = await IdentityKeyPair.generate();
+      final unknown = await IdentityKeyPair.generate();
+      await router.handleMessage(await _inviteMessage(
+        id: 'm1',
+        inviterId: 'known.onion',
+        inviter: known,
+        recipient: localIdentity,
+        groupId: 'g1',
+      ));
+      await router.handleMessage(await _inviteMessage(
+        id: 'm2',
+        inviterId: 'unknown.onion',
+        inviter: unknown,
+        recipient: localIdentity,
+        groupId: 'g2',
+      ));
+      final json = jsonEncode(await known.toPublicJson());
+      await DBHelper.insertOrUpdateUser({
+        'id': 'known.onion',
+        'name': 'Known',
+        'identityJson': json,
+        'publicKeyPem': json,
+      });
+
+      final promoted = await GroupInvitePromoter(
+        userId: 'local.onion',
+        keyManager: KeyManager.fromIdentity(localIdentity),
+      ).promoteResolvable();
+
+      expect(promoted, 1);
+      expect((await dbHelperDb.query('groups')).single['id'], 'g1');
+      final rows = await GroupPendingInviteStore.pending();
+      expect(rows.single['senderId'], 'unknown.onion');
+    });
+  });
+```
+
+- [ ] **Step 2: Run it and watch it fail**
+
+Run: `flutter test test/security/group_invite_mode_test.dart`
+Expected: compile failure — `Couldn't resolve the package 'prysm/services/group_invite_promoter.dart'`.
+
+- [ ] **Step 3: Write the promoter**
+
+Create `lib/services/group_invite_promoter.dart`:
+
+```dart
+import 'package:prysm/constants/group_constants.dart';
+import 'package:prysm/services/group_service.dart';
+import 'package:prysm/util/group_pending_invite_store.dart';
+import 'package:prysm/util/key_manager.dart';
+import 'package:prysm/util/logging.dart';
+import 'package:prysm/util/peer_identity_loader.dart';
+
+/// Replays a held first-contact invite once its sender's identity is in the
+/// local user store.
+///
+/// Promotion never bypasses authentication: the held envelope goes through
+/// [GroupService.handleIncomingControlMessage], the same path the message
+/// would have taken had the sender been known when it arrived. The row is
+/// removed either way — an envelope that fails to authenticate is garbage,
+/// and keeping it would let a failed attempt be retried forever.
+class GroupInvitePromoter {
+  GroupInvitePromoter({
+    required this.userId,
+    required this.keyManager,
+    GroupService? groupService,
+  }) : _groupService = groupService ??
+            GroupService(userId: userId, keyManager: keyManager);
+
+  final String userId;
+  final KeyManager keyManager;
+  final GroupService _groupService;
+
+  Future<bool> promote(String senderId) async {
+    final wire = await GroupPendingInviteStore.take(senderId);
+    if (wire == null) return false;
+    try {
+      return await _groupService.handleIncomingControlMessage(
+        groupInviteType,
+        wire,
+        senderId,
+      );
+    } catch (e) {
+      Logging.error(
+        'Promoting the held invite from ${Logging.redactOnion(senderId)} '
+        'failed: $e',
+        'GroupInvitePromoter',
+      );
+      return false;
+    }
+  }
+
+  /// Promotes every pending invite whose sender is now locally known.
+  /// Returns how many were applied.
+  Future<int> promoteResolvable() async {
+    final rows = await GroupPendingInviteStore.pending();
+    var promoted = 0;
+    for (final row in rows) {
+      final senderId = row['senderId'] as String;
+      if (await loadPeerIdentityFromDb(keyManager, senderId) == null) continue;
+      if (await promote(senderId)) promoted++;
+    }
+    return promoted;
+  }
+}
+```
+
+- [ ] **Step 4: Run the test and watch it pass**
+
+Run: `flutter test test/security/group_invite_mode_test.dart`
+Expected: `+6: All tests passed!`
+
+- [ ] **Step 5: Wire the one-shot sweep**
+
+In `lib/screens/home/home_screen.dart`, import
+`package:prysm/services/group_invite_promoter.dart` and insert, in `initState` immediately
+before `_startAutoRefresh();` (`:404`):
+
+```dart
+    // Invites held while their sender was unknown apply themselves once the
+    // contact exists — including when the user added them from somewhere
+    // else entirely. Skipped in decoy mode: a panic session must not touch
+    // real group state.
+    if (!widget.decoyMode) {
+      unawaited(
+        GroupInvitePromoter(
+          userId: widget.onionAddress,
+          keyManager: widget.keyManager,
+        ).promoteResolvable().then((promoted) {
+          if (promoted > 0 && mounted) scheduleLoadUsers(light: true);
+        }).catchError((Object e, StackTrace st) {
+          Logging.error('Promoting held invites failed: $e\n$st', 'Main');
+          return 0;
+        }),
+      );
+    }
+```
+
+- [ ] **Step 6: Verify the app still analyses clean**
+
+Run: `flutter analyze lib/screens/home/home_screen.dart lib/services/group_invite_promoter.dart`
+Expected: `No issues found!`
+
+- [ ] **Step 7: Commit (controller)**
+
+```bash
+git add lib/services/group_invite_promoter.dart lib/screens/home/home_screen.dart \
+        test/security/group_invite_mode_test.dart
+git commit -m "feat(group): promote held invites once the sender becomes known"
+```
+
+---
+
+### Task 5: The setting UI
+
+**Files:**
+- Modify: `lib/screens/privacy_settings_screen.dart` (new section after the existing
+  `PrysmSection` that ends at `:136`, before the `Emergency` block at `:137`)
+
+**Interfaces:**
+- Consumes: `GroupInviteMode`, `SettingsService().groupInviteMode` / `.setGroupInviteMode`
+  (Task 1).
+- Produces: nothing consumed by later tasks.
+
+- [ ] **Step 1: Add the state field and handler**
+
+In `_PrivacySettingsScreenState`, beside the existing `bool _showOnlineStatus = true;` fields:
+
+```dart
+  GroupInviteMode _groupInviteMode = SettingsService().groupInviteMode;
+```
+
+and beside the other handlers (after `_onTypingIndicatorsToggle`):
+
+```dart
+  Future<void> _onGroupInviteModeChanged(GroupInviteMode? value) async {
+    if (value == null || value == _groupInviteMode) return;
+    setState(() => _groupInviteMode = value);
+    await settings.setGroupInviteMode(value);
+  }
+```
+
+- [ ] **Step 2: Render both modes with their descriptions**
+
+Import `package:prysm/models/group_invite_mode.dart` and
+`package:prysm/ui/core/prysm_radio.dart`, then insert between the closing `),` of the first
+`PrysmSection` (`:136`) and `if (widget.keyManager != null) ...[` (`:137`):
+
+```dart
+              const SizedBox(height: 30),
+              Text('Group invites', style: style.headlineStyle),
+              const SizedBox(height: 12),
+              PrysmSection(
+                children: [
+                  for (final mode in GroupInviteMode.values)
+                    PrysmRadioRow<GroupInviteMode>(
+                      value: mode,
+                      groupValue: _groupInviteMode,
+                      title: mode.label,
+                      subtitle: mode.description,
+                      onChanged: _onGroupInviteModeChanged,
+                    ),
+                ],
+              ),
+```
+
+Both rows are rendered inline, not behind a bottom sheet like
+`panic_pin_settings_screen.dart:133-145`: the point of this screen is that the user reads what
+**both** modes imply before choosing.
+
+- [ ] **Step 3: Verify it analyses clean**
+
+Run: `flutter analyze lib/screens/privacy_settings_screen.dart`
+Expected: `No issues found!`
+
+- [ ] **Step 4: Smoke test on the desktop build**
+
+Run: `flutter run -d linux`
+Navigate: Settings → Advanced Privacy. Confirm: a `Group invites` section with two rows,
+`Hold invites from unknown senders` selected, both descriptions readable, and that tapping the
+other row moves the dot. Close and reopen the screen: the choice must persist.
+
+- [ ] **Step 5: Commit (controller)**
+
+```bash
+git add lib/screens/privacy_settings_screen.dart
+git commit -m "feat(settings): let the user pick how unknown-sender invites are handled"
+```
+
+---
+
+### Task 6: The requests screen and its two entry points
+
+**Files:**
+- Create: `lib/screens/invite_requests_screen.dart`
+- Modify: `lib/screens/settings_screen.dart` (navigation tile beside `Blocked contacts`, `:672-684`)
+- Modify: `lib/screens/home/home_screen.dart` (`_sidebarFooterCount` at `:177-184`; the footer
+  branch in the sidebar `ListView.builder` at `:1461-1513`; a `_pendingInviteCount` field
+  refreshed in `loadUsers`)
+
+**Interfaces:**
+- Consumes: `GroupPendingInviteStore.pending/discard/count` (Task 2),
+  `GroupInvitePromoter.promote` (Task 4), `ContactAddService.instance.addContact` (existing,
+  `lib/services/contact_add_service.dart:65-135`).
+- Produces: `InviteRequestsScreen({required VoidCallback onClose, required String onionAddress, required KeyManager keyManager, VoidCallback? onChanged})`.
+
+- [ ] **Step 1: Write the screen**
+
+Create `lib/screens/invite_requests_screen.dart`, modelled on
+`lib/screens/blocked_contacts_screen.dart:18-162` (same `PrysmPage` + `ListView.separated` +
+`PrysmListRow` shape, same `_shortOnion` helper):
+
+```dart
+import 'dart:async';
+
+import 'package:flutter/widgets.dart';
+import 'package:prysm/screens/widgets/contact_avatar.dart';
+import 'package:prysm/services/contact_add_service.dart';
+import 'package:prysm/services/group_invite_promoter.dart';
+import 'package:prysm/theme/prysm_style_scope.dart';
+import 'package:prysm/ui/core/prysm_button.dart';
+import 'package:prysm/ui/core/prysm_dialog.dart';
+import 'package:prysm/ui/core/prysm_divider.dart';
+import 'package:prysm/ui/core/prysm_icons.dart';
+import 'package:prysm/ui/core/prysm_list_row.dart';
+import 'package:prysm/ui/core/prysm_progress.dart';
+import 'package:prysm/ui/prysm_scaffold.dart';
+import 'package:prysm/util/group_pending_invite_store.dart';
+import 'package:prysm/util/key_manager.dart';
+import 'package:prysm/util/onion_id_codec.dart';
+
+/// Group invites received from senders who are not in the local contacts.
+///
+/// Only the sender's address and the arrival time are shown: the invite
+/// itself is still encrypted and unauthenticated, so nothing inside it —
+/// group name, avatar, roster — may be displayed. Accepting adds the contact
+/// (the only network call in this flow, and it is the user's own action) and
+/// then replays the invite through the authenticated path.
+class InviteRequestsScreen extends StatefulWidget {
+  final VoidCallback onClose;
+  final String onionAddress;
+  final KeyManager keyManager;
+  final VoidCallback? onChanged;
+
+  const InviteRequestsScreen({
+    required this.onClose,
+    required this.onionAddress,
+    required this.keyManager,
+    this.onChanged,
+    super.key,
+  });
+
+  @override
+  State<InviteRequestsScreen> createState() => _InviteRequestsScreenState();
+}
+
+class _InviteRequestsScreenState extends State<InviteRequestsScreen> {
+  List<Map<String, Object?>> _rows = const [];
+  bool _loading = true;
+  String? _busySenderId;
+
+  @override
+  void initState() {
+    super.initState();
+    unawaited(_load());
+  }
+
+  Future<void> _load() async {
+    final rows = await GroupPendingInviteStore.pending();
+    if (!mounted) return;
+    setState(() {
+      _rows = rows;
+      _loading = false;
+    });
+    widget.onChanged?.call();
+  }
+
+  String _shortOnion(String onion) {
+    try {
+      final encoded = encodeOnionToBase58(onion);
+      if (encoded.length <= 12) return encoded;
+      return '${encoded.substring(0, 6)}…${encoded.substring(encoded.length - 4)}';
+    } catch (_) {
+      if (onion.length <= 12) return onion;
+      return '${onion.substring(0, 6)}…';
+    }
+  }
+
+  static String _two(int v) => v.toString().padLeft(2, '0');
+
+  String _receivedLabel(int receivedAt) {
+    final at = DateTime.fromMillisecondsSinceEpoch(receivedAt);
+    return '${at.year}-${_two(at.month)}-${_two(at.day)} '
+        '${_two(at.hour)}:${_two(at.minute)}';
+  }
+
+  Future<void> _accept(String senderId) async {
+    setState(() => _busySenderId = senderId);
+    try {
+      final added = await ContactAddService.instance.addContact(
+        onionId: senderId,
+        displayName: '',
+      );
+      if (!mounted) return;
+      if (!added) {
+        await showPrysmDialog<void>(
+          context: context,
+          title: 'Could not reach this contact',
+          content: const Text(
+            'The invite is still waiting. Try again when they are online.',
+          ),
+          confirmLabel: 'OK',
+          onConfirm: () => Navigator.of(context).pop(),
+        );
+        return;
+      }
+      await GroupInvitePromoter(
+        userId: widget.onionAddress,
+        keyManager: widget.keyManager,
+      ).promote(senderId);
+    } finally {
+      if (mounted) setState(() => _busySenderId = null);
+    }
+    await _load();
+  }
+
+  Future<void> _discard(String senderId) async {
+    final confirmed = await showPrysmConfirmDialog(
+      context: context,
+      title: 'Discard invite',
+      content: const Text('This request will be removed.'),
+      cancelLabel: 'Cancel',
+      confirmLabel: 'Discard',
+    );
+    if (confirmed != true) return;
+    await GroupPendingInviteStore.discard(senderId);
+    await _load();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return PrysmPage(
+      title: 'Invite requests',
+      leading: PrysmIconButton(
+        icon: PrysmIcons.arrowBack,
+        onPressed: widget.onClose,
+      ),
+      body: _loading
+          ? const Center(child: PrysmProgressIndicator())
+          : _rows.isEmpty
+              ? Center(
+                  child: Text(
+                    'No invite requests',
+                    style: TextStyle(
+                      color: context.prysmStyle.tokens.textMuted,
+                    ),
+                  ),
+                )
+              : ListView.separated(
+                  padding: const EdgeInsets.symmetric(vertical: 8),
+                  itemCount: _rows.length,
+                  separatorBuilder: (context, index) => const PrysmDivider(),
+                  itemBuilder: (context, index) {
+                    final row = _rows[index];
+                    final senderId = row['senderId'] as String;
+                    final short = _shortOnion(senderId);
+                    final busy = _busySenderId == senderId;
+
+                    return PrysmListRow(
+                      leading: ContactAvatar(name: short, avatarBase64: null),
+                      title: short,
+                      subtitleWidget: Text(
+                        'Group invite · ${_receivedLabel(row['receivedAt'] as int)}',
+                        style: const TextStyle(fontSize: 12),
+                      ),
+                      trailing: busy
+                          ? const PrysmProgressIndicator()
+                          : Row(
+                              mainAxisSize: MainAxisSize.min,
+                              children: [
+                                PrysmTextButton(
+                                  label: 'Discard',
+                                  onPressed: () => _discard(senderId),
+                                ),
+                                PrysmTextButton(
+                                  label: 'Add contact and join',
+                                  onPressed: () => _accept(senderId),
+                                ),
+                              ],
+                            ),
+                    );
+                  },
+                ),
+    );
+  }
+}
+```
+
+`showPrysmDialog<void>` is the info-dialog form: `confirmLabel`/`cancelLabel` are nullable and
+only the buttons you name are rendered (`lib/ui/core/prysm_dialog.dart:38-66`).
+`showPrysmConfirmDialog` (`:6-36`) is the two-button form used for `Discard`.
+
+- [ ] **Step 2: Add the Settings entry point**
+
+In `lib/screens/settings_screen.dart`, after the `Blocked contacts` tile and its
+`const PrysmDivider(),` (`:672-685`), and only when the screen has what the new screen needs:
+
+```dart
+                if (widget.keyManager != null && widget.onionAddress != null) ...[
+                  _buildNavigationTile(
+                    'Invite requests',
+                    PrysmIcons.group,
+                    () {
+                      Navigator.push(
+                        context,
+                        PrysmPageRoute(
+                          page: InviteRequestsScreen(
+                            onClose: () => Navigator.of(context).pop(),
+                            onionAddress: widget.onionAddress!,
+                            keyManager: widget.keyManager!,
+                          ),
+                        ),
+                      );
+                    },
+                  ),
+                  const PrysmDivider(),
+                ],
+```
+
+`PrysmIcons.group` is `CupertinoIcons.person_2` (`lib/ui/core/prysm_icons.dart:88`). There is
+no `groupOutlined` constant in that file.
+
+- [ ] **Step 3: Add the sidebar footer row**
+
+In `lib/screens/home/home_screen.dart`:
+
+1. a state field beside the other counters:
+
+```dart
+  int _pendingInviteCount = 0;
+```
+
+2. refresh it inside `loadUsers`, in the same `Future.wait` batches that already load the
+   counters (`:802-811` and `:822-827`), or — simpler and equally correct — right before
+   `_applyLoadedUsers` is called at `:858`:
+
+```dart
+      final pendingInvites = await GroupPendingInviteStore.count();
+      if (!mounted) return;
+      _pendingInviteCount = pendingInvites;
+```
+
+3. count it in `_sidebarFooterCount` (`:177-184`):
+
+```dart
+    if (_pendingInviteCount > 0) count++;
+```
+
+4. render it as the first footer row, before the `Archived` branch, adjusting the branch indices
+   so each footer row keeps its own slot:
+
+```dart
+                  if (_pendingInviteCount > 0 && footerIndex == 0) {
+                    return Padding(
+                      padding: const EdgeInsets.symmetric(
+                        horizontal: 8,
+                        vertical: 2,
+                      ),
+                      child: PrysmListRow(
+                        leading: Icon(
+                          PrysmIcons.group,
+                          color: context.prysmStyle.tokens.accent,
+                        ),
+                        title: 'Invite requests',
+                        subtitle:
+                            '$_pendingInviteCount request${_pendingInviteCount == 1 ? '' : 's'}',
+                        onTap: () {
+                          Navigator.push(
+                            context,
+                            PrysmPageRoute(
+                              page: InviteRequestsScreen(
+                                onClose: () => Navigator.of(context).pop(),
+                                onionAddress: widget.onionAddress,
+                                keyManager: widget.keyManager,
+                                onChanged: () => scheduleLoadUsers(light: true),
+                              ),
+                            ),
+                          );
+                        },
+                      ),
+                    );
+                  }
+```
+
+The existing `Archived` branch currently tests `footerIndex == 0`; with a row inserted before
+it, its index becomes `_pendingInviteCount > 0 ? 1 : 0`. Compute the offsets explicitly rather
+than nesting conditionals — an off-by-one here renders the wrong row.
+
+- [ ] **Step 4: Verify it analyses clean**
+
+Run: `flutter analyze`
+Expected: `No issues found!`
+
+- [ ] **Step 5: Smoke test the whole feature on the desktop build**
+
+Run: `flutter run -d linux`
+
+1. With no pending invites: no footer row in the sidebar, and Settings → `Invite requests`
+   shows `No invite requests`.
+2. Seed one request against the running app (a second instance, or a direct POST to the local
+   onion with `type: 'group_invite'` and an unknown `senderId`): the footer row appears with
+   `1 request`, the screen lists the short address and the arrival time, and **no group appears
+   in the sidebar**.
+3. Discard it: the row disappears from both the screen and the sidebar.
+4. Switch the mode to `Only accept invites from contacts` and send another: nothing is stored,
+   nothing appears.
+
+- [ ] **Step 6: Commit (controller)**
+
+```bash
+git add lib/screens/invite_requests_screen.dart lib/screens/settings_screen.dart \
+        lib/screens/home/home_screen.dart
+git commit -m "feat(group): surface pending invite requests and let the user act on them"
+```
+
+---
+
+## Final gate (controller, after every task)
+
+```bash
+flutter analyze          # expect: No issues found!
+flutter test             # expect: at least 935 + the new tests, 1 skipped
+```
+
+The skip is the L3 harness, gated by `PRYSM_E2E`. Any other skip or failure is a regression
+introduced by this plan.
+
+## Out of scope (do not implement)
+
+- The other four group control types keep dropping unconditionally.
+- `DBHelper.ensureUserExist` stays as it is on all six inbound handlers.
+- Issue #130 and the 1:1 DM pre-auth resolve residual are untouched.

--- a/docs/superpowers/specs/2026-08-07-group-invite-mode-design.md
+++ b/docs/superpowers/specs/2026-08-07-group-invite-mode-design.md
@@ -1,0 +1,291 @@
+# Group invite mode — design
+
+Date: 2026-08-07 · Status: approved by the user, not yet implemented
+Base: `main` @ `4f80b5e` (v0.6.4), after PR #128 was merged in `13a2137`
+Branch: `feat/group-invite-mode`
+
+## Problem
+
+PR #128 closed M2 on the group control path by making `_resolveSenderIdentity` DB-only
+(`lib/services/group_service.dart:549-561`). The accepted cost (CR8, option 1, chosen by
+@xmreur) is that a group control message from a sender whose identity is not in the local
+`users` table is dropped before processing (`group_service.dart:481-499`): the sender gets a
+normal `200 {status: received}` ack and the invitee sees nothing. A first-contact group invite
+therefore disappears silently. Issue #129 tracks the missing UX.
+
+The three exits identified during the review were not equivalent:
+
+1. accept the drop (chosen; no code, silent loss stays),
+2. carry the inviter identity key in the invite and TOFU-persist it (wire format change, lets
+   an unauthenticated peer seed a `users` row and pre-empt the real peer),
+3. restore the Tor fetch for invites (smallest diff, reopens the M2 oracle).
+
+This design adds a fourth exit and makes it selectable: **hold the invite as a request and
+resolve the sender only when the user acts**. Option 3's benefit (first-contact invites are not
+lost) without option 3's cost (no outbound traffic is triggered by unauthenticated inbound
+traffic, so no oracle).
+
+## Decision
+
+A two-value user setting in Privacy Settings, defaulting to the new behaviour.
+
+| Mode | Behaviour |
+|---|---|
+| `holdAsRequest` (default) | An invite from an unresolvable sender is stored, opaque and bounded, as a pending request the user can accept or discard. Nothing is decrypted, nothing is sent. |
+| `contactsOnly` | Current merged behaviour: the invite is discarded on arrival. Nothing is stored, nothing is shown. |
+
+The security boundary does not move in either mode: `_resolveSenderIdentity` stays DB-only, and
+no code path fetches a profile for an unauthenticated sender.
+
+## Components
+
+### 1. `GroupInviteMode` (new: `lib/models/group_invite_mode.dart`)
+
+Modelled verbatim on `PanicAction` (`lib/models/panic_action.dart:1-23`): a two-value enum with
+`label` and `description` getters and a `fromJson` that falls back to the default on any
+unknown value.
+
+```dart
+enum GroupInviteMode { holdAsRequest, contactsOnly }
+```
+
+User-facing strings (English, hardcoded — the app has no i18n layer):
+
+| Value | `label` | `description` |
+|---|---|---|
+| `holdAsRequest` | `Hold invites from unknown senders` | `An invite from someone who is not in your contacts is kept as a request. Your device never contacts them, and you don't join the group until you accept.` |
+| `contactsOnly` | `Only accept invites from contacts` | `Invites from anyone else are discarded the moment they arrive: nothing is stored, nothing is shown.` |
+
+### 2. Setting plumbing
+
+- `lib/models/settings.dart`: field `groupInviteMode`, constructor default
+  `GroupInviteMode.holdAsRequest`, `toJson` by `.name`, `fromJson` via
+  `GroupInviteMode.fromJson` with the same default duplicated (the file's existing convention),
+  plus `copyWith`, `==`, `hashCode` — the same five-plus places every other field touches.
+- `lib/services/settings_service.dart`: synchronous getter `groupInviteMode` and
+  `setGroupInviteMode(GroupInviteMode)` following `setPanicAction`
+  (`settings_service.dart:169-172` is the setter shape). No notifier is needed: privacy
+  settings have none, consumers re-read the getter at point of use
+  (`wake_hint_service.dart:85` is the service-layer precedent).
+
+### 3. Setting UI (`lib/screens/privacy_settings_screen.dart`)
+
+A new `PrysmSection` titled `Group invites`, above the `Emergency` section, containing two
+inline `PrysmRadioRow<GroupInviteMode>` (`lib/ui/core/prysm_radio.dart:6-55`), `title` =
+`label`, `subtitle` = `description`.
+
+Inline radios, not the `PanicAction` bottom sheet (`panic_pin_settings_screen.dart:133-145`):
+the requirement is that the user reads what **both** modes imply before choosing, and a sheet
+hides them behind a tap.
+
+### 4. Pending store (new: `lib/util/group_pending_invite_store.dart`)
+
+Shape copied from `GroupSenderIndexStore` (`lib/util/group_sender_index_store.dart`): all-static
+class, private constructor, one process-global `static final Mutex _mutex`, `ensureTable(Database)`
+with `CREATE TABLE IF NOT EXISTS`, `@visibleForTesting resetForTest()`.
+
+```sql
+CREATE TABLE IF NOT EXISTS group_pending_invites (
+  senderId   TEXT PRIMARY KEY,
+  wire       TEXT NOT NULL,
+  receivedAt INTEGER NOT NULL
+)
+```
+
+The row is the raw `control-wrap-2` envelope, stored opaque. It is never decrypted while
+pending: the payload is attacker-controlled and unauthenticated, so no field of it may reach
+the UI or the database in parsed form.
+
+Bounds — all three are load-bearing because this table is written by unauthenticated traffic
+(`POST /message` authenticates nobody; the only rate limit is keyed on the sender-claimed
+`senderId`, `lib/server/PrysmServer.dart:223-228`):
+
+| Bound | Value | Rationale |
+|---|---|---|
+| Per sender | 1 row (the primary key); a newer invite replaces the older | One onion occupies one slot, not N. |
+| Global | 20 senders; **at capacity the new row is refused**, no eviction | Evicting the oldest would let an attacker delete a genuine request. Refusing degrades to today's drop, which is already the accepted worst case. |
+| Retention | 7 days, pruned on the write path | Self-healing: a table filled by an attacker frees itself without user action. |
+
+Public API (all static, all inside `_mutex`):
+
+- `Future<void> ensureTable(Database db)`
+- `Future<bool> hold({required String senderId, required String wire})` — returns false when
+  refused by the global cap.
+- `Future<List<Map<String, Object?>>> pending()` — prunes expired rows, then returns the rest
+  ordered by `receivedAt` descending.
+- `Future<Map<String, Object?>?> take(String senderId)` — reads and deletes atomically.
+- `Future<void> discard(String senderId)`
+- `Future<int> count()` — prunes expired rows, then counts; this is what the two UI entry
+  points display.
+- `@visibleForTesting Future<void> resetForTest()`
+
+Schema: `chat_app.db` goes to `version: 14` (`lib/util/db_helper.dart:64`), `ensureTable` is
+added to `_createCryptoTables` (`db_helper.dart:99-102`) and a ladder step
+`if (oldVersion < 14) { await _createCryptoTables(db); }` is appended to `_onUpgradeImpl`
+(`db_helper.dart:143-217`), matching the `oldVersion < 13` step verbatim in shape.
+
+### 5. Ingress (`lib/services/group_service.dart`)
+
+One change, at the existing `senderKeys == null` branch (`:492-499`). Before the existing
+`Logging.error` + `return false`:
+
+- if `type == groupInviteType` and the mode is `holdAsRequest`, call
+  `GroupPendingInviteStore.hold(...)` with the raw `encryptedPayload`;
+- then drop exactly as today. A `hold` refused by the global cap changes nothing: the drop
+  proceeds and the refusal is logged with the sender redacted, exactly like the drop itself.
+
+`GroupService` reads the setting through `final SettingsService _settings = SettingsService();`,
+the field-initialised singleton convention already used by `ReadReceiptService`
+(`lib/services/read_receipt_service.dart:94`, consumed at `:135`). No constructor change: the
+existing optional collaborators (`keyProvider`, `controlChannel`) are for objects tests must
+replace, and the settings singleton is already driven by tests through
+`SharedPreferences.setMockInitialValues`.
+
+Everything else is unchanged: no fetch, the router still returns `200 {status: received}`
+(`inbound_message_router.dart:360`), and `fetchSenderProfile` still fires only when `handled`
+is true (`:356-358`). The four non-invite control types keep dropping unconditionally.
+
+### 6. Requests UI (new: `lib/screens/invite_requests_screen.dart`)
+
+Modelled on `BlockedContactsScreen` (`lib/screens/blocked_contacts_screen.dart:18-35`), same
+`onClose` constructor shape, reached from two entry points:
+
+- `settings_screen.dart`: a `_buildNavigationTile('Invite requests', …)` next to
+  `Blocked contacts` (`settings_screen.dart:672-684`), with the pending count in the subtitle.
+- `home_screen.dart`: a third footer row in the sidebar `ListView.builder`, same family as
+  `Archived` / `Blocked` (`home_screen.dart:1459-1512`), rendered **only when the pending count
+  is greater than zero**. The count comes from `GroupPendingInviteStore.count()`, loaded inside
+  `loadUsers` (`home_screen.dart:777-875`) into a `_pendingInviteCount` field — `_blockedCount`
+  (`:171`) is derived from the conversation list and cannot serve here — and
+  `_sidebarFooterCount` (`:178-184`) gains a third conditional row.
+
+Each row shows the sender's onion address, truncated, plus the date it arrived. No string from
+the envelope is displayed — group name, avatar and roster stay unread until the invite
+authenticates. Two actions:
+
+- **Add contact and join** — runs the existing `ContactAddService.addContact` (which fetches
+  `/public` over Tor, `contact_add_service.dart:80`, and stores the identity at `:123-131`).
+  The fetch is a consequence of the user's tap, not of the inbound message: this is exactly
+  what keeps M2 closed. On success, promote (below).
+- **Discard** — `GroupPendingInviteStore.discard(senderId)`.
+
+### 7. Promotion
+
+Promotion never bypasses authentication: it re-plays the stored wire through
+`GroupService.handleIncomingControlMessage(groupInviteType, wire, senderId)`, the same
+authenticated path the message would have taken. The row is deleted whether the replay
+succeeds or fails — a wire that fails to authenticate is garbage, and `PendingAuthMessageService`
+sets the precedent of discarding what cannot be promoted
+(`pending_auth_message_service.dart:57-66`).
+
+Two triggers:
+
+- the **Add contact and join** action, immediately after `addContact` returns success;
+- a **sweep after unlock** that promotes any pending row whose sender has meanwhile become
+  resolvable via `loadPeerIdentityFromDb` — this covers "the user added the contact by other
+  means". It runs in `UnlockController.verifyUnlock`, immediately after the existing
+  `PendingAuthMessageService(...).promotePendingAfterUnlock()` call
+  (`lib/app/unlock_controller.dart:78-79`): same moment, same reason — the database is usable
+  and identities can be imported. No new dependency is introduced into
+  `contact_add_service.dart`.
+
+### 8. Comment fix (`lib/services/group_service.dart:485-486`)
+
+The merged comment states the payload "cannot even be read" without the sender identity. That
+is false as a cryptographic statement: `_decryptDhAeadEnvelope` derives the AEAD key from the
+recipient's agreement keypair and the ephemeral public key inside the envelope
+(`lib/crypto/wire.dart:213-240`); the sender identity is consumed only by the Ed25519
+verification (`wire.dart:375-406`, `416-424`). What is true is narrower: `decryptControlPayload`
+requires it because it goes through the signed unwrap. The comment is corrected to say
+"authenticated", not "read", because a future implementer of the pending flow would otherwise
+conclude that showing invite content is impossible rather than forbidden.
+
+## Data flow
+
+```
+POST /message (unauthenticated)
+  -> InboundMessageRouter._handleGroupControl
+  -> GroupService.handleIncomingControlMessage
+       _resolveSenderIdentity  (DB only, never Tor)
+         | null and type == group_invite and mode == holdAsRequest
+         |    -> GroupPendingInviteStore.hold(senderId, wire)   [bounded, opaque]
+         |    -> drop (200 received, no fetch)
+         | null otherwise
+         |    -> drop (200 received, no fetch)
+         | resolved
+              -> decryptControlPayload -> handlers -> fetchSenderProfile
+
+User taps "Add contact and join"
+  -> ContactAddService.addContact       [user-initiated Tor fetch of /public]
+  -> GroupPendingInviteStore.take(senderId)
+  -> GroupService.handleIncomingControlMessage(group_invite, wire, senderId)
+  -> authenticated path, group created
+```
+
+## Error handling
+
+- `hold` refused by the global cap: the invite is dropped exactly as in `contactsOnly` mode.
+  No user-visible difference; the refusal is logged with the onion redacted
+  (`Logging.redactOnion`, as the drop already does).
+- Replay fails to authenticate: the row is deleted, no group is created, the failure is logged
+  by the existing `catch` in `handleIncomingControlMessage` (`:508-515`).
+- `addContact` fails (peer offline, fetch fails): the pending row is left in place so the user
+  can retry; the UI surfaces the failure through the existing contact-add error path.
+- A corrupt or foreign `group_pending_invites` row must not brick the screen: `pending()`
+  tolerates rows it cannot use and prunes them, in the spirit of the pool-read hardening from
+  PR #128 (`600270d`).
+
+## Testing
+
+Every test below must be verified failing on the pre-change code (red) before the change makes
+it pass (green). Conventions: hand-written fakes, `sqflite_common_ffi` in-memory,
+`setDatabaseForTest` / `resetForTest` seams, no new dependencies.
+
+Two hygiene requirements specific to this feature: any test that drives the mode must call
+`SharedPreferences.setMockInitialValues({})` first (`test/settings_migration_test.dart:6-16`
+is the precedent — `save()` hits SharedPreferences), and must restore the default in
+`tearDown`, because `SettingsService` is a process-wide singleton and a leaked mode would make
+an unrelated test assert the wrong policy.
+
+| # | Test | File |
+|---|---|---|
+| 1 | `groupInviteMode` defaults to `holdAsRequest`, survives a `toJson`/`fromJson` round trip, falls back to the default on an unknown stored value | `test/settings_migration_test.dart` (extend) |
+| 2 | `contactsOnly`: an invite from an unresolvable sender leaves `group_pending_invites` empty, creates no group, fires no fetch | `test/security/group_invite_mode_test.dart` (new) |
+| 3 | `holdAsRequest`: the same invite leaves **exactly one** pending row — and the merged `POLICY:` assertions still hold (no group, no members, no group key, no fetch) | same |
+| 4 | A second invite from the same sender replaces the first (one row, newer `receivedAt`) | `test/security/group_pending_invite_store_test.dart` (new) |
+| 5 | The 21st distinct sender is refused; the existing 20 rows are untouched | same |
+| 6 | A row older than 7 days is pruned on the next write; a 6-day-old row is not | same |
+| 7 | Promotion: with the sender's identity stored, replaying the held wire creates the group and deletes the row | `test/security/group_invite_mode_test.dart` |
+| 8 | Promotion of a tampered wire deletes the row and creates no group | same |
+| 9 | `chat_app.db` v13 → v14 upgrade on a real file: `group_pending_invites` exists afterwards, the rows of the other tables survive the upgrade, and a real `hold`/`count` round trip works against the upgraded file | `test/security/chat_db_v13_v14_upgrade_test.dart` (new, modelled on `chat_db_v10_v11_upgrade_test.dart`) |
+| 10 | The existing `POLICY:` pair in `group_profile_fetch_gate_test.dart` still passes under the new default | existing file, unchanged assertions |
+
+## Out of scope, stated
+
+- **The other four control types.** `group_key_rotate`, `group_member_removed`,
+  `group_profile_update`, `group_disappearing_timer` from a roster member whose `users` row has
+  no identity material keep being dropped (CR8-c in the PR #128 triage). A pending request is
+  not a remedy: those messages are not user-actionable, and the fix is identity resolution, not
+  consent.
+- **Placeholder `users` rows.** `DBHelper.ensureUserExist(senderId)` runs before authentication
+  on all six inbound handlers (`inbound_message_router.dart:334, 371, 403, 436, 465, 496`), so
+  an unauthenticated peer can create unbounded `Unknown - xxxxxx` contacts — proven executably
+  on 2026-08-07: 50 POSTs with attacker-chosen `senderId` produced 50 `users` rows, all acked
+  `200`, no group created, no fetch. Removing only the group-control call site would close
+  nothing (a `text` message reaches `:496`), so it is recorded as a separate finding, not
+  folded into this design.
+- **Issue #130** (transport delivery outcome) is untouched.
+- **The 1:1 DM residual** (`direct_message_auth.dart` resolving an unknown sender before
+  verification, via `PrysmServer.dart:73`) is untouched.
+
+## Why not the alternatives
+
+- **Auto-fetch behind a setting** (option 3 as a toggle): the honest subtitle would read "anyone
+  who knows your address can make your device reach out and learn you are online". An option
+  that reopens a closed finding is a footgun with a label, and the benefit is available without
+  the cost.
+- **TOFU on an embedded inviter key** (option 2): requires a wire format change, breaks
+  interoperability with older peers, and lets an unauthenticated peer bind an identity to an
+  onion before its real owner does.
+- **No setting, pending flow only**: it would still be an improvement, but the pending table is
+  a real (bounded) attack surface, and a user who wants none of it has no way to say so.

--- a/docs/superpowers/specs/2026-08-07-group-invite-mode-design.md
+++ b/docs/superpowers/specs/2026-08-07-group-invite-mode-design.md
@@ -82,7 +82,8 @@ hides them behind a tap.
 
 Shape copied from `GroupSenderIndexStore` (`lib/util/group_sender_index_store.dart`): all-static
 class, private constructor, one process-global `static final Mutex _mutex`, `ensureTable(Database)`
-with `CREATE TABLE IF NOT EXISTS`, `@visibleForTesting resetForTest()`.
+with `CREATE TABLE IF NOT EXISTS`. The store has no process-local state, so no `resetForTest()`
+seam exists — tests drive it through `DBHelper.setDatabaseForTest`.
 
 ```sql
 CREATE TABLE IF NOT EXISTS group_pending_invites (
@@ -96,7 +97,7 @@ The row is the raw `control-wrap-2` envelope, stored opaque. It is never decrypt
 pending: the payload is attacker-controlled and unauthenticated, so no field of it may reach
 the UI or the database in parsed form.
 
-Bounds — all three are load-bearing because this table is written by unauthenticated traffic
+Bounds — all four are load-bearing because this table is written by unauthenticated traffic
 (`POST /message` authenticates nobody; the only rate limit is keyed on the sender-claimed
 `senderId`, `lib/server/PrysmServer.dart:223-228`):
 
@@ -104,20 +105,23 @@ Bounds — all three are load-bearing because this table is written by unauthent
 |---|---|---|
 | Per sender | 1 row (the primary key); a newer invite replaces the older | One onion occupies one slot, not N. |
 | Global | 20 senders; **at capacity the new row is refused**, no eviction | Evicting the oldest would let an attacker delete a genuine request. Refusing degrades to today's drop, which is already the accepted worst case. |
+| Wire size | ≤ 64 KiB per envelope; a longer wire is refused | A real `control-wrap-2` invite envelope is a few KB. Without the bound, 20 rows at the 96 MiB request-body cap would pin ~1.9 GB of attacker-chosen bytes for the retention window. |
 | Retention | 7 days, pruned on the write path | Self-healing: a table filled by an attacker frees itself without user action. |
 
 Public API (all static, all inside `_mutex`):
 
 - `Future<void> ensureTable(Database db)`
 - `Future<bool> hold({required String senderId, required String wire})` — returns false when
-  refused by the global cap.
+  refused by the global cap or because the wire exceeds the size bound; the caller then drops
+  the invite exactly as in `contactsOnly` mode.
 - `Future<List<Map<String, Object?>>> pending()` — prunes expired rows, then returns the rest
   ordered by `receivedAt` descending.
 - `Future<Map<String, Object?>?> take(String senderId)` — reads and deletes atomically.
 - `Future<void> discard(String senderId)`
+- `Future<void> clear()` — deletes every row; called by the privacy screen when the user
+  switches to `contactsOnly`, whose promise is that nothing is stored.
 - `Future<int> count()` — prunes expired rows, then counts; this is what the two UI entry
   points display.
-- `@visibleForTesting Future<void> resetForTest()`
 
 Schema: `chat_app.db` goes to `version: 14` (`lib/util/db_helper.dart:64`), `ensureTable` is
 added to `_createCryptoTables` (`db_helper.dart:99-102`) and a ladder step

--- a/docs/superpowers/specs/2026-08-07-group-invite-mode-design.md
+++ b/docs/superpowers/specs/2026-08-07-group-invite-mode-design.md
@@ -105,8 +105,8 @@ Bounds — all four are load-bearing because this table is written by unauthenti
 |---|---|---|
 | Per sender | 1 row (the primary key); a newer invite replaces the older | One onion occupies one slot, not N. |
 | Global | 20 senders; **at capacity the new row is refused**, no eviction | Evicting the oldest would let an attacker delete a genuine request. Refusing degrades to today's drop, which is already the accepted worst case. |
-| Wire size | ≤ 64 KiB per envelope; a longer wire is refused | A real `control-wrap-2` invite envelope is a few KB. Without the bound, 20 rows at the 96 MiB request-body cap would pin ~1.9 GB of attacker-chosen bytes for the retention window. |
-| Retention | 7 days, pruned on the write path | Self-healing: a table filled by an attacker frees itself without user action. |
+| Wire size | ≤ 64 KiB per envelope, measured in **UTF-8 bytes**; a longer wire is refused | A real `control-wrap-2` invite envelope is a few KB. Without the bound, 20 rows at the 96 MiB request-body cap would pin ~1.9 GB of attacker-chosen bytes for the retention window. Bytes and not `String.length`, because SQLite stores UTF-8 and a non-ASCII payload passes a code-unit check at up to three bytes per unit. |
+| Retention | 7 days, pruned on every read and write path (`hold`, `pending`, `count`, `take`) | Self-healing: a table filled by an attacker frees itself without user action, and no path can apply a snapshot older than the window. |
 
 Public API (all static, all inside `_mutex`):
 
@@ -116,7 +116,8 @@ Public API (all static, all inside `_mutex`):
   the invite exactly as in `contactsOnly` mode.
 - `Future<List<Map<String, Object?>>> pending()` — prunes expired rows, then returns the rest
   ordered by `receivedAt` descending.
-- `Future<Map<String, Object?>?> take(String senderId)` — reads and deletes atomically.
+- `Future<String?> take(String senderId)` — prunes expired rows, then reads and deletes
+  atomically, so a row past the retention window returns null instead of applying.
 - `Future<void> discard(String senderId)`
 - `Future<void> clear()` — deletes every row; called by the privacy screen when the user
   switches to `contactsOnly`, whose promise is that nothing is stored.

--- a/docs/superpowers/specs/2026-08-07-group-invite-mode-design.md
+++ b/docs/superpowers/specs/2026-08-07-group-invite-mode-design.md
@@ -181,12 +181,15 @@ sets the precedent of discarding what cannot be promoted
 Two triggers:
 
 - the **Add contact and join** action, immediately after `addContact` returns success;
-- a **sweep after unlock** that promotes any pending row whose sender has meanwhile become
-  resolvable via `loadPeerIdentityFromDb` — this covers "the user added the contact by other
-  means". It runs in `UnlockController.verifyUnlock`, immediately after the existing
-  `PendingAuthMessageService(...).promotePendingAfterUnlock()` call
-  (`lib/app/unlock_controller.dart:78-79`): same moment, same reason — the database is usable
-  and identities can be imported. No new dependency is introduced into
+- a **sweep at home-screen start** that promotes any pending row whose sender has meanwhile
+  become resolvable via `loadPeerIdentityFromDb` — this covers "the user added the contact by
+  other means". It runs once per session in `_HomeScreenState.initState`
+  (`lib/screens/home/home_screen.dart:399-404`), skipped in decoy mode, and it lives there
+  rather than next to `PendingAuthMessageService.promotePendingAfterUnlock()` for a hard
+  reason: promotion needs `GroupService(userId: <local onion>)` — `_handleInvite` checks the
+  roster against that id (`group_service.dart:602-605`) — and `UnlockController` has no onion
+  address, while the home screen already builds `GroupService` with `widget.onionAddress`
+  (`home_screen.dart:787-790`). No new dependency is introduced into
   `contact_add_service.dart`.
 
 ### 8. Comment fix (`lib/services/group_service.dart:485-486`)

--- a/lib/models/group_invite_mode.dart
+++ b/lib/models/group_invite_mode.dart
@@ -16,8 +16,8 @@ enum GroupInviteMode {
   String get description => switch (this) {
         GroupInviteMode.holdAsRequest =>
           'An invite from someone who is not in your contacts is kept as a '
-              "request. Your device never contacts them, and you don't join "
-              'the group until you accept.',
+              'request. Your device never contacts them, and adding them as '
+              'a contact is what applies the invite.',
         GroupInviteMode.contactsOnly =>
           'Invites from anyone else are discarded the moment they arrive: '
               'nothing is stored, nothing is shown.',

--- a/lib/models/group_invite_mode.dart
+++ b/lib/models/group_invite_mode.dart
@@ -1,0 +1,32 @@
+/// What happens to a group invite whose sender's identity is not in the
+/// local user store.
+///
+/// The security boundary is the same in both modes: the sender is never
+/// resolved over the network on an inbound message (M2). The choice is only
+/// whether the invite is kept for the user to decide on, or dropped.
+enum GroupInviteMode {
+  holdAsRequest,
+  contactsOnly;
+
+  String get label => switch (this) {
+        GroupInviteMode.holdAsRequest => 'Hold invites from unknown senders',
+        GroupInviteMode.contactsOnly => 'Only accept invites from contacts',
+      };
+
+  String get description => switch (this) {
+        GroupInviteMode.holdAsRequest =>
+          'An invite from someone who is not in your contacts is kept as a '
+              "request. Your device never contacts them, and you don't join "
+              'the group until you accept.',
+        GroupInviteMode.contactsOnly =>
+          'Invites from anyone else are discarded the moment they arrive: '
+              'nothing is stored, nothing is shown.',
+      };
+
+  static GroupInviteMode fromJson(String? value) {
+    return GroupInviteMode.values.firstWhere(
+      (m) => m.name == value,
+      orElse: () => GroupInviteMode.holdAsRequest,
+    );
+  }
+}

--- a/lib/models/settings.dart
+++ b/lib/models/settings.dart
@@ -1,5 +1,6 @@
 // lib/models/app_settings.dart
 import 'package:prysm/models/appearance_settings.dart';
+import 'package:prysm/models/group_invite_mode.dart';
 import 'package:prysm/models/panic_action.dart';
 import 'package:prysm/models/unlock_type.dart';
 
@@ -21,6 +22,7 @@ class Settings {
   // Privacy
   final int messageRetentionDays;
   final PanicAction panicAction;
+  final GroupInviteMode groupInviteMode;
 
   // Theme
   final int themeMode; // 0=light, 1=dark, 2=pink, 3=cyan, 4=purple, 5=orange
@@ -55,6 +57,7 @@ class Settings {
     this.aggressiveRetry = true,
     this.messageRetentionDays = 30,
     this.panicAction = PanicAction.decoy,
+    this.groupInviteMode = GroupInviteMode.holdAsRequest,
     this.themeMode = 0,
     this.appearance = const AppearanceSettings(),
     this.avatar,
@@ -81,6 +84,7 @@ class Settings {
     'aggressiveRetry': aggressiveRetry,
     'messageRetentionDays': messageRetentionDays,
     'panicAction': panicAction.name,
+    'groupInviteMode': groupInviteMode.name,
     'themeMode': themeMode,
     'appearance': appearance.toJson(),
     'avatar': avatar,
@@ -107,6 +111,9 @@ class Settings {
     aggressiveRetry: json['aggressiveRetry'] ?? true,
     messageRetentionDays: json['messageRetentionDays'] ?? 30,
     panicAction: PanicAction.fromJson(json['panicAction'] as String?),
+    groupInviteMode: GroupInviteMode.fromJson(
+      json['groupInviteMode'] as String?,
+    ),
     themeMode: json['themeMode'] ?? 0,
     appearance: AppearanceSettings.fromJson(
       json['appearance'] as Map<String, dynamic>?,
@@ -137,6 +144,7 @@ class Settings {
     bool? aggressiveRetry,
     int? messageRetentionDays,
     PanicAction? panicAction,
+    GroupInviteMode? groupInviteMode,
     int? themeMode,
     AppearanceSettings? appearance,
     String? avatar,
@@ -163,6 +171,7 @@ class Settings {
     aggressiveRetry: aggressiveRetry ?? this.aggressiveRetry,
     messageRetentionDays: messageRetentionDays ?? this.messageRetentionDays,
     panicAction: panicAction ?? this.panicAction,
+    groupInviteMode: groupInviteMode ?? this.groupInviteMode,
     themeMode: themeMode ?? this.themeMode,
     appearance: appearance ?? this.appearance,
     avatar: avatar ?? this.avatar,
@@ -205,6 +214,7 @@ class Settings {
         other.aggressiveRetry == aggressiveRetry &&
         other.messageRetentionDays == messageRetentionDays &&
         other.panicAction == panicAction &&
+        other.groupInviteMode == groupInviteMode &&
         other.themeMode == themeMode &&
         other.appearance == appearance &&
         other.avatar == avatar &&
@@ -231,6 +241,7 @@ class Settings {
         aggressiveRetry.hashCode ^
         messageRetentionDays.hashCode ^
         panicAction.hashCode ^
+        groupInviteMode.hashCode ^
         themeMode.hashCode ^
         appearance.hashCode ^
         (avatar?.hashCode ?? 0) ^

--- a/lib/services/settings_service.dart
+++ b/lib/services/settings_service.dart
@@ -5,6 +5,7 @@ import 'package:prysm/util/logging.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:prysm/crypto/key_store.dart';
 import 'package:prysm/models/appearance_settings.dart';
+import 'package:prysm/models/group_invite_mode.dart';
 import 'package:prysm/models/panic_action.dart';
 import 'package:prysm/models/settings.dart';
 import 'package:prysm/models/unlock_type.dart';
@@ -57,6 +58,7 @@ class SettingsService {
   // Privacy
   int get messageRetentionDays => _settings.messageRetentionDays;
   PanicAction get panicAction => _settings.panicAction;
+  GroupInviteMode get groupInviteMode => _settings.groupInviteMode;
 
   // Theme
   int get themeMode => _settings.themeMode;
@@ -215,6 +217,11 @@ class SettingsService {
 
   Future<void> setPanicAction(PanicAction value) async {
     _settings = _settings.copyWith(panicAction: value);
+    await save();
+  }
+
+  Future<void> setGroupInviteMode(GroupInviteMode value) async {
+    _settings = _settings.copyWith(groupInviteMode: value);
     await save();
   }
 

--- a/lib/util/db_helper.dart
+++ b/lib/util/db_helper.dart
@@ -5,6 +5,7 @@ import 'package:prysm/database/blocked_users_db.dart';
 import 'package:prysm/database/call_logs_db.dart';
 import 'package:prysm/database/conversation_preferences_db.dart';
 import 'package:prysm/database/database_cipher.dart';
+import 'package:prysm/util/group_pending_invite_store.dart';
 import 'package:prysm/util/group_sender_index_store.dart';
 import 'package:prysm/util/logging.dart';
 import 'package:prysm/util/sqflite_platform.dart';
@@ -61,7 +62,7 @@ class DBHelper {
     await DatabaseCipher.prepare(path);
     final db = await openDatabase(
       path,
-      version: 13,
+      version: 14,
       onCreate: _createDB,
       onUpgrade: _onUpgrade,
       // PRAGMA key must be the first statement on the connection.
@@ -99,6 +100,7 @@ class DBHelper {
   static Future<void> _createCryptoTables(Database db) async {
     await RatchetSessionStore.ensureTable(db);
     await GroupSenderIndexStore.ensureTable(db);
+    await GroupPendingInviteStore.ensureTable(db);
   }
 
   static Future<void> _createGroupTables(Database db) async {
@@ -212,6 +214,15 @@ class DBHelper {
       // ensureTable calls in _createCryptoTables are CREATE TABLE IF NOT
       // EXISTS, so replaying the step on a database that already has
       // session_state and group_sender_index only adds the missing table.
+      await _createCryptoTables(db);
+    }
+    if (oldVersion < 14) {
+      // group_pending_invites (the bounded store for invites from senders
+      // whose identity is not local yet) is created by
+      // GroupPendingInviteStore.ensureTable. Every ensureTable in
+      // _createCryptoTables is CREATE TABLE IF NOT EXISTS, so replaying
+      // the step on a database that already has the other crypto tables
+      // only adds the missing one.
       await _createCryptoTables(db);
     }
   }

--- a/lib/util/group_pending_invite_store.dart
+++ b/lib/util/group_pending_invite_store.dart
@@ -1,0 +1,153 @@
+import 'package:mutex/mutex.dart';
+import 'package:prysm/util/db_helper.dart';
+import 'package:sqflite/sqflite.dart';
+
+/// Group invites received from a sender whose identity is not in the local
+/// user store, kept so the user can decide instead of losing them silently.
+///
+/// The stored [wire] is the raw `control-wrap-2` envelope and is NEVER
+/// decrypted while pending: it is unauthenticated, attacker-controlled input,
+/// so nothing from it may reach the UI or be parsed into the database. It is
+/// only ever replayed through the normal authenticated path once the sender's
+/// identity is locally known.
+///
+/// This table is written by unauthenticated traffic — `POST /message`
+/// authenticates nobody and its only rate limit is keyed on the
+/// sender-claimed `senderId` — so all three bounds below are load-bearing,
+/// not tuning.
+class GroupPendingInviteStore {
+  GroupPendingInviteStore._();
+
+  static final Mutex _mutex = Mutex();
+
+  /// How many distinct senders may hold a pending invite at once.
+  ///
+  /// At capacity a NEW sender is refused rather than evicting the oldest
+  /// row: eviction would let an attacker with cheap throwaway onions delete
+  /// a genuine request, while refusal only degrades to the drop that was the
+  /// accepted behaviour before this feature existed.
+  static const int maxPendingSenders = 20;
+
+  /// How long a pending invite survives without a decision. Bounds the table
+  /// in time as well as in rows, so one filled by an attacker frees itself
+  /// with no user action.
+  static const Duration retention = Duration(days: 7);
+
+  static Future<void> ensureTable(Database db) async {
+    await db.execute('''
+      CREATE TABLE IF NOT EXISTS group_pending_invites (
+        senderId TEXT PRIMARY KEY,
+        wire TEXT NOT NULL,
+        receivedAt INTEGER NOT NULL
+      )
+    ''');
+  }
+
+  /// Keeps [wire] as the pending invite for [senderId], replacing any
+  /// previous one from the same sender. Returns false when the global cap
+  /// refuses a new sender; the caller drops the invite exactly as it would
+  /// with the feature off.
+  static Future<bool> hold({
+    required String senderId,
+    required String wire,
+  }) async {
+    return _mutex.protect(() async {
+      final db = await DBHelper.database;
+      await _pruneExpired(db);
+
+      final existing = await db.query(
+        'group_pending_invites',
+        columns: ['senderId'],
+        where: 'senderId = ?',
+        whereArgs: [senderId],
+        limit: 1,
+      );
+      if (existing.isEmpty && await _count(db) >= maxPendingSenders) {
+        return false;
+      }
+
+      await db.insert(
+        'group_pending_invites',
+        {
+          'senderId': senderId,
+          'wire': wire,
+          'receivedAt': DateTime.now().millisecondsSinceEpoch,
+        },
+        conflictAlgorithm: ConflictAlgorithm.replace,
+      );
+      return true;
+    });
+  }
+
+  /// Pending invites, newest first. Expired rows are pruned first, so a
+  /// caller never sees a row it must filter itself.
+  static Future<List<Map<String, Object?>>> pending() async {
+    return _mutex.protect(() async {
+      final db = await DBHelper.database;
+      await _pruneExpired(db);
+      // rowid breaks a same-millisecond tie: two invites held inside the
+      // same clock tick would otherwise come back in an arbitrary order.
+      return db.query(
+        'group_pending_invites',
+        orderBy: 'receivedAt DESC, rowid DESC',
+      );
+    });
+  }
+
+  static Future<int> count() async {
+    return _mutex.protect(() async {
+      final db = await DBHelper.database;
+      await _pruneExpired(db);
+      return _count(db);
+    });
+  }
+
+  /// Returns the held envelope for [senderId] and deletes the row in the
+  /// same critical section, so a second caller cannot replay it.
+  static Future<String?> take(String senderId) async {
+    return _mutex.protect(() async {
+      final db = await DBHelper.database;
+      final rows = await db.query(
+        'group_pending_invites',
+        where: 'senderId = ?',
+        whereArgs: [senderId],
+        limit: 1,
+      );
+      if (rows.isEmpty) return null;
+      await db.delete(
+        'group_pending_invites',
+        where: 'senderId = ?',
+        whereArgs: [senderId],
+      );
+      return rows.first['wire'] as String?;
+    });
+  }
+
+  static Future<void> discard(String senderId) async {
+    await _mutex.protect(() async {
+      final db = await DBHelper.database;
+      await db.delete(
+        'group_pending_invites',
+        where: 'senderId = ?',
+        whereArgs: [senderId],
+      );
+    });
+  }
+
+  static Future<int> _count(Database db) async {
+    return Sqflite.firstIntValue(
+          await db.rawQuery('SELECT COUNT(*) FROM group_pending_invites'),
+        ) ??
+        0;
+  }
+
+  static Future<void> _pruneExpired(Database db) async {
+    final cutoff =
+        DateTime.now().millisecondsSinceEpoch - retention.inMilliseconds;
+    await db.delete(
+      'group_pending_invites',
+      where: 'receivedAt < ?',
+      whereArgs: [cutoff],
+    );
+  }
+}

--- a/lib/util/group_pending_invite_store.dart
+++ b/lib/util/group_pending_invite_store.dart
@@ -119,9 +119,16 @@ class GroupPendingInviteStore {
 
   /// Returns the held envelope for [senderId] and deletes the row in the
   /// same critical section, so a second caller cannot replay it.
+  ///
+  /// Expired rows are pruned first, like every other read: a held invite is
+  /// a point-in-time snapshot of a group's roster and key version, so the
+  /// retention window is also the bound on how stale a replayed one can be.
+  /// Without this prune that bound would have a hole exactly here, on the
+  /// one path that actually applies the snapshot.
   static Future<String?> take(String senderId) async {
     return _mutex.protect(() async {
       final db = await DBHelper.database;
+      await _pruneExpired(db);
       final rows = await db.query(
         'group_pending_invites',
         where: 'senderId = ?',

--- a/lib/util/group_pending_invite_store.dart
+++ b/lib/util/group_pending_invite_store.dart
@@ -1,3 +1,5 @@
+import 'dart:convert';
+
 import 'package:mutex/mutex.dart';
 import 'package:prysm/util/db_helper.dart';
 import 'package:sqflite/sqflite.dart';
@@ -33,16 +35,19 @@ class GroupPendingInviteStore {
   /// with no user action.
   static const Duration retention = Duration(days: 7);
 
-  /// Longest held envelope, in UTF-16 code units — the envelope is base64
-  /// and JSON, i.e. ASCII, so this equals its size in bytes, and checking
-  /// `length` costs nothing on a payload whose whole point is being large.
+  /// Longest held envelope, in **UTF-8 bytes** — that is what SQLite stores,
+  /// and the wire is `data['message']` straight off `POST /message`, whose
+  /// only validation is `is String` (`inbound_message_router.dart:854`).
+  /// Measuring `String.length` instead would count UTF-16 code units and let
+  /// a non-ASCII payload through at up to three bytes per unit, i.e. 192 KiB
+  /// per row against a declared 64 KiB.
   ///
   /// Same order as the `/sync-hint` body cap (InboundLimits.maxControlBodyBytes,
   /// 64 KiB): a real `control-wrap-2` invite envelope is a few kilobytes, so
   /// this rejects only abuse. It is load-bearing because the general inbound
   /// cap allows a body of up to 96 MiB, and 20 rows at that size would pin
   /// roughly 1.9 GB of attacker-chosen bytes for the whole retention window.
-  static const int maxPendingWireChars = 64 * 1024;
+  static const int maxPendingWireBytes = 64 * 1024;
 
   static Future<void> ensureTable(Database db) async {
     await db.execute('''
@@ -56,7 +61,7 @@ class GroupPendingInviteStore {
 
   /// Keeps [wire] as the pending invite for [senderId], replacing any
   /// previous one from the same sender. Returns false when the global cap
-  /// refuses a new sender or when [wire] exceeds [maxPendingWireChars]; the
+  /// refuses a new sender or when [wire] exceeds [maxPendingWireBytes]; the
   /// caller drops the invite exactly as it would with the feature off.
   static Future<bool> hold({
     required String senderId,
@@ -66,7 +71,13 @@ class GroupPendingInviteStore {
       // Same refusal as the global cap below: a wire this large is not a
       // real invite envelope, and holding it would let unauthenticated
       // traffic pin attacker-chosen bytes for the retention window.
-      if (wire.length > maxPendingWireChars) return false;
+      //
+      // The cheap test runs first and is not redundant: UTF-8 is never fewer
+      // bytes than UTF-16 code units, so a wire over the bound in units is
+      // over it in bytes too. Encoding unconditionally would allocate ~288 MiB
+      // to measure a 96 MiB body — a DoS in the guard meant to prevent one.
+      if (wire.length > maxPendingWireBytes) return false;
+      if (utf8.encode(wire).length > maxPendingWireBytes) return false;
       final db = await DBHelper.database;
       await _pruneExpired(db);
 

--- a/lib/util/group_pending_invite_store.dart
+++ b/lib/util/group_pending_invite_store.dart
@@ -33,6 +33,17 @@ class GroupPendingInviteStore {
   /// with no user action.
   static const Duration retention = Duration(days: 7);
 
+  /// Longest held envelope, in UTF-16 code units — the envelope is base64
+  /// and JSON, i.e. ASCII, so this equals its size in bytes, and checking
+  /// `length` costs nothing on a payload whose whole point is being large.
+  ///
+  /// Same order as the `/sync-hint` body cap (InboundLimits.maxControlBodyBytes,
+  /// 64 KiB): a real `control-wrap-2` invite envelope is a few kilobytes, so
+  /// this rejects only abuse. It is load-bearing because the general inbound
+  /// cap allows a body of up to 96 MiB, and 20 rows at that size would pin
+  /// roughly 1.9 GB of attacker-chosen bytes for the whole retention window.
+  static const int maxPendingWireChars = 64 * 1024;
+
   static Future<void> ensureTable(Database db) async {
     await db.execute('''
       CREATE TABLE IF NOT EXISTS group_pending_invites (
@@ -45,13 +56,17 @@ class GroupPendingInviteStore {
 
   /// Keeps [wire] as the pending invite for [senderId], replacing any
   /// previous one from the same sender. Returns false when the global cap
-  /// refuses a new sender; the caller drops the invite exactly as it would
-  /// with the feature off.
+  /// refuses a new sender or when [wire] exceeds [maxPendingWireChars]; the
+  /// caller drops the invite exactly as it would with the feature off.
   static Future<bool> hold({
     required String senderId,
     required String wire,
   }) async {
     return _mutex.protect(() async {
+      // Same refusal as the global cap below: a wire this large is not a
+      // real invite envelope, and holding it would let unauthenticated
+      // traffic pin attacker-chosen bytes for the retention window.
+      if (wire.length > maxPendingWireChars) return false;
       final db = await DBHelper.database;
       await _pruneExpired(db);
 
@@ -131,6 +146,18 @@ class GroupPendingInviteStore {
         where: 'senderId = ?',
         whereArgs: [senderId],
       );
+    });
+  }
+
+  /// Deletes every pending invite.
+  ///
+  /// Called when the user switches to `contactsOnly` mode: that mode
+  /// promises nothing is stored, so whatever was held while the mode was
+  /// `holdAsRequest` is discarded the moment the choice is made.
+  static Future<void> clear() async {
+    await _mutex.protect(() async {
+      final db = await DBHelper.database;
+      await db.delete('group_pending_invites');
     });
   }
 

--- a/test/group_invite_mode_settings_test.dart
+++ b/test/group_invite_mode_settings_test.dart
@@ -1,0 +1,51 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:prysm/models/group_invite_mode.dart';
+import 'package:prysm/models/settings.dart';
+import 'package:prysm/services/settings_service.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  test('the default mode holds invites from unknown senders', () {
+    expect(Settings().groupInviteMode, GroupInviteMode.holdAsRequest);
+  });
+
+  test('the mode survives a JSON round trip', () {
+    final restored = Settings.fromJson(
+      Settings(groupInviteMode: GroupInviteMode.contactsOnly).toJson(),
+    );
+    expect(restored.groupInviteMode, GroupInviteMode.contactsOnly);
+  });
+
+  test('an unknown stored value falls back to the default', () {
+    expect(
+      Settings.fromJson({'groupInviteMode': 'whatever-a-future-build-wrote'})
+          .groupInviteMode,
+      GroupInviteMode.holdAsRequest,
+    );
+  });
+
+  test('both modes carry a label and an explanatory description', () {
+    for (final mode in GroupInviteMode.values) {
+      expect(mode.label, isNotEmpty);
+      expect(mode.description, isNotEmpty);
+      expect(mode.description.length, greaterThan(40));
+    }
+  });
+
+  test('the setter persists the mode through SettingsService', () async {
+    SharedPreferences.setMockInitialValues({});
+    final service = SettingsService();
+    await service.init();
+    addTearDown(
+      () => service.setGroupInviteMode(GroupInviteMode.holdAsRequest),
+    );
+
+    await service.setGroupInviteMode(GroupInviteMode.contactsOnly);
+    expect(service.groupInviteMode, GroupInviteMode.contactsOnly);
+
+    await service.load();
+    expect(service.groupInviteMode, GroupInviteMode.contactsOnly);
+  });
+}

--- a/test/security/chat_db_v10_v11_upgrade_test.dart
+++ b/test/security/chat_db_v10_v11_upgrade_test.dart
@@ -13,7 +13,7 @@
 // Like test/security/database_cipher_test.dart, this builds a real on-disk
 // database in a fresh temp directory and drives DBHelper's actual open path:
 // plaintext v10/v11 fixture -> DatabaseCipher.prepare (in-place encryption)
-// -> openDatabase(version: 13, onUpgrade) -> real GroupSenderIndexStore
+// -> openDatabase(version: 14, onUpgrade) -> real GroupSenderIndexStore
 // calls.
 import 'dart:io';
 
@@ -263,14 +263,14 @@ void main() {
       expect(File(path).existsSync(), isTrue);
 
       // The real open path: DatabaseCipher.prepare encrypts the plaintext
-      // fixture in place, then openDatabase(version: 13, onUpgrade) runs the
+      // fixture in place, then openDatabase(version: 14, onUpgrade) runs the
       // oldVersion < 11 and oldVersion < 13 steps that create
       // group_inbound_seen and group_inbound_floor. The handle is closed by
       // DBHelper.closeForWipe() in tearDown.
       final db = await DBHelper.database;
 
       final uv = await db.rawQuery('PRAGMA user_version');
-      expect(uv.first.values.single, 13);
+      expect(uv.first.values.single, 14);
 
       final inbound = await db.rawQuery(
         "SELECT name FROM sqlite_master WHERE type = 'table' "
@@ -366,7 +366,7 @@ void main() {
       final db = await DBHelper.database;
 
       final uv = await db.rawQuery('PRAGMA user_version');
-      expect(uv.first.values.single, 13);
+      expect(uv.first.values.single, 14);
 
       final cols = await db.rawQuery('PRAGMA table_info(group_inbound_seen)');
       final colNames = cols.map((c) => c['name']).toSet();

--- a/test/security/chat_db_v13_v14_upgrade_test.dart
+++ b/test/security/chat_db_v13_v14_upgrade_test.dart
@@ -1,0 +1,210 @@
+// Regression test for the chat_app.db schema upgrade in the group-invite
+// wave: DBHelper bumped the schema to version 14 so an install already at
+// version 13 gets the new group_pending_invites table (the bounded store
+// for invites from senders whose identity is not local yet). Before the
+// v14 bump the table was only created from onCreate and from the
+// oldVersion < 7 step, so an install at version 13 would throw "no such
+// table: group_pending_invites" on the first hold.
+//
+// Like test/security/database_cipher_test.dart, this builds a real on-disk
+// database in a fresh temp directory and drives DBHelper's actual open path:
+// plaintext v13 fixture -> DatabaseCipher.prepare (in-place encryption)
+// -> openDatabase(version: 14, onUpgrade) -> real GroupPendingInviteStore
+// calls.
+import 'dart:io';
+
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:prysm/crypto/key_store.dart';
+import 'package:prysm/crypto/ratchet/session_store.dart';
+import 'package:prysm/database/blocked_users_db.dart';
+import 'package:prysm/database/call_logs_db.dart';
+import 'package:prysm/database/conversation_preferences_db.dart';
+import 'package:prysm/util/db_helper.dart';
+import 'package:prysm/util/group_pending_invite_store.dart';
+import 'package:prysm/util/group_sender_index_store.dart';
+import 'package:sqflite/sqflite.dart';
+import 'package:sqflite_common_ffi/sqflite_ffi.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  late Directory tempDir;
+
+  setUpAll(() {
+    sqfliteFfiInit();
+    databaseFactory = databaseFactoryFfi;
+  });
+
+  setUp(() {
+    tempDir = Directory.systemTemp.createTempSync('chat_db_v13_v14_upgrade_test');
+    Directory('${tempDir.path}/prysm').createSync(recursive: true);
+    CryptoKeyStore.setUseInMemoryStorageOnly(true);
+    CryptoKeyStore.resetInMemoryStorageForTest();
+
+    // Point path_provider at the throwaway directory so DBHelper opens
+    // <tempDir>/prysm/chat_app.db.
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(
+      const MethodChannel('plugins.flutter.io/path_provider'),
+      (call) async {
+        if (call.method == 'getApplicationDocumentsDirectory') {
+          return tempDir.path;
+        }
+        return null;
+      },
+    );
+  });
+
+  tearDown(() async {
+    // Close the handle DBHelper memoised so nothing leaks into the rest of
+    // the suite, then forget every cached open.
+    await DBHelper.closeForWipe();
+    DBHelper.setDatabaseForTest(null);
+    CryptoKeyStore.resetInMemoryStorageForTest();
+    CryptoKeyStore.setUseInMemoryStorageOnly(false);
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(
+      const MethodChannel('plugins.flutter.io/path_provider'),
+      null,
+    );
+    if (tempDir.existsSync()) {
+      tempDir.deleteSync(recursive: true);
+    }
+  });
+
+  /// Builds a real v13 chat_app.db at [path]: every table the v13 onCreate
+  /// created, with the same DDL it used, plus one pre-existing user row and
+  /// one pre-existing outbound counter row, and `PRAGMA user_version = 13`.
+  ///
+  /// The DDL is taken from DBHelper._createDB / _createGroupTables and the
+  /// public satellite createTable/ensureTable helpers (ConversationPreferencesDb,
+  /// BlockedUsersDb, CallLogsDb, RatchetSessionStore, GroupSenderIndexStore)
+  /// so the fixture cannot drift from the real schema. The one exception is
+  /// group_pending_invites, the table under test:
+  /// GroupPendingInviteStore.ensureTable must NOT be called here — the
+  /// fixture would build the table and make the test vacuous.
+  Future<void> buildV13Fixture(String path) async {
+    final db = await databaseFactory.openDatabase(
+      path,
+      options: OpenDatabaseOptions(singleInstance: false),
+    );
+    try {
+      // users + idx_users_name: DBHelper._createDB.
+      await db.execute('''
+        CREATE TABLE users (
+          id TEXT PRIMARY KEY,
+          name TEXT,
+          avatarUrl TEXT,
+          avatarBase64 TEXT,
+          customName TEXT,
+          publicKeyPem TEXT,
+          identityJson TEXT
+        )
+      ''');
+      await db.execute('CREATE INDEX idx_users_name ON users(name)');
+      // groups, group_members, group_keys: DBHelper._createGroupTables.
+      await db.execute('''
+        CREATE TABLE groups (
+          id TEXT PRIMARY KEY,
+          name TEXT NOT NULL,
+          avatarBase64 TEXT,
+          createdBy TEXT NOT NULL,
+          createdAt INTEGER NOT NULL
+        )
+      ''');
+      await db.execute('''
+        CREATE TABLE group_members (
+          groupId TEXT NOT NULL,
+          memberId TEXT NOT NULL,
+          role TEXT NOT NULL,
+          joinedAt INTEGER NOT NULL,
+          PRIMARY KEY (groupId, memberId),
+          FOREIGN KEY (groupId) REFERENCES groups(id) ON DELETE CASCADE
+        )
+      ''');
+      await db.execute('''
+        CREATE TABLE group_keys (
+          groupId TEXT PRIMARY KEY,
+          encryptedKey TEXT NOT NULL,
+          keyVersion INTEGER NOT NULL DEFAULT 1,
+          FOREIGN KEY (groupId) REFERENCES groups(id) ON DELETE CASCADE
+        )
+      ''');
+      // conversation_preferences, blocked_users, call_logs: the satellite
+      // helpers DBHelper calls.
+      await ConversationPreferencesDb.createTable(db);
+      await BlockedUsersDb.createTable(db);
+      await CallLogsDb.createTable(db);
+      // session_state, group_sender_index, group_inbound_seen,
+      // group_inbound_floor: DBHelper._createCryptoTables.
+      await RatchetSessionStore.ensureTable(db);
+      await GroupSenderIndexStore.ensureTable(db);
+      // Rows the upgrade must preserve: silently dropping them would be
+      // worse than the missing pending table.
+      await db.insert('users', {
+        'id': 'local-user',
+        'name': 'Local',
+      });
+      await db.insert('group_sender_index', {
+        'groupId': 'g1',
+        'senderId': 'local-user',
+        'nextIndex': 7,
+      });
+
+      await db.rawQuery('PRAGMA user_version = 13');
+
+      // Fixture guards, each its own expect: a single isNot(containsAll([...]))
+      // is satisfied by the absence of one element and would be vacuous —
+      // this is the CN4 lesson from PR #128.
+      final tables = await db.rawQuery(
+        "SELECT name FROM sqlite_master WHERE type='table' AND name=?",
+        ['group_pending_invites'],
+      );
+      expect(tables, isEmpty, reason: 'the v13 fixture must not have the table');
+      expect(
+        Sqflite.firstIntValue(await db.rawQuery('PRAGMA user_version')),
+        13,
+      );
+    } finally {
+      await db.close();
+    }
+  }
+
+  test('v13 -> v14 adds group_pending_invites and keeps existing rows',
+      () async {
+    final path = '${tempDir.path}/prysm/chat_app.db';
+    await buildV13Fixture(path);
+    expect(File(path).existsSync(), isTrue);
+
+    // The real open path: DatabaseCipher.prepare encrypts the plaintext
+    // fixture in place, then openDatabase(version: 14, onUpgrade) runs the
+    // oldVersion < 14 step that creates group_pending_invites. The handle
+    // is closed by DBHelper.closeForWipe() in tearDown.
+    final db = await DBHelper.database;
+
+    expect(Sqflite.firstIntValue(await db.rawQuery('PRAGMA user_version')), 14);
+    expect(
+      await db.rawQuery(
+        "SELECT name FROM sqlite_master WHERE type='table' AND name=?",
+        ['group_pending_invites'],
+      ),
+      hasLength(1),
+    );
+    // The upgrade is not allowed to lose what was already there.
+    expect(await db.query('users'), hasLength(1));
+    expect(
+      (await db.query('group_sender_index')).single['nextIndex'],
+      7,
+    );
+    // The upgraded file works with the real store, not just the schema.
+    expect(
+      await GroupPendingInviteStore.hold(
+        senderId: 'a.onion',
+        wire: 'wire-a',
+      ),
+      isTrue,
+    );
+    expect(await GroupPendingInviteStore.count(), 1);
+  });
+}

--- a/test/security/group_pending_invite_store_test.dart
+++ b/test/security/group_pending_invite_store_test.dart
@@ -1,0 +1,123 @@
+// The pending-invite table is written by UNAUTHENTICATED inbound traffic:
+// POST /message authenticates nobody and its only rate limit is keyed on the
+// sender-claimed senderId (PrysmServer.dart:223-228). These tests pin the
+// three bounds that keep it from being a remote write primitive.
+import 'package:flutter_test/flutter_test.dart';
+import 'package:prysm/util/db_helper.dart';
+import 'package:prysm/util/group_pending_invite_store.dart';
+import 'package:sqflite_common_ffi/sqflite_ffi.dart';
+
+Future<Database> _openDb() async {
+  final db = await databaseFactory.openDatabase(
+    '${inMemoryDatabasePath}_${DateTime.now().microsecondsSinceEpoch}',
+    options: OpenDatabaseOptions(version: 1),
+  );
+  await GroupPendingInviteStore.ensureTable(db);
+  return db;
+}
+
+void main() {
+  late Database db;
+
+  setUpAll(() {
+    TestWidgetsFlutterBinding.ensureInitialized();
+    sqfliteFfiInit();
+    databaseFactory = databaseFactoryFfi;
+  });
+
+  setUp(() async {
+    db = await _openDb();
+    DBHelper.setDatabaseForTest(db);
+  });
+
+  tearDown(() async {
+    await db.close();
+    DBHelper.setDatabaseForTest(null);
+  });
+
+  test('a held invite comes back, newest first', () async {
+    expect(await GroupPendingInviteStore.hold(
+      senderId: 'a.onion',
+      wire: 'wire-a',
+    ), isTrue);
+    expect(await GroupPendingInviteStore.hold(
+      senderId: 'b.onion',
+      wire: 'wire-b',
+    ), isTrue);
+
+    final rows = await GroupPendingInviteStore.pending();
+    expect(rows, hasLength(2));
+    expect(rows.first['senderId'], 'b.onion');
+    expect(rows.first['wire'], 'wire-b');
+    expect(await GroupPendingInviteStore.count(), 2);
+  });
+
+  test('a second invite from the same sender replaces the first', () async {
+    await GroupPendingInviteStore.hold(senderId: 'a.onion', wire: 'first');
+    await GroupPendingInviteStore.hold(senderId: 'a.onion', wire: 'second');
+
+    final rows = await GroupPendingInviteStore.pending();
+    expect(rows, hasLength(1));
+    expect(rows.single['wire'], 'second');
+  });
+
+  test('the 21st distinct sender is refused and changes nothing', () async {
+    for (var i = 0; i < GroupPendingInviteStore.maxPendingSenders; i++) {
+      expect(
+        await GroupPendingInviteStore.hold(senderId: 's$i.onion', wire: 'w$i'),
+        isTrue,
+      );
+    }
+
+    expect(
+      await GroupPendingInviteStore.hold(
+        senderId: 'one-too-many.onion',
+        wire: 'w',
+      ),
+      isFalse,
+    );
+    expect(await GroupPendingInviteStore.count(),
+        GroupPendingInviteStore.maxPendingSenders);
+    // An existing sender may still refresh its own slot at capacity.
+    expect(
+      await GroupPendingInviteStore.hold(senderId: 's0.onion', wire: 'fresh'),
+      isTrue,
+    );
+  });
+
+  test('a row past the retention window is pruned, a fresh one is kept',
+      () async {
+    final now = DateTime.now().millisecondsSinceEpoch;
+    final expired = now - GroupPendingInviteStore.retention.inMilliseconds - 1;
+    final fresh = now - GroupPendingInviteStore.retention.inMilliseconds ~/ 2;
+    await db.insert('group_pending_invites', {
+      'senderId': 'old.onion',
+      'wire': 'old',
+      'receivedAt': expired,
+    });
+    await db.insert('group_pending_invites', {
+      'senderId': 'recent.onion',
+      'wire': 'recent',
+      'receivedAt': fresh,
+    });
+
+    expect(await GroupPendingInviteStore.count(), 1);
+    final rows = await GroupPendingInviteStore.pending();
+    expect(rows.single['senderId'], 'recent.onion');
+  });
+
+  test('take returns the wire once and deletes the row', () async {
+    await GroupPendingInviteStore.hold(senderId: 'a.onion', wire: 'wire-a');
+
+    expect(await GroupPendingInviteStore.take('a.onion'), 'wire-a');
+    expect(await GroupPendingInviteStore.take('a.onion'), isNull);
+    expect(await GroupPendingInviteStore.count(), 0);
+  });
+
+  test('discard removes the row without returning it', () async {
+    await GroupPendingInviteStore.hold(senderId: 'a.onion', wire: 'wire-a');
+
+    await GroupPendingInviteStore.discard('a.onion');
+    expect(await GroupPendingInviteStore.count(), 0);
+  });
+}

--- a/test/security/group_pending_invite_store_test.dart
+++ b/test/security/group_pending_invite_store_test.dart
@@ -106,6 +106,28 @@ void main() {
     expect(rows.single['senderId'], 'recent.onion');
   });
 
+  test('a wire longer than the bound is refused and changes nothing',
+      () async {
+    expect(
+      await GroupPendingInviteStore.hold(
+        senderId: 'big.onion',
+        wire: 'x' * (GroupPendingInviteStore.maxPendingWireChars + 1),
+      ),
+      isFalse,
+    );
+    expect(await GroupPendingInviteStore.count(), 0);
+
+    // A wire exactly at the bound is accepted.
+    expect(
+      await GroupPendingInviteStore.hold(
+        senderId: 'at-bound.onion',
+        wire: 'x' * GroupPendingInviteStore.maxPendingWireChars,
+      ),
+      isTrue,
+    );
+    expect(await GroupPendingInviteStore.count(), 1);
+  });
+
   test('take returns the wire once and deletes the row', () async {
     await GroupPendingInviteStore.hold(senderId: 'a.onion', wire: 'wire-a');
 

--- a/test/security/group_pending_invite_store_test.dart
+++ b/test/security/group_pending_invite_store_test.dart
@@ -136,6 +136,20 @@ void main() {
     expect(await GroupPendingInviteStore.count(), 0);
   });
 
+  test('take returns null for a row past the retention window', () async {
+    final expired = DateTime.now().millisecondsSinceEpoch -
+        GroupPendingInviteStore.retention.inMilliseconds -
+        1;
+    await db.insert('group_pending_invites', {
+      'senderId': 'stale.onion',
+      'wire': 'stale',
+      'receivedAt': expired,
+    });
+
+    expect(await GroupPendingInviteStore.take('stale.onion'), isNull);
+    expect(await GroupPendingInviteStore.count(), 0);
+  });
+
   test('discard removes the row without returning it', () async {
     await GroupPendingInviteStore.hold(senderId: 'a.onion', wire: 'wire-a');
 

--- a/test/security/group_pending_invite_store_test.dart
+++ b/test/security/group_pending_invite_store_test.dart
@@ -1,7 +1,9 @@
 // The pending-invite table is written by UNAUTHENTICATED inbound traffic:
 // POST /message authenticates nobody and its only rate limit is keyed on the
 // sender-claimed senderId (PrysmServer.dart:223-228). These tests pin the
-// three bounds that keep it from being a remote write primitive.
+// four bounds that keep it from being a remote write primitive.
+import 'dart:convert';
+
 import 'package:flutter_test/flutter_test.dart';
 import 'package:prysm/util/db_helper.dart';
 import 'package:prysm/util/group_pending_invite_store.dart';
@@ -111,7 +113,7 @@ void main() {
     expect(
       await GroupPendingInviteStore.hold(
         senderId: 'big.onion',
-        wire: 'x' * (GroupPendingInviteStore.maxPendingWireChars + 1),
+        wire: 'x' * (GroupPendingInviteStore.maxPendingWireBytes + 1),
       ),
       isFalse,
     );
@@ -121,8 +123,38 @@ void main() {
     expect(
       await GroupPendingInviteStore.hold(
         senderId: 'at-bound.onion',
-        wire: 'x' * GroupPendingInviteStore.maxPendingWireChars,
+        wire: 'x' * GroupPendingInviteStore.maxPendingWireBytes,
       ),
+      isTrue,
+    );
+    expect(await GroupPendingInviteStore.count(), 1);
+  });
+
+  test('the bound counts UTF-8 bytes, not UTF-16 code units', () async {
+    // '€' is one UTF-16 code unit and three UTF-8 bytes, so a length that
+    // fits the bound in code units can still be three times over it in the
+    // bytes SQLite actually stores.
+    final over = '€' * (GroupPendingInviteStore.maxPendingWireBytes ~/ 3 + 1);
+    expect(over.length, lessThan(GroupPendingInviteStore.maxPendingWireBytes));
+    expect(
+      utf8.encode(over).length,
+      greaterThan(GroupPendingInviteStore.maxPendingWireBytes),
+    );
+    expect(
+      await GroupPendingInviteStore.hold(senderId: 'euro.onion', wire: over),
+      isFalse,
+    );
+    expect(await GroupPendingInviteStore.count(), 0);
+
+    // The same alphabet just under the byte bound is accepted, so the guard
+    // rejects on size and not on being non-ASCII.
+    final under = '€' * (GroupPendingInviteStore.maxPendingWireBytes ~/ 3);
+    expect(
+      utf8.encode(under).length,
+      lessThanOrEqualTo(GroupPendingInviteStore.maxPendingWireBytes),
+    );
+    expect(
+      await GroupPendingInviteStore.hold(senderId: 'ok.onion', wire: under),
       isTrue,
     );
     expect(await GroupPendingInviteStore.count(), 1);


### PR DESCRIPTION
## What

First of three stacked PRs implementing the user-selectable group invite mode. This one adds only the data layer — no behaviour change to the inbound path yet.

- `GroupInviteMode` (`lib/models/group_invite_mode.dart`): two-value enum with `label` and `description`, so both choices can be explained in the UI without a tap.
- `Settings.groupInviteMode` + getter/setter on `SettingsService`. Default is `holdAsRequest`.
- `GroupPendingInviteStore` (`lib/util/group_pending_invite_store.dart`): bounded store for first-contact invites, plus `chat_app.db` `version: 14`.

## Why the store is bounded the way it is

This table is written by **unauthenticated** traffic: `POST /message` authenticates nobody, and the only rate limit is keyed on the sender-claimed `senderId` (`lib/server/PrysmServer.dart:223-228`). Without bounds it is a remote write primitive, so all four are load-bearing:

| Bound | Value | Why this and not something else |
|---|---|---|
| Per sender | 1 row (primary key); a newer invite replaces the older | One onion occupies one slot, not N |
| Global | 20 senders; **at capacity the new row is refused**, no eviction | Evicting the oldest would let an attacker delete a genuine request. Refusing degrades to today's drop, which is already the accepted worst case |
| Wire size | ≤ 64 KiB per envelope | A real `control-wrap-2` envelope is a few KB. The general inbound cap allows a 96 MiB body, so 20 rows at that size would pin ~1.9 GB of attacker-chosen bytes for the whole retention window |
| Retention | 7 days, pruned on the write path | Self-healing: a table filled by an attacker frees itself with no user action |

The row is the raw `control-wrap-2` envelope, stored **opaque**. It is never decrypted while pending: the payload is attacker-controlled and unauthenticated, so no field of it may reach the UI or the database in parsed form.

## Schema

`chat_app.db` goes to `version: 14`. `ensureTable` is called both from `_createCryptoTables` and from a **guarded ladder step**, because a table added only in `onCreate` would be missing on every installation already at v13 and would fail with `no such table` on the first group message.

## Verification

- `flutter analyze`: 0 issues.
- `flutter test`: all green on this branch alone.
- Upgrade path exercised on a real file, not in memory: `test/security/chat_db_v13_v14_upgrade_test.dart`.
- Bounds have tests that fail against the pre-fix code, including the exactly-at-the-bound case (`test/security/group_pending_invite_store_test.dart`).

## Review order

Stacked. Merge this first, then `invite-mode/policy`, then `invite-mode/ui`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable handling for group invites from unknown senders.
  * Users can hold invites as pending requests or accept invites only from contacts.
  * Added a pending invite requests screen with accept and discard actions.
  * Added privacy settings, navigation, and pending-request counts.
  * Pending requests are securely retained with size limits and automatic expiry.
* **Bug Fixes**
  * Preserved existing handling for other message types.
* **Tests**
  * Added coverage for settings, persistence, upgrades, storage, and invite workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->