### PR TITLE
Group invite mode (2/3): hold and promote policy

### DIFF
--- a/lib/screens/home/home_screen.dart
+++ b/lib/screens/home/home_screen.dart
@@ -54,6 +54,7 @@ import 'package:prysm/services/detached_chat_host.dart';
 import 'package:prysm/services/detached_chat_window_registry.dart';
 import 'package:prysm/screens/widgets/conversation_context_menu.dart';
 import 'package:prysm/screens/widgets/conversation_actions_sheet.dart';
+import 'package:prysm/services/group_invite_promoter.dart';
 import 'package:prysm/services/group_service.dart';
 import 'package:prysm/util/db_helper.dart';
 import 'package:prysm/util/desktop_platform.dart';
@@ -400,6 +401,27 @@ class _HomeScreenState extends State<HomeScreen> with WidgetsBindingObserver {
       if (!mounted) return;
       unawaited(AppUpdateService().checkOnStartup(context));
     });
+
+    // Invites held while their sender was unknown apply themselves once the
+    // contact exists — including when the user added them from somewhere
+    // else entirely. Skipped in decoy mode: a panic session must not touch
+    // real group state.
+    if (!widget.decoyMode) {
+      unawaited(
+        GroupInvitePromoter(
+          userId: widget.onionAddress,
+          keyManager: widget.keyManager,
+        )
+            .promoteResolvable()
+            .catchError((Object e, StackTrace st) {
+              Logging.error('Promoting held invites failed: $e\n$st', 'Main');
+              return 0;
+            })
+            .then((promoted) {
+              if (promoted > 0 && mounted) scheduleLoadUsers(light: true);
+            }),
+      );
+    }
 
     _startAutoRefresh();
     if (!widget.offlineMode) {

--- a/lib/services/group_invite_promoter.dart
+++ b/lib/services/group_invite_promoter.dart
@@ -1,5 +1,7 @@
 import 'package:prysm/constants/group_constants.dart';
+import 'package:prysm/models/group_invite_mode.dart';
 import 'package:prysm/services/group_service.dart';
+import 'package:prysm/services/settings_service.dart';
 import 'package:prysm/util/group_pending_invite_store.dart';
 import 'package:prysm/util/key_manager.dart';
 import 'package:prysm/util/logging.dart';
@@ -59,7 +61,14 @@ class GroupInvitePromoter {
 
   /// Promotes every pending invite whose sender is now locally known.
   /// Returns how many were applied.
+  ///
+  /// A no-op while the mode is `contactsOnly`: that mode promises nothing is
+  /// stored and nothing is applied, and any rows still present (e.g. held
+  /// before the mode changed) must not be promoted behind the user's back.
   Future<int> promoteResolvable() async {
+    if (SettingsService().groupInviteMode == GroupInviteMode.contactsOnly) {
+      return 0;
+    }
     final rows = await GroupPendingInviteStore.pending();
     var promoted = 0;
     for (final row in rows) {

--- a/lib/services/group_invite_promoter.dart
+++ b/lib/services/group_invite_promoter.dart
@@ -1,0 +1,72 @@
+import 'package:prysm/constants/group_constants.dart';
+import 'package:prysm/services/group_service.dart';
+import 'package:prysm/util/group_pending_invite_store.dart';
+import 'package:prysm/util/key_manager.dart';
+import 'package:prysm/util/logging.dart';
+import 'package:prysm/util/peer_identity_loader.dart';
+
+/// Replays a held first-contact invite once its sender's identity is in the
+/// local user store.
+///
+/// Promotion never bypasses authentication: the held envelope goes through
+/// [GroupService.handleIncomingControlMessage], the same path the message
+/// would have taken had the sender been known when it arrived. The row is
+/// removed either way — an envelope that fails to authenticate is garbage,
+/// and keeping it would let a failed attempt be retried forever.
+///
+/// Known limitation, deliberately not fixed here because it is not this
+/// class's to fix: an invite is a point-in-time snapshot of a group's roster
+/// and key version, and `_handleInvite`'s staleness guards read only local
+/// state (`group_service.dart:626-639`). So a snapshot applied late can
+/// re-create a group the user has since left — `deleteGroupLocal` removes the
+/// `group_keys` row, which sets `localKeyVersion` back to 0 and disarms the
+/// version guard — and can drop members who joined after it was taken, since
+/// adding a member does not rotate the key. This is a pre-existing property
+/// of the live path: a queued invite envelope re-delivered by the transport
+/// after the user left does exactly the same thing. Promotion does not widen
+/// it beyond `GroupPendingInviteStore.retention`, which bounds how stale a
+/// replayed snapshot can be.
+class GroupInvitePromoter {
+  GroupInvitePromoter({
+    required this.userId,
+    required this.keyManager,
+    GroupService? groupService,
+  }) : _groupService = groupService ??
+            GroupService(userId: userId, keyManager: keyManager);
+
+  final String userId;
+  final KeyManager keyManager;
+  final GroupService _groupService;
+
+  Future<bool> promote(String senderId) async {
+    final wire = await GroupPendingInviteStore.take(senderId);
+    if (wire == null) return false;
+    try {
+      return await _groupService.handleIncomingControlMessage(
+        groupInviteType,
+        wire,
+        senderId,
+      );
+    } catch (e) {
+      Logging.error(
+        'Promoting the held invite from ${Logging.redactOnion(senderId)} '
+        'failed: $e',
+        'GroupInvitePromoter',
+      );
+      return false;
+    }
+  }
+
+  /// Promotes every pending invite whose sender is now locally known.
+  /// Returns how many were applied.
+  Future<int> promoteResolvable() async {
+    final rows = await GroupPendingInviteStore.pending();
+    var promoted = 0;
+    for (final row in rows) {
+      final senderId = row['senderId'] as String;
+      if (await loadPeerIdentityFromDb(keyManager, senderId) == null) continue;
+      if (await promote(senderId)) promoted++;
+    }
+    return promoted;
+  }
+}

--- a/lib/services/group_service.dart
+++ b/lib/services/group_service.dart
@@ -6,13 +6,16 @@ import 'package:prysm/util/logging.dart';
 import 'package:prysm/constants/group_constants.dart';
 import 'package:prysm/database/messages.dart';
 import 'package:prysm/models/group.dart';
+import 'package:prysm/models/group_invite_mode.dart';
 import 'package:prysm/services/conversation_preferences_service.dart';
 import 'package:prysm/services/disappearing_timer_service.dart';
 import 'package:prysm/services/group_control_channel.dart';
 import 'package:prysm/services/group_key_provider.dart';
+import 'package:prysm/services/settings_service.dart';
 import 'package:prysm/util/db_helper.dart';
 import 'package:prysm/crypto/group_crypto.dart';
 import 'package:prysm/crypto/identity.dart';
+import 'package:prysm/util/group_pending_invite_store.dart';
 import 'package:prysm/util/group_sender_index_store.dart';
 import 'package:prysm/util/key_manager.dart';
 import 'package:prysm/util/group_membership_notifier.dart';
@@ -37,6 +40,7 @@ class GroupServiceException implements Exception {
 class GroupService {
   final String userId;
   final KeyManager keyManager;
+  final SettingsService _settings = SettingsService();
 
   late final GroupKeyProvider _keyProvider;
   late final GroupControlChannel _controlChannel;
@@ -480,16 +484,46 @@ class GroupService {
   ) async {
     final senderKeys = await _resolveSenderIdentity(senderId);
     // Accepted policy (option 1, PR #128): a control message from a sender
-    // whose identity is not in the local store is deliberately dropped —
-    // the invitee sees nothing today. The identity is not merely unverified
-    // but required: decryptControlPayload below authenticates the payload
-    // against it, so the payload cannot even be read without it. Do not
-    // "fix" this by resolving the sender over the network on cache-miss:
-    // that would reopen the M2 profile-fetch oracle (an unauthenticated
-    // sender forcing GET /profile as an implicit delivery receipt) before
-    // any signature check. A pending-invite flow is the tracked follow-up
-    // (https://github.com/xmreur/prysm/pull/128#issuecomment-5205552544).
+    // whose identity is not in the local store is not processed. The
+    // identity is required to *authenticate* it: decryptControlPayload
+    // below verifies the control-wrap-2 signature against it, so without it
+    // the payload can only be read unverified — which is exactly what must
+    // not happen. Do not "fix" this by resolving the sender over the network
+    // on cache-miss: that would reopen the M2 profile-fetch oracle (an
+    // unauthenticated sender forcing GET /profile as an implicit delivery
+    // receipt) before any signature check.
+    //
+    // What the user can choose (GroupInviteMode) is only what happens to an
+    // *invite* afterwards: dropped outright, or held opaque and bounded for
+    // the user to accept — never processed, never decrypted, and never a
+    // reason to send anything.
     if (senderKeys == null) {
+      if (type == groupInviteType &&
+          _settings.groupInviteMode == GroupInviteMode.holdAsRequest) {
+        // A store failure must not change the sender-visible outcome: on
+        // this ingress a status difference is an oracle, so a broken store
+        // (DB error, locked file) degrades to the plain drop, exactly like
+        // a full one.
+        try {
+          final held = await GroupPendingInviteStore.hold(
+            senderId: senderId,
+            wire: encryptedPayload,
+          );
+          if (!held) {
+            Logging.error(
+              'Pending invite store full, dropping invite from '
+              '${Logging.redactOnion(senderId)}',
+              'GroupService',
+            );
+          }
+        } catch (e) {
+          Logging.error(
+            'Pending invite store failed, dropping invite from '
+            '${Logging.redactOnion(senderId)}: $e',
+            'GroupService',
+          );
+        }
+      }
       Logging.error(
         'Dropping $type from ${Logging.redactOnion(senderId)}: '
         'sender identity unresolvable',

--- a/lib/util/group_pending_invite_store.dart
+++ b/lib/util/group_pending_invite_store.dart
@@ -119,9 +119,16 @@ class GroupPendingInviteStore {
 
   /// Returns the held envelope for [senderId] and deletes the row in the
   /// same critical section, so a second caller cannot replay it.
+  ///
+  /// Expired rows are pruned first, like every other read: a held invite is
+  /// a point-in-time snapshot of a group's roster and key version, so the
+  /// retention window is also the bound on how stale a replayed one can be.
+  /// Without this prune that bound would have a hole exactly here, on the
+  /// one path that actually applies the snapshot.
   static Future<String?> take(String senderId) async {
     return _mutex.protect(() async {
       final db = await DBHelper.database;
+      await _pruneExpired(db);
       final rows = await db.query(
         'group_pending_invites',
         where: 'senderId = ?',

--- a/test/group_control_auth_test.dart
+++ b/test/group_control_auth_test.dart
@@ -11,6 +11,7 @@ import 'package:prysm/crypto/wire.dart';
 import 'package:prysm/database/messages.dart';
 import 'package:prysm/services/group_service.dart';
 import 'package:prysm/util/db_helper.dart';
+import 'package:prysm/util/group_pending_invite_store.dart';
 import 'package:prysm/util/group_sender_index_store.dart';
 import 'package:prysm/util/key_manager.dart';
 import 'package:prysm/util/tor_runtime_gate.dart';
@@ -86,6 +87,7 @@ Future<Database> _openTestDb() async {
           )
         ''');
         await GroupSenderIndexStore.ensureTable(db);
+        await GroupPendingInviteStore.ensureTable(db);
         await RatchetSessionStore.ensureTable(db);
       },
     ),

--- a/test/security/group_invite_mode_test.dart
+++ b/test/security/group_invite_mode_test.dart
@@ -1,0 +1,430 @@
+// Task 3 (group invite mode): the single ingress change of the
+// pending-invite flow.
+//
+// `GroupService.handleIncomingControlMessage` drops control messages from
+// senders whose identity is not in the local user store (M2: never resolve
+// the sender over the network on inbound traffic). The GroupInviteMode
+// setting chooses what happens to a *group_invite* at that drop:
+// contactsOnly drops it with nothing stored; holdAsRequest keeps exactly
+// one opaque, still-encrypted `control-wrap-2` envelope per sender in
+// GroupPendingInviteStore — never decrypted, never parsed, and never a
+// reason to fetch anything.
+//
+// The fake HTTP layer is the same one the POLICY tests use: it serves the
+// registered peer profiles, so a restored network identity-resolve would
+// succeed (and these tests go red) instead of failing silently. It is inert
+// while the DB-only resolve holds.
+import 'dart:async';
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:prysm/constants/group_constants.dart';
+import 'package:prysm/crypto/crypto.dart';
+import 'package:prysm/database/conversation_preferences_db.dart';
+import 'package:prysm/database/message_schema_migrations.dart';
+import 'package:prysm/database/messages.dart';
+import 'package:prysm/models/group_invite_mode.dart';
+import 'package:prysm/server/inbound_message_router.dart';
+import 'package:prysm/services/settings_service.dart';
+import 'package:prysm/util/db_helper.dart';
+import 'package:prysm/util/group_pending_invite_store.dart';
+import 'package:prysm/util/group_sender_index_store.dart';
+import 'package:prysm/util/key_manager.dart';
+import 'package:prysm/util/tor_runtime_gate.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:sqflite_common_ffi/sqflite_ffi.dart';
+
+Future<Database> _openMessagesDb() async {
+  return databaseFactory.openDatabase(
+    '${inMemoryDatabasePath}_${DateTime.now().microsecondsSinceEpoch}',
+    options: OpenDatabaseOptions(
+      version: MessageSchemaMigrations.dbVersion,
+      onCreate: MessageSchemaMigrations.onCreate,
+    ),
+  );
+}
+
+Future<Database> _openDbHelperDb() async {
+  final db = await databaseFactory.openDatabase(
+    '${inMemoryDatabasePath}_${DateTime.now().microsecondsSinceEpoch}',
+    options: OpenDatabaseOptions(
+      version: 1,
+      onCreate: (db, _) async {
+        await db.execute('''
+          CREATE TABLE users (
+            id TEXT PRIMARY KEY,
+            name TEXT,
+            avatarUrl TEXT,
+            avatarBase64 TEXT,
+            customName TEXT,
+            publicKeyPem TEXT,
+            identityJson TEXT
+          )
+        ''');
+        await db.execute('''
+          CREATE TABLE group_members (
+            groupId TEXT NOT NULL,
+            memberId TEXT NOT NULL,
+            role TEXT NOT NULL,
+            joinedAt INTEGER NOT NULL,
+            PRIMARY KEY (groupId, memberId)
+          )
+        ''');
+        await db.execute('''
+          CREATE TABLE groups (
+            id TEXT PRIMARY KEY,
+            name TEXT NOT NULL,
+            avatarBase64 TEXT,
+            createdBy TEXT NOT NULL,
+            createdAt INTEGER NOT NULL
+          )
+        ''');
+        await db.execute('''
+          CREATE TABLE group_keys (
+            groupId TEXT PRIMARY KEY,
+            encryptedKey TEXT NOT NULL,
+            keyVersion INTEGER NOT NULL DEFAULT 1
+          )
+        ''');
+        await ConversationPreferencesDb.createTable(db);
+      },
+    ),
+  );
+  await GroupSenderIndexStore.ensureTable(db);
+  await GroupPendingInviteStore.ensureTable(db);
+  return db;
+}
+
+/// Serves the peer profiles registered by the tests over fake HTTP.
+///
+/// The flutter_test binding replaces all outbound HTTP with an instant
+/// empty 400. That would make a restored network identity-resolve (the
+/// behavior the tests below forbid) fail silently and the tests would stay
+/// green. This fake stands in for the Tor network instead: it serves the
+/// registered profiles keyed by onion, so the tests only pass when the code
+/// under test never performs that fetch. It is inert while the policy
+/// holds — the DB-only resolve does no HTTP at all.
+class _ProfileNetworkOverrides extends HttpOverrides {
+  final Map<String, String> profilesByOnion;
+
+  _ProfileNetworkOverrides(this.profilesByOnion);
+
+  @override
+  HttpClient createHttpClient(SecurityContext? context) =>
+      _FakeHttpClient(profilesByOnion);
+}
+
+class _FakeHttpClient implements HttpClient {
+  final Map<String, String> profilesByOnion;
+
+  _FakeHttpClient(this.profilesByOnion);
+
+  @override
+  Future<HttpClientRequest> getUrl(Uri url) async =>
+      _FakeHttpClientRequest(profilesByOnion, url);
+
+  @override
+  Future<void> close({bool force = false}) async {}
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => null;
+}
+
+class _FakeHttpClientRequest implements HttpClientRequest {
+  final Map<String, String> profilesByOnion;
+  final Uri url;
+
+  _FakeHttpClientRequest(this.profilesByOnion, this.url);
+
+  @override
+  final HttpHeaders headers = _FakeHttpHeaders();
+
+  @override
+  Future<HttpClientResponse> close() async =>
+      _FakeHttpClientResponse(profilesByOnion, url);
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => null;
+}
+
+class _FakeHttpHeaders implements HttpHeaders {
+  @override
+  void set(String name, Object value, {bool preserveHeaderCase = false}) {}
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => null;
+}
+
+class _FakeHttpClientResponse implements HttpClientResponse {
+  final Map<String, String> profilesByOnion;
+  final Uri url;
+
+  _FakeHttpClientResponse(this.profilesByOnion, this.url);
+
+  String? get _body => profilesByOnion[url.host];
+
+  @override
+  int get statusCode => _body == null ? 400 : 200;
+
+  @override
+  int get contentLength => _body?.length ?? 0;
+
+  @override
+  Stream<S> transform<S>(StreamTransformer<List<int>, S> transformer) =>
+      Stream<List<int>>.fromIterable([utf8.encode(_body ?? '')])
+          .transform(transformer);
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => null;
+}
+
+/// Builds a `control-wrap-2` group invite exactly as a legitimate inviter
+/// sends it (`GroupControlChannel.sendInvite`): the fresh group key
+/// encrypted for the local user, the whole payload signed by the inviter.
+Future<Map<String, dynamic>> _inviteMessage({
+  required String id,
+  required String inviterId,
+  required IdentityKeyPair inviter,
+  required IdentityKeyPair recipient,
+  required String groupId,
+}) async {
+  final recipientAgreePublic = await recipient.agreePublicKey;
+  final groupKey = GroupCryptoV2.generateGroupKey();
+  final encryptedGroupKey = await GroupCryptoV2.encryptGroupKeyForStorage(
+    groupKey,
+    inviter,
+    peerAgreePublic: recipientAgreePublic,
+  );
+  final wire = await GroupCryptoV2.encryptControlPayload(
+    jsonEncode({
+      'groupId': groupId,
+      'name': 'Invited Group',
+      'createdBy': inviterId,
+      'members': [
+        {'id': 'local.onion', 'role': 'member'},
+        {'id': inviterId, 'role': 'admin'},
+      ],
+      'encryptedGroupKey': encryptedGroupKey,
+      'keyVersion': 1,
+    }),
+    inviter,
+    recipientAgreePublic,
+  );
+  return {
+    'id': id,
+    'senderId': inviterId,
+    'receiverId': 'local.onion',
+    'message': wire,
+    'type': groupInviteType,
+    'timestamp': 1000,
+  };
+}
+
+void main() {
+  late Database messagesDb;
+  late Database dbHelperDb;
+  late InboundMessageRouter router;
+  late IdentityKeyPair localIdentity;
+  late Map<String, IdentityPublicKeys> peers;
+  late List<String> fetched;
+
+  // Profiles the fake network serves, keyed by onion — populated by the
+  // tests so a restored network identity-resolve would succeed (and the
+  // tests go red) instead of failing silently.
+  final peerProfiles = <String, String>{};
+  late HttpOverrides? originalOverrides;
+
+  setUpAll(() {
+    TestWidgetsFlutterBinding.ensureInitialized();
+    sqfliteFfiInit();
+    databaseFactory = databaseFactoryFfi;
+    originalOverrides = HttpOverrides.current;
+    HttpOverrides.global = _ProfileNetworkOverrides(peerProfiles);
+  });
+
+  tearDownAll(() {
+    HttpOverrides.global = originalOverrides;
+  });
+
+  setUp(() async {
+    // The Tor runtime gate starts `stopped`, which would silently block any
+    // (forbidden) network identity-resolve — and mask a restored one. Ready
+    // keeps the tests honest: only the DB-only gate may drop.
+    TorRuntimeGate.resetForTest();
+    localIdentity = await IdentityKeyPair.generate();
+    peers = {};
+
+    messagesDb = await _openMessagesDb();
+    MessagesDb.setDatabaseForTest(messagesDb);
+
+    dbHelperDb = await _openDbHelperDb();
+    DBHelper.setDatabaseForTest(dbHelperDb);
+
+    fetched = [];
+    router = InboundMessageRouter(
+      keyManager: KeyManager.fromIdentity(localIdentity),
+      settings: SettingsService(),
+      localOnionAddress: () => 'local.onion',
+      fetchSenderProfile: (senderId) => fetched.add(senderId),
+      resolvePeerIdentity: (senderId) async => peers[senderId],
+    );
+  });
+
+  tearDown(() async {
+    // Claim ownership is process-global: a claim left by one case would
+    // refuse the same triple in the next, so it must be cleared between
+    // cases.
+    GroupSenderIndexStore.resetForTest();
+    await messagesDb.close();
+    MessagesDb.setDatabaseForTest(null);
+
+    await dbHelperDb.close();
+    DBHelper.setDatabaseForTest(null);
+  });
+
+  group('group invite mode', () {
+    setUp(() {
+      SharedPreferences.setMockInitialValues({});
+      // Profiles registered by the tests are keyed by onion, so a profile
+      // left behind by an earlier case would be served for a different
+      // identity later. Each case starts clean.
+      peerProfiles.clear();
+    });
+
+    tearDown(() async {
+      await SettingsService().setGroupInviteMode(GroupInviteMode.holdAsRequest);
+    });
+
+    test(
+      'contactsOnly: an invite from an unresolvable sender is dropped and '
+      'nothing is stored', () async {
+        await SettingsService().setGroupInviteMode(
+          GroupInviteMode.contactsOnly,
+        );
+        final inviter = await IdentityKeyPair.generate();
+        peerProfiles['stranger.onion'] =
+            jsonEncode(await inviter.toPublicJson());
+
+        final result = await router.handleMessage(await _inviteMessage(
+          id: 'm1',
+          inviterId: 'stranger.onion',
+          inviter: inviter,
+          recipient: localIdentity,
+          groupId: 'g1',
+        ));
+
+        expect(result.statusCode, 200);
+        expect(await GroupPendingInviteStore.count(), 0);
+        expect(await dbHelperDb.query('groups'), isEmpty);
+        expect(fetched, isEmpty);
+      },
+    );
+
+    test(
+      'holdAsRequest: the same invite is held exactly once, and still creates '
+      'no group and no fetch', () async {
+        final inviter = await IdentityKeyPair.generate();
+        peerProfiles['stranger.onion'] =
+            jsonEncode(await inviter.toPublicJson());
+        final invite = await _inviteMessage(
+          id: 'm1',
+          inviterId: 'stranger.onion',
+          inviter: inviter,
+          recipient: localIdentity,
+          groupId: 'g1',
+        );
+
+        final result = await router.handleMessage(invite);
+        // A retry of the same envelope must not create a second row.
+        await router.handleMessage({...invite, 'id': 'm2'});
+
+        expect(result.statusCode, 200);
+        final rows = await GroupPendingInviteStore.pending();
+        expect(rows, hasLength(1));
+        expect(rows.single['senderId'], 'stranger.onion');
+        expect(rows.single['wire'], invite['message']);
+        expect(await dbHelperDb.query('groups'), isEmpty);
+        expect(await dbHelperDb.query('group_members'), isEmpty);
+        expect(await dbHelperDb.query('group_keys'), isEmpty);
+        expect(fetched, isEmpty);
+      },
+    );
+
+    test(
+      'holdAsRequest: a failing pending-invite store degrades to the plain '
+      'drop — the sender sees the same 200 as a drop', () async {
+        await SettingsService().setGroupInviteMode(
+          GroupInviteMode.holdAsRequest,
+        );
+        final inviter = await IdentityKeyPair.generate();
+        peerProfiles['stranger.onion'] =
+            jsonEncode(await inviter.toPublicJson());
+
+        // Point the DB helper at a database that has no
+        // group_pending_invites table — the real failure mode of a stale or
+        // partial database — so hold() throws instead of writing. The
+        // ingress must not turn that into a 500 the sender can observe: it
+        // degrades to the drop.
+        final brokenDb = await databaseFactory.openDatabase(
+          '${inMemoryDatabasePath}_${DateTime.now().microsecondsSinceEpoch}',
+          options: OpenDatabaseOptions(
+            version: 1,
+            onCreate: (db, _) async {
+              await db.execute('''
+                CREATE TABLE users (
+                  id TEXT PRIMARY KEY,
+                  name TEXT,
+                  avatarUrl TEXT,
+                  avatarBase64 TEXT,
+                  customName TEXT,
+                  publicKeyPem TEXT,
+                  identityJson TEXT
+                )
+              ''');
+            },
+          ),
+        );
+        DBHelper.setDatabaseForTest(brokenDb);
+
+        final result = await router.handleMessage(await _inviteMessage(
+          id: 'm1',
+          inviterId: 'stranger.onion',
+          inviter: inviter,
+          recipient: localIdentity,
+          groupId: 'g1',
+        ));
+
+        expect(result.statusCode, 200);
+        // The exact ok-ack the plain drop answers with: status received and
+        // no error key (the unguarded failure used to surface as a 500
+        // {'error': ...} body instead).
+        expect(result.jsonBody, containsPair('status', 'received'));
+        expect(result.jsonBody, isNot(containsPair('error', anything)));
+        await brokenDb.close();
+      },
+    );
+
+    test(
+      'holdAsRequest holds invites only: a key rotate from an unresolvable '
+      'sender is dropped and stored nowhere', () async {
+        final stranger = await IdentityKeyPair.generate();
+        final result = await router.handleMessage({
+          'id': 'm1',
+          'senderId': 'stranger.onion',
+          'receiverId': 'local.onion',
+          'message': await GroupCryptoV2.encryptControlPayload(
+            jsonEncode({'groupId': 'g1', 'keyVersion': 2}),
+            stranger,
+            await localIdentity.agreePublicKey,
+          ),
+          'type': groupKeyRotateType,
+          'timestamp': 1000,
+        });
+
+        expect(result.statusCode, 200);
+        expect(await GroupPendingInviteStore.count(), 0);
+      },
+    );
+  });
+}

--- a/test/security/group_invite_mode_test.dart
+++ b/test/security/group_invite_mode_test.dart
@@ -434,6 +434,17 @@ void main() {
       },
     );
 
+    test('clear empties a populated store', () async {
+      await GroupPendingInviteStore.hold(senderId: 'a.onion', wire: 'wire-a');
+      await GroupPendingInviteStore.hold(senderId: 'b.onion', wire: 'wire-b');
+      expect(await GroupPendingInviteStore.count(), 2);
+
+      await GroupPendingInviteStore.clear();
+
+      expect(await GroupPendingInviteStore.count(), 0);
+      expect(await GroupPendingInviteStore.pending(), isEmpty);
+    });
+
     group('promotion', () {
       test(
         'once the inviter identity is stored, the held invite applies and '
@@ -531,6 +542,44 @@ void main() {
         final rows = await GroupPendingInviteStore.pending();
         expect(rows.single['senderId'], 'unknown.onion');
       });
+
+      test(
+        'contactsOnly: the sweep promotes nothing even with a resolvable '
+        'held sender', () async {
+          final inviter = await IdentityKeyPair.generate();
+          final invite = await _inviteMessage(
+            id: 'm1',
+            inviterId: 'stranger.onion',
+            inviter: inviter,
+            recipient: localIdentity,
+            groupId: 'g1',
+          );
+          await router.handleMessage(invite);
+          // The invite was held while the mode was the default; the switch
+          // to contactsOnly must stop the sweep from applying it even
+          // though the sender has meanwhile become resolvable.
+          expect(await GroupPendingInviteStore.count(), 1);
+          await SettingsService().setGroupInviteMode(
+            GroupInviteMode.contactsOnly,
+          );
+          final json = jsonEncode(await inviter.toPublicJson());
+          await DBHelper.insertOrUpdateUser({
+            'id': 'stranger.onion',
+            'name': 'Stranger',
+            'identityJson': json,
+            'publicKeyPem': json,
+          });
+
+          final promoted = await GroupInvitePromoter(
+            userId: 'local.onion',
+            keyManager: KeyManager.fromIdentity(localIdentity),
+          ).promoteResolvable();
+
+          expect(promoted, 0);
+          expect(await GroupPendingInviteStore.count(), 1);
+          expect(await dbHelperDb.query('groups'), isEmpty);
+        },
+      );
     });
   });
 }

--- a/test/security/group_invite_mode_test.dart
+++ b/test/security/group_invite_mode_test.dart
@@ -14,6 +14,12 @@
 // registered peer profiles, so a restored network identity-resolve would
 // succeed (and these tests go red) instead of failing silently. It is inert
 // while the DB-only resolve holds.
+//
+// Task 4 (group invite mode): promotion. Once the sender's identity is in
+// the local user store, the held envelope is replayed through the
+// authenticated path (`GroupInvitePromoter` -> `handleIncomingControlMessage`)
+// — never decrypted while pending, never resolved over the network, and the
+// row is gone whether the replay authenticates or not.
 import 'dart:async';
 import 'dart:convert';
 import 'dart:io';
@@ -26,6 +32,7 @@ import 'package:prysm/database/message_schema_migrations.dart';
 import 'package:prysm/database/messages.dart';
 import 'package:prysm/models/group_invite_mode.dart';
 import 'package:prysm/server/inbound_message_router.dart';
+import 'package:prysm/services/group_invite_promoter.dart';
 import 'package:prysm/services/settings_service.dart';
 import 'package:prysm/util/db_helper.dart';
 import 'package:prysm/util/group_pending_invite_store.dart';
@@ -426,5 +433,104 @@ void main() {
         expect(await GroupPendingInviteStore.count(), 0);
       },
     );
+
+    group('promotion', () {
+      test(
+        'once the inviter identity is stored, the held invite applies and '
+        'the row is gone', () async {
+          final inviter = await IdentityKeyPair.generate();
+          final invite = await _inviteMessage(
+            id: 'm1',
+            inviterId: 'stranger.onion',
+            inviter: inviter,
+            recipient: localIdentity,
+            groupId: 'g1',
+          );
+          await router.handleMessage(invite);
+          expect(await GroupPendingInviteStore.count(), 1);
+
+          // What "the user added the contact" leaves behind.
+          final json = jsonEncode(await inviter.toPublicJson());
+          await DBHelper.insertOrUpdateUser({
+            'id': 'stranger.onion',
+            'name': 'Stranger',
+            'identityJson': json,
+            'publicKeyPem': json,
+          });
+
+          final promoter = GroupInvitePromoter(
+            userId: 'local.onion',
+            keyManager: KeyManager.fromIdentity(localIdentity),
+          );
+          expect(await promoter.promote('stranger.onion'), isTrue);
+
+          expect(await GroupPendingInviteStore.count(), 0);
+          expect((await dbHelperDb.query('groups')).single['id'], 'g1');
+          expect(await dbHelperDb.query('group_members'), hasLength(2));
+        },
+      );
+
+      test('a tampered held envelope is discarded and creates no group',
+          () async {
+        final inviter = await IdentityKeyPair.generate();
+        final json = jsonEncode(await inviter.toPublicJson());
+        await DBHelper.insertOrUpdateUser({
+          'id': 'stranger.onion',
+          'name': 'Stranger',
+          'identityJson': json,
+          'publicKeyPem': json,
+        });
+        await GroupPendingInviteStore.hold(
+          senderId: 'stranger.onion',
+          wire: 'not-a-control-envelope',
+        );
+
+        final promoter = GroupInvitePromoter(
+          userId: 'local.onion',
+          keyManager: KeyManager.fromIdentity(localIdentity),
+        );
+        expect(await promoter.promote('stranger.onion'), isFalse);
+
+        expect(await GroupPendingInviteStore.count(), 0);
+        expect(await dbHelperDb.query('groups'), isEmpty);
+      });
+
+      test('the sweep promotes only the senders that became resolvable',
+          () async {
+        final known = await IdentityKeyPair.generate();
+        final unknown = await IdentityKeyPair.generate();
+        await router.handleMessage(await _inviteMessage(
+          id: 'm1',
+          inviterId: 'known.onion',
+          inviter: known,
+          recipient: localIdentity,
+          groupId: 'g1',
+        ));
+        await router.handleMessage(await _inviteMessage(
+          id: 'm2',
+          inviterId: 'unknown.onion',
+          inviter: unknown,
+          recipient: localIdentity,
+          groupId: 'g2',
+        ));
+        final json = jsonEncode(await known.toPublicJson());
+        await DBHelper.insertOrUpdateUser({
+          'id': 'known.onion',
+          'name': 'Known',
+          'identityJson': json,
+          'publicKeyPem': json,
+        });
+
+        final promoted = await GroupInvitePromoter(
+          userId: 'local.onion',
+          keyManager: KeyManager.fromIdentity(localIdentity),
+        ).promoteResolvable();
+
+        expect(promoted, 1);
+        expect((await dbHelperDb.query('groups')).single['id'], 'g1');
+        final rows = await GroupPendingInviteStore.pending();
+        expect(rows.single['senderId'], 'unknown.onion');
+      });
+    });
   });
 }

--- a/test/security/group_profile_fetch_gate_test.dart
+++ b/test/security/group_profile_fetch_gate_test.dart
@@ -32,6 +32,7 @@ import 'package:prysm/database/messages.dart';
 import 'package:prysm/server/inbound_message_router.dart';
 import 'package:prysm/services/settings_service.dart';
 import 'package:prysm/util/db_helper.dart';
+import 'package:prysm/util/group_pending_invite_store.dart';
 import 'package:prysm/util/group_sender_index_store.dart';
 import 'package:prysm/util/key_manager.dart';
 import 'package:prysm/util/tor_runtime_gate.dart';
@@ -106,6 +107,7 @@ Future<Database> _openDbHelperDb() async {
     ),
   );
   await GroupSenderIndexStore.ensureTable(db);
+  await GroupPendingInviteStore.ensureTable(db);
   return db;
 }
 


### PR DESCRIPTION
## What

Second of three stacked PRs. **Base: `invite-mode/data`** — review that one first.

This PR wires the store from PR 1 into the inbound group-control path and adds the promoter:

- `group_service.dart`: the drop branch now *holds* the envelope instead of discarding it, when the user asked for `holdAsRequest`. In `contactsOnly` the behaviour is byte-for-byte what it was before this series.
- `GroupInvitePromoter` (`lib/services/group_invite_promoter.dart`): applies every held invite whose sender has meanwhile become locally known, plus a one-shot sweep on startup.
- The promoter is a **no-op** under `contactsOnly`. That mode promises nothing is stored and nothing is applied, so rows held before the mode changed must not be promoted behind the user's back.
- `take()` prunes expired rows first, like every other read: a held invite is a point-in-time snapshot of a group's roster and key version, so the retention window is also the bound on how stale a replayed one can be.

## The property that decides this feature — do not regress it

This is **not** "reopen the profile fetch". M2 stays closed in **both** modes:

- `_resolveSenderIdentity` remains **DB-only**. No Tor fetch for an unknown sender, on any group control path.
- The held envelope stays encrypted and opaque until the user adds the contact. The fetch therefore starts from a **user gesture**, never from unauthenticated traffic.
- The two `POLICY:` tests in `test/security/group_profile_fetch_gate_test.dart` are unchanged from what shipped in #128 — assertions intact. The positive one is load-bearing: without it, the negative would pass even if invites were broken outright.

Anyone touching `group_service.dart:500-527` has to preserve this.

## Context

This closes the functional cost of the M2 fix, decided in #128 (CR8) and filed as #129. Before this series, closing M2 on the group path removed the only source of identity→onion binding for an unknown sender, so group invites from non-contacts vanished silently. That defect was the **absence** of a path, which is why no per-task review caught it.

## Verification

- `flutter analyze`: 0 issues.
- `flutter test`: all green on this branch alone.
- New tests cover the hold path, the promotion path, and that `contactsOnly` promotes nothing even when the held sender has become resolvable (`test/security/group_invite_mode_test.dart`).

## Review order

Merge after `invite-mode/data`, before `invite-mode/ui`.
