### PR TITLE
Live-app-testing toolkit: container, prysmlab CLI, and skill

### DIFF
--- a/.agents/skills/live-app-testing/SKILL.md
+++ b/.agents/skills/live-app-testing/SKILL.md
@@ -1,0 +1,220 @@
+---
+name: live-app-testing
+description: "Use when you need to prove UI<->state integration on the real, running Prysm desktop app: screens render what the stores contain, taps land, routes open and close. Proves the app's own wiring end to end. It does NOT prove pixels, does NOT prove the compositor's input path, and does NOT run in CI."
+---
+
+# Live App Testing
+
+Drive the real Prysm Linux desktop app with `tool/live/prysmlab` — observation (Dart VM
+Service widget trees), control (in-app pointer events via `evaluate`), and data injection
+(HTTP against the app's loopback server). The app runs in a throwaway container under Xvfb
+with a private D-Bus session and keyring.
+
+## When to use it — and when not
+
+Use it when the defect lives in the integration between UI and state: a screen that does not
+show what the DB holds, a tap that does not reach its handler, a route that does not open or
+close, a store whose change the UI never reflects. That is where this method found real bugs.
+
+Do NOT use it for:
+
+- **Pixels.** The dump is text: what is in the tree, not how it looks. Alignment, contrast,
+  truncation, overlap are invisible here. `prysmlab shot` writes a PNG of the Xvfb framebuffer
+  (verified: 1440x900), but producing an image is not reading one: with no vision-capable tool
+  available, the PNG proves nothing on its own.
+- **The compositor's input path.** `prysmlab tap` delivers `PointerDown/UpEvent` through
+  Flutter's own hit test and gesture recognizers. It proves the app's wiring, not that a real
+  click (window focus, display scaling, layered windows) arrives the same way.
+- **Regression.** It is a repeatable manual proof, not a test: it does not run in CI and does
+  not fail on its own. Turn findings into real tests afterwards.
+
+## Safety — the container is not decoration
+
+`TorManager._killOrphanTorForce` (`lib/util/tor_service.dart:497`) runs a bare `pkill -9 tor`
+when its targeted pkill misses — the normal case. The container's PID namespace is the only
+thing between that and the host's tor. The app's server binds `127.0.0.1:12345`; the network
+namespace is the only thing between the injection channel and — or blocked by — the user's
+real Prysm. Rules:
+
+- Never run the app outside the container.
+- Never unlock the user's real identity. If "Enter Passcode" appears and you did not create
+  the lab identity yourself, isolation broke: stop.
+- Use a throwaway PIN (`prysmlab onboard --pin 112233`). The lab identity lives in the
+  container's writable layer — its keyring is `/home/ubuntu/.local/share/keyrings`, not the
+  pub-cache volume — so it dies with the container, and `up --fresh` or any `down` ends it.
+- The repo is never written to: `up` stages a copy into `/tmp/prysm-lab/work` and mounts that;
+  `tool/live` is mounted read-only.
+
+## Workflow
+
+```sh
+prysmlab doctor           # preflight: docker, image, rsync, tor binary; shows host tor/port are irrelevant
+prysmlab up               # stage repo, start container, start app; waits for the VM Service line
+prysmlab onboard --pin 112233   # reaches home from wherever the app is: first-run wizard,
+                                # passcode unlock, or local-data reset, by reading the screen
+# observe and act, in a loop:
+prysmlab screen           # what is on screen, from the widget tree
+prysmlab tap "Settings"   # act
+prysmlab down --purge     # teardown is part of the method — always
+```
+
+`up` prints progress; the first run compiles the Linux bundle (minutes). `up --fresh` destroys
+the container first (loses the test identity) and re-stages; `prysmlab sync` re-stages without
+relaunching (a running app keeps the old code); `prysmlab restart [--sync]` relaunches the app
+in the running container — the way to pick up code changes (hot restart over stdin is not an
+option: sending `R` to `flutter run` makes it exit; `--sync` re-stages first). All commands
+except the lifecycle ones (`doctor`, `up`, `down`, `sync`, `restart`, `shell`, `build-image`)
+are forwarded into the container.
+
+## Rules learned the hard way
+
+1. **`screen` deduplicates texts; assert presence per surface with `count`.**
+   `prysmlab screen` lists each unique `Text` string once, so one string on two surfaces looks
+   like one — and "it's there" hides "it's missing here". `prysmlab count "<string>"` counts
+   raw `Text` occurrences in the tree. Two surfaces → count 2.
+
+2. **`eval` wants ONE LINE and only types visible in the target library.**
+   Multi-line snippets fail with a baffling "Can't find '}' to match '{'". `prysmlab eval
+   --file snippet.dart` (or `--file -` for stdin) flattens for you. The default evaluation
+   library is `package:flutter/src/widgets/binding.dart`, NOT `package:prysm/main.dart` —
+   main.dart does not import most widgets, so `Tooltip` "isn't a type" there. To reach an
+   app store's own library: `prysmlab libs <substring>` to find it, then `prysmlab eval --lib
+   package:prysm/util/group_pending_invite_store.dart '<expr>'`.
+
+3. **Async results cannot be awaited through `evaluate`.**
+   The VM service returns synchronously; a Future resolves later. Print inside `.then()` and
+   read the result from the app log: `prysmlab logs --grep 'PENDING_COUNT='`.
+
+4. **`localToGlobal` returns coordinates for off-screen widgets; blind taps fail silently.**
+   A widget scrolled out of the viewport still reports a center, the pointer event lands on
+   nothing, and nothing happens. `prysmlab tap` runs the real hit test first and refuses with
+   `OCCLUDED n=… x=… y=…` when the coordinate resolves to something else. `OCCLUDED` means
+   scroll it into view or close the route covering it — NOT that the widget is missing
+   (`NOTFOUND` is missing). `tap` autoscrolls by default; `--no-scroll` disables that, `--force`
+   taps anyway. `prysmlab where "<text>"` reports `hit=yes/no` without sending events;
+   `prysmlab scroll <dy>` jumps the longest scrollable when autoscroll is not enough.
+
+5. **`SettingsScreen` is a branch of HomeScreen's build, not a route.**
+   `showSettings` (`lib/screens/home/home_screen.dart:135`) selects it as the main pane
+   (`:2146`, `if (showSettings) return SettingsScreen(onClose: …)`); there is no route to
+   pop, so `prysmlab pop` returns `CANNOT-POP` there — observed. Exit it with its own
+   close button.
+   `PrivacySettingsScreen` and `InviteRequestsScreen` are real pushed routes —
+   `pop` works there. An unexpected `CANNOT-POP` means you are higher in the stack than you
+   think.
+
+6. **An open route covers what is under it.**
+   A pushed route overlays the previous screen; a tap aimed at the covered screen's
+   coordinates lands on the route (or nothing). Close the covering route first, then tap
+   through.
+
+7. **Keyboard traversal is useless here.**
+   The reason is in the widget: `PrysmPressable` (`lib/ui/core/prysm_pressable.dart:31`) builds
+   a bare `GestureDetector` — no `Focus`, no `InkWell`, no focusable ancestor of its own — so
+   its buttons are never in the traversal order. The focus tree itself is real and populated
+   (on HomeScreen, `prysmlab screen --tree focus` prints 85 lines and `primaryFocus` is a live
+   `Focus` node, reached via `Focus <- Semantics <- _FocusInheritedScope <- Focus <-
+   CallbackShortcuts <- HomeScreen`); traversal just never reaches the controls. Verify with
+   `prysmlab screen --tree focus` before wasting time on it (`--tree` also accepts
+   `render|layer|semantics` for the other debugDump trees). Real dialogs (GTK/secret-service
+   prompts) need real input — that is what the container's setup avoids.
+
+8. **The identity survives a restart; the runbook's reset-and-re-onboard loop was a bug in
+   its launcher.** The runbook claimed every restart lands on StartupFatalErrorScreen ("Local
+   data error", `DATABASE_KEY_V1 could not be persisted to secure storage`). Root cause: it
+   unlocked the keyring with `printf '' | gnome-keyring-daemon --unlock` — a bare EOF, no
+   newline. The daemon then never creates `login.keyring`, so the first `flutter_secure_storage`
+   write pops a `gcr-prompter` GUI dialog that blocks the app's main isolate forever — which is
+   also the real explanation of the runbook's "debugDumpApp times out" symptom. `labd.sh` uses
+   `printf '\n'` — empty password *plus newline* — and the daemon creates `login.keyring` +
+   `user.keystore` silently. Verified: `prysmlab restart` took 5.4 s and came back on
+   `UnlockScreen` / "Enter Passcode", not on a data error; `prysmlab onboard --pin 112233` then
+   reached HomeScreen in 3.8 s by entering the PIN. Treat `onboard` as the single "get me to the
+   home screen" command: it handles the first-run wizard, the passcode unlock, and the "Reset
+   local data and continue" button, because it reacts to what is on screen instead of replaying
+   a fixed script.
+
+9. **`evaluate` needs the WebSocket transport.** The VM Service also answers plain HTTP GET
+   JSON-RPC (`curl "$BASE/getVM"` works), which is tempting. Over HTTP every `evaluate` fails
+   with `No compilation service available; cannot evaluate from source` — the same sentence the
+   runbook attributes to running a prebuilt bundle, but from a different cause: flutter_tools
+   registers its compileExpression service on the WebSocket session, so `prysmlab` speaks
+   WebSocket. Worth knowing because that error message otherwise sends you hunting for the
+   wrong problem.
+
+10. **A missing *system* D-Bus hangs the app before its first frame.** Symptom: the bundle
+    builds, a window opens, the VM Service comes up, and `prysmlab screen` returns
+    `{"screens": [], "texts": [], "lines": 2}` — the raw dump says `<no tree currently
+    mounted>`. Cause: `battery_plus` asks UPower over the system bus
+    (`BatterySaverService.init` -> `_refresh` -> `Battery.batteryLevel`); with no
+    `/run/dbus/system_bus_socket` the DBus stream throws asynchronously, the future never
+    completes, `AppBootstrap.initializeServices` never returns and `runApp` is never called.
+    Trap: `BatterySaverService._refresh` wraps the await in a try/catch, and it does not help,
+    because the throw arrives on the zone from `DBusSignalStream._onListen`, not from the
+    awaited future. `labroot.sh` starts `dbus-daemon --system` and `upowerd`, and `up` runs it.
+    Sibling failure: without `xdg-user-dirs` installed, path_provider_linux throws
+    `MissingPlatformDirectoryException(Unable to get application documents directory)` and
+    bootstrap dies the same way.
+
+11. **The injection channel: `prysmlab peer`, plus `eval` in the crypto library.** The app's
+    loopback server is the third channel. `prysmlab peer public` (verified: 200 with the app's
+    real `signPublic`/`agreePublic`/`fingerprint` JSON), `prysmlab peer onion` (verified:
+    returns the lab's `.onion`, read from
+    `~/Documents/prysm/tor_executable/tor_data/hidden_service/hostname`), and
+    `prysmlab peer post --json <file|->`, which POSTs to `/message`. What you must get right:
+    `POST /message` authenticates nobody, but `_validateAddressedToLocal`
+    (`lib/server/inbound_message_router.dart:296`) rejects the request unless `receiverId`
+    equals the app's own onion. For envelopes that need real crypto, the durable way is
+    `prysmlab eval --file <snippet.dart> --lib package:prysm/crypto/group_crypto.dart`: the
+    snippet runs inside the app, so `GroupCryptoV2.encryptControlPayload`,
+    `IdentityKeyPair.generate()` and `dart:io`'s HttpClient are all in scope, and there is no
+    throwaway `flutter test` file to build, forget to delete, or trip over (`HttpOverrides.global
+    = null`, per the runbook). Observe the effect of an injection with `prysmlab wait "<text>"`,
+    which polls until the string appears in the tree.
+
+12. **`type` goes through `EditableTextState.updateEditingValue`.**
+    `prysmlab type "<text>" [-n IDX] [--submit]` (verified working) finds an `EditableText` and
+    feeds the text through `updateEditingValue` — the real platform-input entry point — so input
+    formatters run and `onChanged` fires. Assigning to `controller.text` instead fires neither.
+
+## Worked example
+
+Reach home, open the self chat, and prove "Chat with myself" is on two surfaces (sidebar
+tile + main-pane header — both are `Text` widgets, and the sidebar stays visible because
+only the main pane swaps):
+
+```sh
+prysmlab doctor
+prysmlab up --timeout 900
+prysmlab onboard --pin 112233
+prysmlab tap "Chat with myself"
+prysmlab count "Chat with myself"     # -> "   2  Chat with myself"
+prysmlab screen                        # 'texts' lists it ONCE (deduplicated)
+```
+
+`count` returning 2 is the assertion: the string is present on both surfaces. A single
+`screen` entry would have looked like "present" while a surface was missing. (The sidebar
+"Chat with myself" tile is always there; the header appears once the self chat is open.)
+
+## Cleanup — part of the method
+
+```sh
+prysmlab down --purge
+```
+
+Removes the container, the pub-cache volume, the staging dir and the image, then prints a
+verification block: leftover container/volume/staging/image, host tor processes, and the
+repo working tree (`git status --porcelain`). Nothing from the session may remain; the repo
+was never written to, so the working tree should be clean. If the container is still needed,
+`prysmlab down` alone keeps the volume and image.
+
+Measured on this machine, with the image already built: `up --fresh` to a rendered
+`OnboardingScreen` 90 s (native bundle compile included), `onboard` to HomeScreen 22 s,
+`restart` back to `UnlockScreen` 5.4 s, `down --purge` 2 s. The runbook this supersedes
+budgeted 20-30 minutes; almost all of that was the keyring dialog and the re-onboarding
+loop it forced. Building the image from scratch is the one slow step (minutes), and `up`
+does it automatically when the image is missing.
+
+Use this when the defect lives in UI<->state integration — exactly where widget tests hang
+(screens that read the DB in `initState` deadlock under fake-async) and where
+`evaluate`-driven observation shines.

--- a/.agents/skills/live-app-testing/SKILL.md
+++ b/.agents/skills/live-app-testing/SKILL.md
@@ -152,6 +152,9 @@ are forwarded into the container.
     Trap: `BatterySaverService._refresh` wraps the await in a try/catch, and it does not help,
     because the throw arrives on the zone from `DBusSignalStream._onListen`, not from the
     awaited future. `labroot.sh` starts `dbus-daemon --system` and `upowerd`, and `up` runs it.
+    It also waits for the bus *name* `org.freedesktop.UPower` and exits non-zero
+    (`PRYSMLAB_UPOWER_FAILED`) when nothing claims it — a live `upowerd` process is not proof
+    that it owns the name, and proceeding anyway turns this loud cause into a bare timeout.
     Sibling failure: without `xdg-user-dirs` installed, path_provider_linux throws
     `MissingPlatformDirectoryException(Unable to get application documents directory)` and
     bootstrap dies the same way.

--- a/.agents/skills/live-app-testing/SKILL.md
+++ b/.agents/skills/live-app-testing/SKILL.md
@@ -26,7 +26,7 @@ Do NOT use it for:
   Flutter's own hit test and gesture recognizers. It proves the app's wiring, not that a real
   click (window focus, display scaling, layered windows) arrives the same way.
 - **Regression.** It is a repeatable manual proof, not a test: it does not run in CI and does
-  not fail on its own. Turn findings into real tests afterwards.
+  not fail on its own. Turn findings into real tests afterward.
 
 ## Safety — the container is not decoration
 
@@ -179,7 +179,7 @@ are forwarded into the container.
 
 ## Worked example
 
-Reach home, open the self chat, and prove "Chat with myself" is on two surfaces (sidebar
+Reach home, open the self-chat, and prove "Chat with myself" is on two surfaces (sidebar
 tile + main-pane header — both are `Text` widgets, and the sidebar stays visible because
 only the main pane swaps):
 
@@ -194,7 +194,7 @@ prysmlab screen                        # 'texts' lists it ONCE (deduplicated)
 
 `count` returning 2 is the assertion: the string is present on both surfaces. A single
 `screen` entry would have looked like "present" while a surface was missing. (The sidebar
-"Chat with myself" tile is always there; the header appears once the self chat is open.)
+"Chat with myself" tile is always there; the header appears once the self-chat is open.)
 
 ## Cleanup — part of the method
 

--- a/tool/live/Containerfile
+++ b/tool/live/Containerfile
@@ -1,0 +1,107 @@
+# Prysm — live app testing environment (headless GUI)
+#
+# Same containment argument as .l3e2e/Containerfile: TorManager._killOrphanTorForce
+# runs a bare `pkill -9 tor` (lib/util/tor_service.dart:497) and the container's
+# PID namespace is what keeps that away from the host's tor. On top of that the
+# network namespace keeps the app's loopback server (127.0.0.1:12345) from
+# colliding with — or being mistaken for — the user's real Prysm.
+#
+# Difference from .l3e2e: that image runs `flutter test` (flutter_tester, no GUI).
+# This one runs the real Linux desktop app under Xvfb, so it needs the GTK
+# toolchain, every native plugin's dev package, software GL, a D-Bus session and
+# a throwaway Secret Service.
+#
+# Layers 1-5 are byte-identical to .l3e2e/Containerfile so Docker reuses its
+# cache — in particular the ~1 GB Flutter SDK download. Keep them in sync.
+FROM ubuntu:24.04
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+# Last group: runtime libraries for the bundled tor binary (ldd on
+# tor_executable/tor — it is NOT statically linked).
+RUN apt-get update && apt-get install -y --no-install-recommends \
+      bash ca-certificates curl git xz-utils unzip \
+      build-essential \
+      psmisc procps \
+      libevent-2.1-7t64 libssl3t64 liblzma5 libzstd1 zlib1g \
+      libcap2 libseccomp2 libsystemd0 libbrotli1 \
+    && rm -rf /var/lib/apt/lists/*
+
+# Official Flutter SDK, same version as the host toolchain and .dart_tool/version.
+# SHA-256 from Google's releases_linux.json for this exact archive — verified
+# against storage.googleapis.com so a tampered or truncated download aborts the
+# build before extraction.
+ARG FLUTTER_VERSION=3.44.8
+ARG FLUTTER_SHA256=672089e001571a9fbb209a495c583580c0c6c73ef98999264ba07fa93ace332d
+RUN curl -fsSL -o /tmp/flutter.tar.xz \
+      "https://storage.googleapis.com/flutter_infra_release/releases/stable/linux/flutter_linux_${FLUTTER_VERSION}-stable.tar.xz" \
+    && echo "${FLUTTER_SHA256}  /tmp/flutter.tar.xz" | sha256sum -c - \
+    && tar -xJf /tmp/flutter.tar.xz -C /opt \
+    && rm /tmp/flutter.tar.xz
+
+ENV PATH="/opt/flutter/bin:${PATH}"
+RUN git config --global --add safe.directory /opt/flutter \
+    && flutter --disable-analytics \
+    && flutter precache --linux
+
+# --- everything below is specific to running the desktop app headless ---------
+#
+# Build toolchain:  clang cmake ninja pkg-config  (flutter doctor's Linux device)
+# Plugin dev deps:  derived from pkg_check_modules in
+#                   linux/flutter/ephemeral/.plugin_symlinks/*/linux/CMakeLists.txt
+#                     gtk+-3.0                 every plugin
+#                     libsecret-1              flutter_secure_storage_linux
+#                     libpulse                 prysm_linux_audio
+#                     gstreamer-1.0/-audio/-app audioplayers_linux, record_linux
+#                     ayatana-appindicator3    tray_manager
+#                   plus jsoncpp (desktop_multi_window) and X11 (window_manager,
+#                   screen_retriever_linux).
+# Headless display: Xvfb + software GL (llvmpipe); x11-utils/xwd + netpbm turn the
+#                   framebuffer into a PNG for `prysmlab shot`.
+# Session services: dbus-x11 for a private session bus, dbus + upower for the
+#                   *system* bus battery_plus needs (without it the app hangs in
+#                   bootstrap and never calls runApp), gnome-keyring for a
+#                   throwaway Secret Service (libsecret has no other backend),
+#                   xdg-user-dirs because path_provider_linux shells out to
+#                   `xdg-user-dir DOCUMENTS` and throws
+#                   MissingPlatformDirectoryException when it is absent.
+RUN apt-get update && apt-get install -y --no-install-recommends \
+      clang cmake ninja-build pkg-config \
+      libgtk-3-dev libsecret-1-dev libpulse-dev libjsoncpp-dev \
+      libgstreamer1.0-dev libgstreamer-plugins-base1.0-dev \
+      libayatana-appindicator3-dev libx11-dev libnotify-dev \
+      gstreamer1.0-plugins-base gstreamer1.0-plugins-good \
+      xvfb x11-utils x11-apps netpbm mesa-utils \
+      libgl1-mesa-dri libglx-mesa0 libegl1 libgles2 libglu1-mesa \
+      dbus dbus-x11 gnome-keyring libsecret-tools upower xdg-user-dirs \
+      fonts-dejavu-core fontconfig \
+      python3 socat \
+    && rm -rf /var/lib/apt/lists/*
+
+# Bind-mount ownership: ubuntu:24.04 ships a default uid-1000 user
+# 'ubuntu', but the host user may be any uid. tool/live/prysmlab passes the host
+# uid/gid as build args, and this step remaps 'ubuntu' to match, so the
+# bind-mounted /work stays readable/writable for the container user.
+ARG HOST_UID=1000
+ARG HOST_GID=1000
+RUN if [ "${HOST_UID}" != "1000" ] || [ "${HOST_GID}" != "1000" ]; then \
+      groupmod -g "${HOST_GID}" ubuntu \
+      && usermod -u "${HOST_UID}" -g "${HOST_GID}" ubuntu; \
+    fi \
+    && chown -R ubuntu:ubuntu /opt/flutter \
+    && mkdir -p /home/ubuntu/.pub-cache /home/ubuntu/lab \
+    && chown -R ubuntu:ubuntu /home/ubuntu
+
+# The pub cache is a named Docker volume so nothing lands in the host's HOME and
+# `prysmlab down --purge` can drop it. Docker seeds a fresh volume from the image
+# path, so that path must already exist and belong to `ubuntu` — otherwise the
+# volume comes up root-owned and `flutter pub get` dies on hosted-hashes.
+
+USER ubuntu
+ENV HOME=/home/ubuntu \
+    PUB_CACHE=/home/ubuntu/.pub-cache \
+    DISPLAY=:99 \
+    LIBGL_ALWAYS_SOFTWARE=1 \
+    XDG_RUNTIME_DIR=/tmp/xdg-runtime
+
+WORKDIR /work

--- a/tool/live/Containerfile
+++ b/tool/live/Containerfile
@@ -84,9 +84,15 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 # bind-mounted /work stays readable/writable for the container user.
 ARG HOST_UID=1000
 ARG HOST_GID=1000
+#
+# --non-unique is required, not defensive: ubuntu:24.04 already owns gid 20
+# (dialout) and gid 100 (users), and plain `groupmod -g` refuses a gid another
+# group holds ("GID '20' already exists"), which aborts the whole build for any
+# host user on one of those gids. Sharing the id is harmless here — `chown
+# ubuntu:ubuntu` still resolves by name, and the container is single-user.
 RUN if [ "${HOST_UID}" != "1000" ] || [ "${HOST_GID}" != "1000" ]; then \
-      groupmod -g "${HOST_GID}" ubuntu \
-      && usermod -u "${HOST_UID}" -g "${HOST_GID}" ubuntu; \
+      groupmod --non-unique -g "${HOST_GID}" ubuntu \
+      && usermod --non-unique -u "${HOST_UID}" -g "${HOST_GID}" ubuntu; \
     fi \
     && chown -R ubuntu:ubuntu /opt/flutter \
     && mkdir -p /home/ubuntu/.pub-cache /home/ubuntu/lab \

--- a/tool/live/labd.sh
+++ b/tool/live/labd.sh
@@ -52,7 +52,20 @@ exec dbus-run-session -- sh -c '
   secret-tool store --label=prysmlab-probe prysmlab probe </dev/null 2>/dev/null \
     && echo "PRYSMLAB_KEYRING_UP" || echo "PRYSMLAB_KEYRING_DEGRADED"
   cd /work
-  # flutter run treats stdin EOF as quit, so hold stdin open with a writer that
-  # never writes.
-  sleep 2147483647 | flutter run -d linux --debug --no-pub --disable-service-auth-codes
+  # flutter run treats stdin EOF as quit, so it needs a stdin that never ends.
+  # A FIFO opened read-write is exactly that, with **no holder process**: the fd
+  # is its own writer, so it never signals EOF, and nothing outlives the app.
+  #
+  # It used to be `sleep 2147483647 | flutter run`. That leaked: sleep never
+  # writes, so it never takes SIGPIPE, and this shell kept waiting for it after
+  # flutter exited — holding dbus-run-session and its gnome-keyring-daemon
+  # alive. `prysmlab restart` kills only flutter_tools.snapshot, so every
+  # restart added one stale session bus and one stale keyring daemon.
+  FIFO="$HOME/lab/app-stdin"
+  rm -f "$FIFO"
+  mkfifo "$FIFO"
+  flutter run -d linux --debug --no-pub --disable-service-auth-codes <> "$FIFO"
+  rc=$?
+  rm -f "$FIFO"
+  exit "$rc"
 '

--- a/tool/live/labd.sh
+++ b/tool/live/labd.sh
@@ -1,0 +1,58 @@
+#!/bin/sh
+# prysmlab — in-container launcher for the real Prysm desktop app.
+# Started by `prysmlab up` as: sh -lc '/opt/lab/labd.sh > ~/lab/app.log 2>&1'
+set -e
+
+LAB="$HOME/lab"
+DISP="${DISPLAY:-:99}"
+mkdir -p "$LAB" "$HOME/Documents/prysm/tor_executable" \
+         "$HOME/.local/share/keyrings" "$HOME/.config" "$HOME/.cache" \
+         "${XDG_RUNTIME_DIR:-/tmp/xdg-runtime}"
+chmod 700 "${XDG_RUNTIME_DIR:-/tmp/xdg-runtime}"
+
+# path_provider_linux resolves getApplicationDocumentsDirectory through
+# ~/.config/user-dirs.dirs; without it the app lands somewhere else and the
+# pre-seeded tor binary below is ignored.
+[ -f "$HOME/.config/user-dirs.dirs" ] || \
+  printf 'XDG_DOCUMENTS_DIR="$HOME/Documents"\n' > "$HOME/.config/user-dirs.dirs"
+
+# TorDownloader fetches ~14 MB into <documents>/prysm/tor_executable on first run.
+# The repo ships the same binary, so reuse it.
+if [ ! -x "$HOME/Documents/prysm/tor_executable/tor" ] && [ -f /work/tor_executable/tor ]; then
+  cp /work/tor_executable/tor "$HOME/Documents/prysm/tor_executable/tor"
+  chmod +x "$HOME/Documents/prysm/tor_executable/tor"
+fi
+
+# The default collection must be the login keyring, which is the one the daemon
+# unlocks below; otherwise the first secret write asks to create "Default".
+[ -f "$HOME/.local/share/keyrings/default" ] || \
+  printf 'login' > "$HOME/.local/share/keyrings/default"
+
+if ! xdpyinfo -display "$DISP" >/dev/null 2>&1; then
+  Xvfb "$DISP" -screen 0 1440x900x24 -nolisten tcp >"$LAB/xvfb.log" 2>&1 &
+  for _ in 1 2 3 4 5 6 7 8 9 10; do
+    xdpyinfo -display "$DISP" >/dev/null 2>&1 && break
+    sleep 0.5
+  done
+fi
+xdpyinfo -display "$DISP" >/dev/null 2>&1 || { echo "PRYSMLAB_XVFB_FAILED"; exit 1; }
+echo "PRYSMLAB_XVFB_UP $DISP"
+
+cd /work
+flutter config --enable-linux-desktop >/dev/null 2>&1 || true
+[ -f .dart_tool/package_config.json ] || flutter pub get
+
+exec dbus-run-session -- sh -c '
+  # An empty password *followed by a newline*. With a bare EOF (printf "") the
+  # daemon never creates login.keyring, and the first flutter_secure_storage
+  # write pops a gcr prompt that blocks the app main isolate forever — which
+  # looks exactly like a hung debugDumpApp.
+  eval "$(printf "\n" | gnome-keyring-daemon --unlock --components=secrets 2>/dev/null)"
+  export GNOME_KEYRING_CONTROL SSH_AUTH_SOCK
+  secret-tool store --label=prysmlab-probe prysmlab probe </dev/null 2>/dev/null \
+    && echo "PRYSMLAB_KEYRING_UP" || echo "PRYSMLAB_KEYRING_DEGRADED"
+  cd /work
+  # flutter run treats stdin EOF as quit, so hold stdin open with a writer that
+  # never writes.
+  sleep 2147483647 | flutter run -d linux --debug --no-pub --disable-service-auth-codes
+'

--- a/tool/live/labroot.sh
+++ b/tool/live/labroot.sh
@@ -25,13 +25,28 @@ fi
 # reliable in a container, so start the daemon outright.
 if ! pgrep -x upowerd >/dev/null 2>&1; then
   setsid /usr/libexec/upowerd >/var/log/upowerd.log 2>&1 &
-  i=0
-  while [ $i -lt 20 ]; do
-    dbus-send --system --dest=org.freedesktop.DBus --print-reply \
-      /org/freedesktop/DBus org.freedesktop.DBus.ListNames 2>/dev/null \
-      | grep -q org.freedesktop.UPower && break
-    i=$((i + 1)); sleep 0.25
-  done
 fi
+
+# Wait for the bus NAME, not for the process, and wait unconditionally.
+#
+# A pgrep hit only proves some upowerd exists — not that it owns
+# org.freedesktop.UPower — so the wait used to be skipped exactly when a stale
+# daemon was the problem. And the loop had no verdict after it: on failure the
+# script still printed PRYSMLAB_SYSTEM_BUS_UP, `prysmlab up` started the app,
+# and the only symptom was a later timeout. That is the mute failure this file
+# exists to prevent: without UPower, battery_plus never completes,
+# AppBootstrap.initializeServices never returns and runApp is never reached.
+up=0
+i=0
+while [ $i -lt 40 ]; do
+  if dbus-send --system --dest=org.freedesktop.DBus --print-reply \
+       /org/freedesktop/DBus org.freedesktop.DBus.ListNames 2>/dev/null \
+       | grep -q org.freedesktop.UPower; then
+    up=1
+    break
+  fi
+  i=$((i + 1)); sleep 0.25
+done
+[ "$up" = 1 ] || { echo "PRYSMLAB_UPOWER_FAILED"; exit 1; }
 
 echo "PRYSMLAB_SYSTEM_BUS_UP"

--- a/tool/live/labroot.sh
+++ b/tool/live/labroot.sh
@@ -1,0 +1,37 @@
+#!/bin/sh
+# prysmlab — root-side, once per container: the system D-Bus and UPower.
+# Run by `prysmlab up` as `docker exec -u 0 <container> /opt/lab/labroot.sh`.
+#
+# Why this exists: battery_plus asks UPower for the battery level through the
+# *system* bus. With no /run/dbus/system_bus_socket the DBus stream throws
+# asynchronously, `Battery.batteryLevel` never completes, so
+# AppBootstrap.initializeServices never returns and runApp is never reached — the
+# app builds, opens a window and renders nothing, and `debugDumpApp` answers
+# "<no tree currently mounted>". A private session bus (dbus-run-session, in
+# labd.sh) is not enough; this is a different bus.
+set -e
+
+mkdir -p /run/dbus
+if [ ! -S /run/dbus/system_bus_socket ]; then
+  dbus-daemon --system --fork
+  i=0
+  while [ ! -S /run/dbus/system_bus_socket ] && [ $i -lt 20 ]; do
+    i=$((i + 1)); sleep 0.25
+  done
+fi
+[ -S /run/dbus/system_bus_socket ] || { echo "PRYSMLAB_SYSTEM_BUS_FAILED"; exit 1; }
+
+# D-Bus activation of UPower needs the setuid launch helper, which is not
+# reliable in a container, so start the daemon outright.
+if ! pgrep -x upowerd >/dev/null 2>&1; then
+  setsid /usr/libexec/upowerd >/var/log/upowerd.log 2>&1 &
+  i=0
+  while [ $i -lt 20 ]; do
+    dbus-send --system --dest=org.freedesktop.DBus --print-reply \
+      /org/freedesktop/DBus org.freedesktop.DBus.ListNames 2>/dev/null \
+      | grep -q org.freedesktop.UPower && break
+    i=$((i + 1)); sleep 0.25
+  done
+fi
+
+echo "PRYSMLAB_SYSTEM_BUS_UP"

--- a/tool/live/prysmlab
+++ b/tool/live/prysmlab
@@ -1,0 +1,1152 @@
+#!/usr/bin/env python3
+"""prysmlab — drive and observe the real Prysm desktop app, live, in a container.
+
+Three channels, all textual:
+
+    observation   Dart VM Service -> ext.flutter.debugDumpApp
+    control       Dart VM Service -> evaluate -> handlePointerEvent inside the app
+    injection     plain HTTP against the app's loopback server (127.0.0.1:12345)
+
+Everything runs inside a throwaway Docker container (image `prysm-lab`, built from
+tool/live/Containerfile) with an Xvfb display, a private D-Bus session and a private
+gnome-keyring. Two things make that mandatory rather than tidy:
+
+  * TorManager._killOrphanTorForce runs a bare `pkill -9 tor` when the targeted
+    pkill misses (lib/util/tor_service.dart:497). Only a PID namespace keeps that
+    off the host's tor.
+  * The app's server binds 127.0.0.1:12345. Only a network namespace keeps the
+    injection channel from reaching — or being blocked by — the user's real Prysm.
+
+The repo is never written to: `up` stages a copy into /tmp/prysm-lab/work and mounts
+that. `down --purge` removes container, volume, staging dir and image.
+
+Usage from the host; every command except the lifecycle ones is forwarded into the
+container automatically:
+
+    tool/live/prysmlab up
+    tool/live/prysmlab screen
+    tool/live/prysmlab onboard --pin 112233
+    tool/live/prysmlab tap "Settings"
+    tool/live/prysmlab down --purge
+"""
+
+from __future__ import annotations
+
+import argparse
+import base64
+import json
+import os
+import re
+import shutil
+import socket
+import subprocess
+import struct
+import sys
+import time
+import urllib.error
+import urllib.parse
+import urllib.request
+
+IN_CONTAINER = os.environ.get("PRYSMLAB_IN_CONTAINER") == "1"
+
+# ---- host side -------------------------------------------------------------
+IMAGE = os.environ.get("PRYSMLAB_IMAGE", "prysm-lab")
+CONTAINER = os.environ.get("PRYSMLAB_CONTAINER", "prysm-lab")
+VOLUME = "prysm-lab-pub"
+HOST_LAB = os.environ.get("PRYSMLAB_HOST_LAB", "/tmp/prysm-lab")
+WORK = os.path.join(HOST_LAB, "work")
+
+# ---- container side --------------------------------------------------------
+LAB = "/home/ubuntu/lab"
+LOG_PATH = f"{LAB}/app.log"
+STATE_PATH = f"{LAB}/state.json"
+APP_PORT = 12345
+
+# Evaluation context. Flutter's own widgets/binding.dart imports foundation,
+# gestures, rendering, scheduler and services, so WidgetsBinding, Element,
+# RenderBox, Offset, PointerDownEvent and HitTestResult are all visible there.
+# package:prysm/main.dart sees far less, which is where the runbook's
+# "'Tooltip' isn't a type" class of failure comes from.
+PREFERRED_LIB = "package:flutter/src/widgets/binding.dart"
+
+HOST_COMMANDS = {"up", "down", "doctor", "sync", "shell", "build-image", "restart"}
+
+# Staged into /work. Excludes .dart_tool and linux/flutter/ephemeral so the
+# container regenerates them for its own toolchain.
+STAGE_PATHS = [
+    "lib", "test", "assets", "linux", "packages", "tor_executable",
+    "pubspec.yaml", "pubspec.lock", "analysis_options.yaml", "devtools_options.yaml",
+]
+
+
+class Fail(Exception):
+    pass
+
+
+def die(msg: str, code: int = 1):
+    print(f"prysmlab: {msg}", file=sys.stderr)
+    sys.exit(code)
+
+
+def repo_root() -> str:
+    here = os.path.dirname(os.path.abspath(__file__))
+    root = os.path.abspath(os.path.join(here, "..", ".."))
+    if not os.path.exists(os.path.join(root, "pubspec.yaml")):
+        die(f"cannot locate the Prysm repo from {here}")
+    return root
+
+
+def run(cmd: list[str], **kw) -> subprocess.CompletedProcess:
+    return subprocess.run(cmd, capture_output=True, text=True, **kw)
+
+
+# ============================================================ container plumbing
+
+
+def container_state() -> str:
+    res = run(["docker", "inspect", "-f", "{{.State.Status}}", CONTAINER])
+    return res.stdout.strip() if res.returncode == 0 else "absent"
+
+
+def image_exists() -> bool:
+    return run(["docker", "image", "inspect", IMAGE]).returncode == 0
+
+
+def dexec(argv: list[str], capture: bool = True, timeout: float | None = None,
+          stdin_data: str | None = None) -> subprocess.CompletedProcess:
+    cmd = ["docker", "exec", "-i", "-e", "PRYSMLAB_IN_CONTAINER=1", CONTAINER] + argv
+    if capture:
+        return subprocess.run(cmd, capture_output=True, text=True, timeout=timeout,
+                              input=stdin_data)
+    return subprocess.run(cmd, timeout=timeout)
+
+
+def forward(argv: list[str]) -> int:
+    """Re-run this same CLI inside the container with the same arguments."""
+    if container_state() != "running":
+        die("no lab container is running — start it with `prysmlab up`")
+    cmd = ["docker", "exec", "-i", "-e", "PRYSMLAB_IN_CONTAINER=1", CONTAINER,
+           "python3", "/opt/lab/prysmlab"] + argv
+    return subprocess.run(cmd).returncode
+
+
+# ================================================================== vm service
+
+
+def vm_base() -> str:
+    """The VM Service endpoint, read straight out of the app log.
+
+    Deriving it instead of storing it means a hot restart or a relaunch cannot
+    leave a stale endpoint behind.
+    """
+    try:
+        with open(LOG_PATH, errors="replace") as fh:
+            text = fh.read()
+    except OSError as exc:
+        raise Fail(f"no app log at {LOG_PATH} ({exc}); run `prysmlab up`") from exc
+    hits = re.findall(r"Dart VM Service on Linux is available at:\s*(\S+)", text)
+    if not hits:
+        raise Fail("the app has not published a VM Service yet — see `prysmlab logs`")
+    return hits[-1]
+
+
+class _WebSocket:
+    """Minimal RFC 6455 client — stdlib only, just enough for VM Service JSON-RPC.
+
+    The VM Service also answers plain HTTP GETs, which is tempting and much
+    shorter. It is not usable here: `evaluate` needs flutter_tools' compileExpression
+    service, which is registered on the WebSocket session, so over HTTP every
+    evaluate fails with "No compilation service available; cannot evaluate from
+    source" — the same message the prebuilt bundle gives, for a different reason.
+    """
+
+    def __init__(self, url: str, timeout: float):
+        parts = urllib.parse.urlparse(url)
+        self.sock = socket.create_connection(
+            (parts.hostname, parts.port or 80), timeout=timeout)
+        key = base64.b64encode(os.urandom(16)).decode()
+        self.sock.sendall(
+            f"GET {parts.path or '/'} HTTP/1.1\r\n"
+            f"Host: {parts.hostname}:{parts.port}\r\n"
+            "Upgrade: websocket\r\nConnection: Upgrade\r\n"
+            f"Sec-WebSocket-Key: {key}\r\nSec-WebSocket-Version: 13\r\n\r\n".encode())
+        buf = bytearray()
+        while b"\r\n\r\n" not in buf:
+            chunk = self.sock.recv(4096)
+            if not chunk:
+                raise Fail(f"VM Service closed the connection during handshake ({url})")
+            buf += chunk
+        head, _, rest = bytes(buf).partition(b"\r\n\r\n")
+        if b" 101 " not in head.split(b"\r\n")[0] + b" ":
+            raise Fail(f"VM Service refused the WebSocket upgrade: "
+                       f"{head.splitlines()[0].decode(errors='replace')}")
+        self.buf = bytearray(rest)
+        self.next_id = 0
+
+    def _need(self, n: int):
+        while len(self.buf) < n:
+            chunk = self.sock.recv(1 << 16)
+            if not chunk:
+                raise Fail("VM Service closed the connection")
+            self.buf += chunk
+
+    def _send(self, opcode: int, data: bytes):
+        header = bytes([0x80 | opcode])
+        n = len(data)
+        if n < 126:
+            header += struct.pack("!B", 0x80 | n)
+        elif n < 1 << 16:
+            header += struct.pack("!BH", 0x80 | 126, n)
+        else:
+            header += struct.pack("!BQ", 0x80 | 127, n)
+        mask = os.urandom(4)
+        self.sock.sendall(header + mask
+                          + bytes(b ^ mask[i % 4] for i, b in enumerate(data)))
+
+    def _recv(self) -> dict:
+        payload = bytearray()
+        opcode = 0
+        while True:
+            self._need(2)
+            b0, b1 = self.buf[0], self.buf[1]
+            length = b1 & 0x7F
+            offset = 2
+            if length == 126:
+                self._need(4)
+                length = struct.unpack("!H", bytes(self.buf[2:4]))[0]
+                offset = 4
+            elif length == 127:
+                self._need(10)
+                length = struct.unpack("!Q", bytes(self.buf[2:10]))[0]
+                offset = 10
+            self._need(offset + length)
+            frame = bytes(self.buf[offset:offset + length])
+            del self.buf[:offset + length]
+            kind = b0 & 0x0F
+            if kind == 0x8:
+                raise Fail("VM Service closed the connection")
+            if kind == 0x9:          # ping -> pong, then keep reading
+                self._send(0xA, frame)
+                continue
+            if kind == 0xA:
+                continue
+            opcode = opcode or kind
+            payload += frame
+            if b0 & 0x80:
+                return json.loads(bytes(payload))
+
+    def call(self, method: str, params: dict, timeout: float) -> dict:
+        self.next_id += 1
+        mine = self.next_id
+        self.sock.settimeout(timeout)
+        self._send(0x1, json.dumps(
+            {"jsonrpc": "2.0", "id": mine, "method": method, "params": params}).encode())
+        while True:
+            message = self._recv()
+            if message.get("id") == mine:
+                return message
+
+    def close(self):
+        try:
+            self._send(0x8, b"")
+            self.sock.close()
+        except OSError:
+            pass
+
+
+_CONN: _WebSocket | None = None
+
+
+def rpc(method: str, timeout: float = 30.0, **params) -> dict:
+    global _CONN
+    if _CONN is None:
+        _CONN = _WebSocket(
+            vm_base().replace("http://", "ws://").rstrip("/") + "/ws", timeout)
+    try:
+        payload = _CONN.call(method, params, timeout)
+    except socket.timeout as exc:
+        raise Fail(
+            f"{method} timed out after {timeout}s — the main isolate is blocked "
+            "(a modal dialog outside Flutter does exactly this)"
+        ) from exc
+    except OSError as exc:
+        raise Fail(f"VM Service unreachable: {exc}") from exc
+    if "error" in payload:
+        err = payload["error"]
+        detail = (err.get("data") or {}).get("details") or err.get("message")
+        raise Fail(f"{method}: {detail}")
+    return payload.get("result", {})
+
+
+def load_state() -> dict:
+    try:
+        with open(STATE_PATH) as fh:
+            return json.load(fh)
+    except (OSError, ValueError):
+        return {}
+
+
+def save_state(state: dict):
+    os.makedirs(LAB, exist_ok=True)
+    tmp = STATE_PATH + ".tmp"
+    with open(tmp, "w") as fh:
+        json.dump(state, fh, indent=2)
+    os.replace(tmp, STATE_PATH)
+
+
+def main_isolate() -> str:
+    isolates = rpc("getVM").get("isolates", [])
+    if not isolates:
+        raise Fail("the VM has no isolates")
+    for iso in isolates:
+        if "main" in iso.get("name", ""):
+            return iso["id"]
+    return isolates[0]["id"]
+
+
+def resolve_libs(iso: str) -> dict:
+    info = rpc("getIsolate", isolateId=iso, timeout=60)
+    return {lib["uri"]: lib["id"] for lib in info.get("libraries", [])}
+
+
+def pick_lib(libs: dict, want: str | None) -> str:
+    if want and want in libs:
+        return want
+    if want:
+        matches = sorted(uri for uri in libs if want in uri)
+        if len(matches) == 1:
+            return matches[0]
+        if not matches:
+            raise Fail(f"no library matches {want!r} (try `prysmlab libs {want}`)")
+        raise Fail(f"{want!r} is ambiguous: {', '.join(matches[:5])}")
+    if PREFERRED_LIB in libs:
+        return PREFERRED_LIB
+    prysm = [uri for uri in libs if uri.endswith("prysm/main.dart")]
+    if prysm:
+        return prysm[0]
+    raise Fail("cannot pick an evaluation library")
+
+
+def _context(want: str | None, refresh: bool) -> tuple[str, str]:
+    state = load_state()
+    if refresh or not state.get("lib") or (want and want != state.get("lib_uri")):
+        iso = main_isolate()
+        libs = resolve_libs(iso)
+        uri = pick_lib(libs, want)
+        state.update(iso=iso, lib=libs[uri], lib_uri=uri)
+        save_state(state)
+    return state["iso"], state["lib"]
+
+
+def eval_dart(expr: str, lib_uri: str | None = None, timeout: float = 30.0) -> str:
+    iso, lib = _context(lib_uri, refresh=False)
+    try:
+        res = rpc("evaluate", isolateId=iso, targetId=lib, expression=expr,
+                  timeout=timeout)
+    except Fail as exc:
+        # A relaunch or hot restart invalidates the cached ids exactly once.
+        if not re.search(r"isolate|targetId|Unrecognized", str(exc), re.I):
+            raise
+        iso, lib = _context(lib_uri, refresh=True)
+        res = rpc("evaluate", isolateId=iso, targetId=lib, expression=expr,
+                  timeout=timeout)
+    if res.get("type") == "@Error" or res.get("kind") == "Error":
+        raise Fail(res.get("message", json.dumps(res)))
+    if "valueAsString" in res:
+        return res["valueAsString"]
+    return json.dumps(res)
+
+
+def flatten_dart(src: str) -> str:
+    """Collapse a snippet onto one line — `evaluate` rejects newlines with a
+    baffling "Can't find '}' to match '{'". Whole-line // comments are dropped;
+    trailing // comments are not supported, use /* */."""
+    return " ".join(
+        line.strip() for line in src.splitlines()
+        if line.strip() and not line.strip().startswith("//")
+    )
+
+
+# ============================================================== dart expressions
+
+_WALK = (
+    "final b = WidgetsBinding.instance; final hits = <Element>[]; "
+    "void walk(Element e) {{ final dynamic w = e.widget; if ({pred}) {{ hits.add(e); }} "
+    "e.visitChildren(walk); }} final r = b.rootElement; if (r == null) return 'ERR no-root'; "
+    "walk(r); if (hits.length <= {idx}) return 'NOTFOUND n=' + hits.length.toString(); "
+    "final ro = hits[{idx}].renderObject; if (ro is! RenderBox) return 'ERR not-a-box'; "
+    "if (!ro.hasSize) return 'ERR unlaid-out'; "
+    "final c = ro.localToGlobal(ro.size.center(Offset.zero)); "
+    "final view = b.renderViews.first; final vs = view.size; "
+    "final vid = view.flutterView.viewId; var hit = 'unknown'; "
+    "try {{ final res = HitTestResult(); b.hitTestInView(res, c, vid); "
+    "hit = res.path.any((h) => identical(h.target, ro)) ? 'yes' : 'no'; }} "
+    "catch (_) {{ hit = 'unknown'; }} "
+)
+
+_REPORT = (
+    "return '{tag} n=' + hits.length.toString() + ' x=' + c.dx.toStringAsFixed(1) + "
+    "' y=' + c.dy.toStringAsFixed(1) + ' w=' + ro.size.width.toStringAsFixed(1) + "
+    "' h=' + ro.size.height.toStringAsFixed(1) + ' vw=' + vs.width.toStringAsFixed(0) + "
+    "' vh=' + vs.height.toStringAsFixed(0) + ' hit=' + hit;"
+)
+
+
+def dq(value: str) -> str:
+    return json.dumps(value)
+
+
+def pred_text(label: str, exact: bool = True) -> str:
+    if exact:
+        return f"w.runtimeType.toString() == 'Text' && w.data == {dq(label)}"
+    return ("w.runtimeType.toString() == 'Text' && w.data is String && "
+            f"(w.data as String).contains({dq(label)})")
+
+
+def pred_widget(type_name: str, contains: str | None) -> str:
+    pred = f"w.runtimeType.toString() == {dq(type_name)}"
+    if contains:
+        pred += f" && w.toString().contains({dq(contains)})"
+    return pred
+
+
+def probe_expr(pred: str, idx: int) -> str:
+    return "(() { " + _WALK.format(pred=pred, idx=idx) + _REPORT.format(tag="AT") + " })()"
+
+
+def tap_expr(pred: str, idx: int, pointer: int = 7, force: bool = False) -> str:
+    """Tap through the app's real hit test and real gesture recognizers.
+
+    The runbook's version fired the pointer events blind, so a widget scrolled out
+    of the viewport produced a cheerful TAPPED@452,1417 on a 720px-tall window and
+    nothing happened. Here the hit test decides: if the target is not what the
+    coordinate resolves to, the tap is refused as OCCLUDED.
+    """
+    guard = "" if force else (
+        "if (hit == 'no') " + _REPORT.format(tag="OCCLUDED") + " "
+    )
+    return (
+        "(() { " + _WALK.format(pred=pred, idx=idx) + guard
+        + f"b.handlePointerEvent(PointerDownEvent(position: c, pointer: {pointer}, viewId: vid)); "
+        + f"b.handlePointerEvent(PointerUpEvent(position: c, pointer: {pointer}, viewId: vid)); "
+        + _REPORT.format(tag="TAPPED") + " })()"
+    )
+
+
+SCROLL_EXPR = (
+    "(() {{ final b = WidgetsBinding.instance; dynamic best; double bestExtent = -1; "
+    "void walk(Element e) {{ if (e is StatefulElement && "
+    "e.state.runtimeType.toString() == 'ScrollableState') {{ final dynamic st = e.state; "
+    "try {{ final double m = st.position.maxScrollExtent as double; "
+    "if (m > bestExtent) {{ bestExtent = m; best = st; }} }} catch (_) {{}} }} "
+    "e.visitChildren(walk); }} final r = b.rootElement; if (r == null) return 'ERR no-root'; "
+    "walk(r); if (best == null) return 'NO-SCROLLABLE'; "
+    "final double max = best.position.maxScrollExtent as double; "
+    "final double target = (best.position.pixels as double) + {dy}; "
+    "final double clamped = target < 0 ? 0 : (target > max ? max : target); "
+    "best.position.jumpTo(clamped); "
+    "return 'SCROLLED ' + clamped.toStringAsFixed(0) + '/' + max.toStringAsFixed(0); }})()"
+)
+
+POP_EXPR = (
+    "(() { final b = WidgetsBinding.instance; dynamic nav; "
+    "void walk(Element e) { if (e is StatefulElement && "
+    "e.state.runtimeType.toString() == 'NavigatorState') { nav = e.state; } "
+    "e.visitChildren(walk); } final r = b.rootElement; if (r == null) return 'ERR no-root'; "
+    "walk(r); if (nav == null) return 'NO-NAV'; "
+    "if (!(nav.canPop() as bool)) return 'CANNOT-POP'; nav.pop(); return 'POPPED'; })()"
+)
+
+
+def editable_expr(idx: int, body: str) -> str:
+    return (
+        "(() { final b = WidgetsBinding.instance; final hits = <StatefulElement>[]; "
+        "void walk(Element e) { if (e is StatefulElement && "
+        "e.state.runtimeType.toString() == 'EditableTextState') { hits.add(e); } "
+        "e.visitChildren(walk); } final r = b.rootElement; if (r == null) return 'ERR no-root'; "
+        f"walk(r); if (hits.length <= {idx}) return 'NOTFOUND n=' + hits.length.toString(); "
+        f"final dynamic st = hits[{idx}].state; " + body + " })()"
+    )
+
+
+def type_expr(text: str, idx: int) -> str:
+    """Feed text through EditableText's real platform-input entry point.
+
+    updateEditingValue runs the input formatters and fires onChanged; assigning to
+    controller.text does not. The new value is built with copyWith so no type from
+    package:flutter/services.dart needs to be visible in the evaluation library.
+    """
+    lit = dq(text)
+    return editable_expr(idx, (
+        "try { st.widget.focusNode.requestFocus(); } catch (_) {} "
+        f"final dynamic cur = st.textEditingValue; final int n = {lit}.length; "
+        f"st.updateEditingValue(cur.copyWith(text: {lit}, "
+        "selection: cur.selection.copyWith(baseOffset: n, extentOffset: n))); "
+        "return 'TYPED n=' + hits.length.toString() + ' now=' + st.textEditingValue.text;"
+    ))
+
+
+# ==================================================================== observation
+
+TREES = {
+    "app": "ext.flutter.debugDumpApp",
+    "render": "ext.flutter.debugDumpRenderTree",
+    "layer": "ext.flutter.debugDumpLayerTree",
+    "focus": "ext.flutter.debugDumpFocusTree",
+    "semantics": "ext.flutter.debugDumpSemanticsTreeInTraversalOrder",
+}
+
+SCREEN_RE = re.compile(r"(\w*(?:Screen|Onboarding|Page|Unlock|Step|Dialog|Sheet)\w*)[\(\-]")
+TEXT_RE = re.compile(r'Text\("([^"]{1,160})"')
+FIELD_RE = re.compile(r"EditableText|TextField")
+
+
+def dump(kind: str = "app", timeout: float = 60.0) -> str:
+    ext = TREES.get(kind)
+    if not ext:
+        raise Fail(f"unknown tree {kind!r}")
+    state = load_state()
+    iso = state.get("iso") or main_isolate()
+    try:
+        return rpc(ext, isolateId=iso, timeout=timeout).get("data", "")
+    except Fail as exc:
+        if not re.search(r"isolate", str(exc), re.I):
+            raise
+        iso = main_isolate()
+        state["iso"] = iso
+        save_state(state)
+        return rpc(ext, isolateId=iso, timeout=timeout).get("data", "")
+
+
+def summarize(tree: str) -> dict:
+    return {
+        "screens": sorted({m.group(1) for m in SCREEN_RE.finditer(tree)}),
+        "texts": list(dict.fromkeys(m.group(1) for m in TEXT_RE.finditer(tree))),
+        "fields": len(FIELD_RE.findall(tree)),
+        "lines": tree.count("\n"),
+    }
+
+
+def count_text(tree: str, needle: str) -> int:
+    return len(re.findall(r'Text\("' + re.escape(needle) + r'"', tree))
+
+
+# ================================================================ host lifecycle
+
+
+def stage_repo(repo: str) -> None:
+    os.makedirs(WORK, exist_ok=True)
+    cmd = ["rsync", "-a", "--delete",
+           "--exclude", ".dart_tool",
+           "--exclude", "linux/flutter/ephemeral",
+           "--exclude", "build"]
+    cmd += [os.path.join(repo, p) for p in STAGE_PATHS if os.path.exists(os.path.join(repo, p))]
+    cmd.append(WORK + "/")
+    res = run(cmd)
+    if res.returncode != 0:
+        die(f"staging failed: {res.stderr.strip()}")
+
+
+def cmd_build_image(args) -> int:
+    repo = repo_root()
+    cmd = ["docker", "build", "-f", os.path.join(repo, "tool/live/Containerfile"),
+           "-t", IMAGE,
+           "--build-arg", f"HOST_UID={os.getuid()}",
+           "--build-arg", f"HOST_GID={os.getgid()}",
+           os.path.join(repo, "tool/live")]
+    print(" ".join(cmd))
+    return subprocess.run(cmd).returncode
+
+
+def cmd_up(args) -> int:
+    repo = repo_root()
+    if run(["docker", "version"]).returncode != 0:
+        die("docker is not usable")
+    if not image_exists():
+        print(f"image {IMAGE} missing — building it")
+        if cmd_build_image(args) != 0:
+            die("image build failed")
+
+    status = container_state()
+    if status == "running" and not args.fresh:
+        print(f"container {CONTAINER} already running")
+    else:
+        if status != "absent":
+            run(["docker", "rm", "-f", CONTAINER])
+        if args.fresh:
+            shutil.rmtree(HOST_LAB, ignore_errors=True)
+        stage_repo(repo)
+        run(["docker", "volume", "create", VOLUME])
+        res = run([
+            "docker", "run", "-d", "--name", CONTAINER,
+            "--init", "--shm-size=512m",
+            "-v", f"{WORK}:/work",
+            "-v", f"{os.path.join(repo, 'tool/live')}:/opt/lab:ro",
+            "-v", f"{VOLUME}:/home/ubuntu/.pub-cache",
+            IMAGE, "sleep", "infinity",
+        ])
+        if res.returncode != 0:
+            die(f"docker run failed: {res.stderr.strip()}")
+        print(f"container {CONTAINER} up ({res.stdout.strip()[:12]})")
+
+    root = run(["docker", "exec", "-u", "0", CONTAINER, "/opt/lab/labroot.sh"])
+    if "PRYSMLAB_SYSTEM_BUS_UP" not in root.stdout:
+        die("could not bring up the container's system D-Bus: "
+            + (root.stderr or root.stdout).strip())
+
+    # The bracket keeps the pattern from matching the `sh -lc` that carries it.
+    running = dexec(["sh", "-lc", "pgrep -f '[f]lutter_tools.snapshot run' >/dev/null && echo yes"])
+    if running.stdout.strip() == "yes" and not args.fresh:
+        print("app already running")
+    else:
+        start_app()
+    wait_for_vm(args.timeout)
+    forward(["status"])
+    return 0
+
+
+def start_app():
+    dexec(["sh", "-lc", f"pkill -f '[f]lutter_tools.snapshot run'; sleep 1; "
+                        f"mkdir -p {LAB} && rm -f {LOG_PATH} {STATE_PATH}"])
+    subprocess.run([
+        "docker", "exec", "-d", "-e", "PRYSMLAB_IN_CONTAINER=1", CONTAINER,
+        "sh", "-lc", f"/opt/lab/labd.sh > {LOG_PATH} 2>&1",
+    ], check=False)
+    print("app starting (the first run compiles the Linux bundle, a few minutes)")
+
+
+def wait_for_vm(timeout: float):
+    deadline = time.time() + timeout
+    pattern = "Dart VM Service on Linux is available at:"
+    last = ""
+    while time.time() < deadline:
+        log = dexec(["sh", "-lc", f"cat {LOG_PATH} 2>/dev/null"]).stdout
+        if pattern in log:
+            return
+        if "PRYSMLAB_XVFB_FAILED" in log:
+            die("Xvfb never came up inside the container; see `prysmlab logs`")
+        tail = (log.strip().splitlines() or [""])[-1]
+        if tail != last:
+            last = tail
+            print(f"  … {last[:110]}")
+        time.sleep(2)
+    print(dexec(["sh", "-lc", f"tail -40 {LOG_PATH}"]).stdout, file=sys.stderr)
+    die(f"no VM Service line after {timeout}s")
+
+
+def cmd_restart(args) -> int:
+    """Relaunch the app in the running container — the way to pick up code changes.
+
+    Hot restart over stdin is not an option: sending `R` to `flutter run` makes it
+    exit rather than restart.
+    """
+    if container_state() != "running":
+        die("no lab container is running — `prysmlab up` first")
+    if args.sync:
+        stage_repo(repo_root())
+        print(f"re-staged into {WORK}")
+    start_app()
+    wait_for_vm(args.timeout)
+    forward(["status"])
+    return 0
+
+
+def cmd_sync(args) -> int:
+    repo = repo_root()
+    stage_repo(repo)
+    print(f"staged {repo} -> {WORK}")
+    print("note: a running app keeps the old code; `prysmlab up --fresh` to relaunch")
+    return 0
+
+
+def cmd_shell(args) -> int:
+    return subprocess.run(["docker", "exec", "-it", CONTAINER, "bash", "-l"]).returncode
+
+
+def cmd_doctor(args) -> int:
+    repo = repo_root()
+    ok = True
+
+    def check(good: bool, label: str, hint: str = ""):
+        nonlocal ok
+        print(f"  {'ok  ' if good else 'FAIL'}  {label}")
+        if not good:
+            ok = False
+            if hint:
+                print(f"        -> {hint}")
+
+    check(run(["docker", "version"]).returncode == 0, "docker usable",
+          "rootless docker must be running")
+    check(image_exists(), f"image {IMAGE} present", "run `prysmlab build-image`")
+    check(shutil.which("rsync") is not None, "rsync present", "needed to stage the repo")
+    check(os.path.exists(os.path.join(repo, "tor_executable/tor")),
+          "repo tor binary present", "the app would download ~14 MB inside the container")
+
+    status = container_state()
+    print(f"  info  container {CONTAINER}: {status}")
+    print(f"  info  staging {WORK} "
+          f"({'present' if os.path.isdir(WORK) else 'absent'})")
+
+    host_tor = run(["pgrep", "-a", "tor"]).stdout.strip()
+    print("  info  host tor: " + (host_tor or "none")
+          + "  (unaffected either way: the app's `pkill -9 tor` cannot leave the "
+            "container's PID namespace)")
+    with socket.socket() as sock:
+        sock.settimeout(0.3)
+        busy = sock.connect_ex(("127.0.0.1", APP_PORT)) == 0
+    print(f"  info  host 127.0.0.1:{APP_PORT}: "
+          + ("in use by something (your real Prysm?) — irrelevant, the lab has its "
+             "own network namespace" if busy else "free"))
+
+    if status == "running":
+        probe = dexec(["python3", "/opt/lab/prysmlab", "status"])
+        print("  info  in-container status:")
+        for line in (probe.stdout or probe.stderr).splitlines():
+            print(f"        {line}")
+    return 0 if ok else 1
+
+
+def cmd_down(args) -> int:
+    status = container_state()
+    if status != "absent":
+        run(["docker", "rm", "-f", CONTAINER])
+        print(f"removed container {CONTAINER}")
+    else:
+        print("no container to remove")
+
+    if args.purge:
+        run(["docker", "volume", "rm", "-f", VOLUME])
+        shutil.rmtree(HOST_LAB, ignore_errors=True)
+        run(["docker", "image", "rm", "-f", IMAGE])
+        print(f"purged volume {VOLUME}, staging {HOST_LAB}, image {IMAGE}")
+
+    print("\nverification")
+    left = run(["docker", "ps", "-a", "--filter", f"name=^{CONTAINER}$",
+                "--format", "{{.Names}} {{.Status}}"]).stdout.strip()
+    print("  containers named " + CONTAINER + ": " + (left or "none"))
+    vols = run(["docker", "volume", "ls", "--filter", f"name={VOLUME}",
+                "--format", "{{.Name}}"]).stdout.strip()
+    print(f"  volume {VOLUME}: " + (vols or "none"))
+    print(f"  staging {HOST_LAB}: "
+          + ("present" if os.path.exists(HOST_LAB) else "removed"))
+    img = run(["docker", "images", "--format", "{{.Repository}}:{{.Tag}}",
+               IMAGE]).stdout.strip()
+    print(f"  image {IMAGE}: " + (img or "removed"))
+    print("  host tor: " + (run(["pgrep", "-a", "tor"]).stdout.strip() or "none"))
+    repo = repo_root()
+    dirty = run(["git", "-C", repo, "status", "--porcelain"]).stdout.strip()
+    print("  repo working tree: " + (dirty.replace("\n", " | ") if dirty else "clean"))
+    return 0
+
+
+# ================================================================== in-container
+
+
+def cmd_status(args) -> int:
+    info: dict = {"log": LOG_PATH}
+    try:
+        info["vm"] = vm_base()
+    except Fail as exc:
+        info["vm"] = f"unavailable: {exc}"
+    state = load_state()
+    info["evalLib"] = state.get("lib_uri")
+    res = run(["sh", "-lc", "pgrep -af '[f]lutter_tools.snapshot run' | head -1"])
+    info["flutterRun"] = res.stdout.strip() or None
+    print(json.dumps(info, indent=2))
+    if isinstance(info["vm"], str) and info["vm"].startswith("http"):
+        print(json.dumps(summarize(dump()), indent=2, ensure_ascii=False))
+    return 0
+
+
+def cmd_logs(args) -> int:
+    if args.follow:
+        proc = subprocess.Popen(["tail", "-n", str(args.tail), "-f", LOG_PATH])
+        try:
+            proc.wait(timeout=args.timeout)
+        except (subprocess.TimeoutExpired, KeyboardInterrupt):
+            proc.terminate()
+        return 0
+    try:
+        with open(LOG_PATH, errors="replace") as fh:
+            lines = fh.read().splitlines()
+    except OSError as exc:
+        die(str(exc))
+    if args.grep:
+        rx = re.compile(args.grep)
+        lines = [ln for ln in lines if rx.search(ln)]
+    print("\n".join(lines[-args.tail:]))
+    return 0
+
+
+def cmd_screen(args) -> int:
+    tree = dump(args.tree)
+    if args.raw:
+        print(tree)
+        return 0
+    info = summarize(tree)
+    if args.grep:
+        rx = re.compile(args.grep)
+        info["texts"] = [t for t in info["texts"] if rx.search(t)]
+    print(json.dumps(info, indent=2, ensure_ascii=False))
+    return 0
+
+
+def cmd_count(args) -> int:
+    tree = dump()
+    for needle in args.text:
+        print(f"{count_text(tree, needle):4d}  {needle}")
+    return 0
+
+
+def cmd_where(args) -> int:
+    print(eval_dart(probe_expr(pred_text(args.text, not args.contains), args.index)))
+    return 0
+
+
+def scroll_by(dy: float) -> str:
+    return eval_dart(SCROLL_EXPR.format(dy=int(dy)))
+
+
+def do_tap(pred: str, index: int, force: bool, autoscroll: bool, settle: float) -> str:
+    """Bring the target into view, then tap it.
+
+    localToGlobal happily returns coordinates for widgets outside the viewport, so
+    without this the tap silently lands on nothing.
+    """
+    for attempt in range(6):
+        probe = eval_dart(probe_expr(pred, index))
+        if probe.startswith(("NOTFOUND", "ERR")):
+            return probe
+        fields = dict(p.split("=", 1) for p in probe.split() if "=" in p)
+        if fields.get("hit") != "no" or not autoscroll or attempt == 5:
+            break
+        vh = float(fields.get("vh", 0))
+        if vh <= 0:
+            break
+        res = scroll_by(round(float(fields["y"]) - vh * 0.5))
+        if not res.startswith("SCROLLED"):
+            break
+        time.sleep(0.4)
+    out = eval_dart(tap_expr(pred, index, force=force))
+    if settle:
+        time.sleep(settle)
+    return out
+
+
+def cmd_tap(args) -> int:
+    out = do_tap(pred_text(args.text, not args.contains), args.index,
+                 args.force, not args.no_scroll, args.settle)
+    print(out)
+    return 0 if out.startswith("TAPPED") else 2
+
+
+def cmd_tap_widget(args) -> int:
+    out = do_tap(pred_widget(args.type, args.contains), args.index,
+                 args.force, not args.no_scroll, args.settle)
+    print(out)
+    return 0 if out.startswith("TAPPED") else 2
+
+
+def cmd_scroll(args) -> int:
+    print(scroll_by(args.dy))
+    return 0
+
+
+def cmd_pop(args) -> int:
+    out = eval_dart(POP_EXPR)
+    print(out)
+    time.sleep(args.settle)
+    return 0 if out == "POPPED" else 2
+
+
+def cmd_type(args) -> int:
+    out = eval_dart(type_expr(args.text, args.index))
+    print(out)
+    if args.submit:
+        print(eval_dart(editable_expr(
+            args.index, "st.performAction(TextInputAction.done); return 'SUBMITTED';")))
+    time.sleep(args.settle)
+    return 0 if out.startswith("TYPED") else 2
+
+
+def cmd_eval(args) -> int:
+    src = args.expr
+    if args.file:
+        src = sys.stdin.read() if args.file == "-" else open(args.file).read()
+    if not src:
+        die("nothing to evaluate")
+    print(eval_dart(flatten_dart(src), lib_uri=args.lib, timeout=args.timeout))
+    return 0
+
+
+def cmd_libs(args) -> int:
+    iso = load_state().get("iso") or main_isolate()
+    for uri, lid in sorted(resolve_libs(iso).items()):
+        if not args.pattern or args.pattern in uri:
+            print(f"{lid:<22} {uri}")
+    return 0
+
+
+def cmd_wait(args) -> int:
+    start = time.time()
+    while time.time() - start < args.timeout:
+        if count_text(dump(), args.text) >= args.count:
+            print(f"FOUND {args.text!r} after {time.time() - start:.1f}s")
+            return 0
+        time.sleep(args.interval)
+    print(f"TIMEOUT waiting for {args.text!r}", file=sys.stderr)
+    return 2
+
+
+# ============================================================ injection channel
+
+
+def http_json(method: str, path: str, body=None, timeout: float = 15.0):
+    data = json.dumps(body).encode() if body is not None else None
+    req = urllib.request.Request(
+        f"http://127.0.0.1:{APP_PORT}{path}", data=data, method=method,
+        headers={"Content-Type": "application/json"} if data else {})
+    try:
+        with urllib.request.urlopen(req, timeout=timeout) as resp:
+            return resp.status, resp.read().decode(errors="replace")
+    except urllib.error.HTTPError as exc:
+        return exc.code, exc.read().decode(errors="replace")
+    except urllib.error.URLError as exc:
+        raise Fail(f"the app's loopback server is not answering: {exc}") from exc
+
+
+def cmd_peer(args) -> int:
+    if args.what == "onion":
+        path = os.path.expanduser(
+            "~/Documents/prysm/tor_executable/tor_data/hidden_service/hostname")
+        try:
+            with open(path) as fh:
+                print(fh.read().strip())
+        except OSError as exc:
+            raise Fail(f"no onion yet at {path} ({exc}); Tor may still be bootstrapping")
+        return 0
+    if args.what == "public":
+        status, body = http_json("GET", "/public")
+    else:
+        raw = sys.stdin.read() if args.json == "-" else open(args.json).read()
+        status, body = http_json("POST", "/message", json.loads(raw))
+    print(status, body)
+    return 0 if status == 200 else 2
+
+
+# ==================================================================== onboarding
+
+
+def cmd_onboard(args) -> int:
+    """Drive the first-run flow by reading the screen and reacting to it.
+
+    A fixed replay of "Next, Next, PIN, Next×5, Get started" breaks the first time
+    a step is added; matching on what is actually on screen does not.
+    """
+    if not (args.pin.isdigit() and len(args.pin) >= 4):
+        die("--pin must be at least 4 digits")
+    advance = ["Reset local data and continue", "Get started", "Get Started",
+               "Next", "Continue", "Avanti", "Continua", "Inizia"]
+    digits = set("123456789")
+    entries = 0
+
+    for step in range(args.max_steps):
+        info = summarize(dump())
+        texts = set(info["texts"])
+        if any(s in info["screens"] for s in ("HomeScreen", "ChatListScreen")):
+            print(f"[{step}] home reached: {info['screens']}")
+            return 0
+        if digits <= texts:
+            entries += 1
+            print(f"[{step}] pin pad (entry {entries}) -> {args.pin}")
+            for digit in args.pin:
+                out = eval_dart(tap_expr(pred_text(digit), 0, force=True))
+                if not out.startswith("TAPPED"):
+                    print(f"       digit {digit}: {out}", file=sys.stderr)
+                    return 2
+                time.sleep(0.25)
+            time.sleep(args.settle)
+            continue
+        target = next((t for t in advance if t in texts), None)
+        if target:
+            print(f"[{step}] tap {target!r}")
+            out = do_tap(pred_text(target), 0, False, True, args.settle)
+            if not out.startswith("TAPPED"):
+                print(f"       {out}", file=sys.stderr)
+                return 2
+            continue
+        print(f"[{step}] stuck: screens={info['screens']} texts={info['texts'][:14]}",
+              file=sys.stderr)
+        return 2
+    print("onboard: step budget exhausted", file=sys.stderr)
+    return 2
+
+
+def cmd_shot(args) -> int:
+    out = args.out or f"{LAB}/shot-{int(time.time())}.png"
+    display = os.environ.get("DISPLAY", ":99")
+    res = run(["sh", "-lc",
+               f"xwd -root -display {display} | xwdtopnm 2>/dev/null | pnmtopng > {out}"])
+    if res.returncode != 0 or not os.path.exists(out) or os.path.getsize(out) == 0:
+        die(f"screenshot failed: {res.stderr.strip()}")
+    print(out)
+    print(f"copy it out with: docker cp {CONTAINER}:{out} .", file=sys.stderr)
+    return 0
+
+
+# =========================================================================== cli
+
+
+def build_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(
+        prog="prysmlab", description=__doc__.split("\n\n")[0],
+        epilog="lifecycle commands run on the host; all others are forwarded into "
+               "the container automatically",
+        formatter_class=argparse.RawDescriptionHelpFormatter)
+    sub = p.add_subparsers(dest="cmd", required=True)
+
+    s = sub.add_parser("doctor", help="preflight checks, host and container")
+    s.set_defaults(func=cmd_doctor)
+
+    s = sub.add_parser("build-image", help="build the prysm-lab image")
+    s.set_defaults(func=cmd_build_image)
+
+    s = sub.add_parser("up", help="stage the repo, start the container, start the app")
+    s.add_argument("--fresh", action="store_true",
+                   help="destroy the container first (loses the test identity)")
+    s.add_argument("--timeout", type=float, default=1200.0)
+    s.set_defaults(func=cmd_up)
+
+    s = sub.add_parser("down", help="stop the lab")
+    s.add_argument("--purge", action="store_true",
+                   help="also remove the volume, the staging dir and the image")
+    s.set_defaults(func=cmd_down)
+
+    s = sub.add_parser("sync", help="re-stage the repo into the container mount")
+    s.set_defaults(func=cmd_sync)
+
+    s = sub.add_parser("restart", help="relaunch the app inside the running container")
+    s.add_argument("--sync", action="store_true", help="re-stage the repo first")
+    s.add_argument("--timeout", type=float, default=600.0)
+    s.set_defaults(func=cmd_restart)
+
+    s = sub.add_parser("shell", help="interactive shell inside the container")
+    s.set_defaults(func=cmd_shell)
+
+    s = sub.add_parser("status", help="vm endpoint, app process and current screen")
+    s.set_defaults(func=cmd_status)
+
+    s = sub.add_parser("logs", help="the app log")
+    s.add_argument("--tail", type=int, default=40)
+    s.add_argument("--grep")
+    s.add_argument("--follow", action="store_true")
+    s.add_argument("--timeout", type=float, default=30.0)
+    s.set_defaults(func=cmd_logs)
+
+    s = sub.add_parser("screen", help="what is on screen, from the widget tree")
+    s.add_argument("--raw", action="store_true")
+    s.add_argument("--grep", help="filter the texts by regex")
+    s.add_argument("--tree", default="app", choices=sorted(TREES))
+    s.set_defaults(func=cmd_screen)
+
+    s = sub.add_parser("count",
+                       help="count Text occurrences (screen's list is deduplicated, "
+                            "so one string on two surfaces looks like one)")
+    s.add_argument("text", nargs="+")
+    s.set_defaults(func=cmd_count)
+
+    s = sub.add_parser("where", help="locate a text and say whether a tap would land")
+    s.add_argument("text")
+    s.add_argument("-n", "--index", type=int, default=0)
+    s.add_argument("--contains", action="store_true")
+    s.set_defaults(func=cmd_where)
+
+    for name, helptext in (("tap", "tap a widget by its text"),
+                           ("tap-widget", "tap by widget type (icons have no Text)")):
+        s = sub.add_parser(name, help=helptext)
+        if name == "tap":
+            s.add_argument("text")
+            s.add_argument("--contains", action="store_true")
+            s.set_defaults(func=cmd_tap)
+        else:
+            s.add_argument("--type", required=True, help="e.g. Semantics, IconButton")
+            s.add_argument("--contains", help="substring of the widget's toString")
+            s.set_defaults(func=cmd_tap_widget)
+        s.add_argument("-n", "--index", type=int, default=0)
+        s.add_argument("--no-scroll", action="store_true",
+                       help="do not scroll the target into view first")
+        s.add_argument("--force", action="store_true",
+                       help="tap even if the hit test says something covers it")
+        s.add_argument("--settle", type=float, default=1.2)
+
+    s = sub.add_parser("scroll", help="jump the longest scrollable by dy pixels")
+    s.add_argument("dy", type=int)
+    s.set_defaults(func=cmd_scroll)
+
+    s = sub.add_parser("pop", help="Navigator.pop (routes only; SettingsScreen is a "
+                                   "branch of HomeScreen's build, not a route)")
+    s.add_argument("--settle", type=float, default=1.2)
+    s.set_defaults(func=cmd_pop)
+
+    s = sub.add_parser("type", help="enter text into an EditableText")
+    s.add_argument("text")
+    s.add_argument("-n", "--index", type=int, default=0)
+    s.add_argument("--submit", action="store_true")
+    s.add_argument("--settle", type=float, default=0.8)
+    s.set_defaults(func=cmd_type)
+
+    s = sub.add_parser("eval", help="evaluate Dart inside the running app")
+    s.add_argument("expr", nargs="?")
+    s.add_argument("--file", help="read the snippet from a file ('-' = stdin); it is "
+                                  "flattened to one line for you")
+    s.add_argument("--lib", help="library uri or substring to evaluate in")
+    s.add_argument("--timeout", type=float, default=30.0)
+    s.set_defaults(func=cmd_eval)
+
+    s = sub.add_parser("libs", help="library uri -> id, for --lib")
+    s.add_argument("pattern", nargs="?")
+    s.set_defaults(func=cmd_libs)
+
+    s = sub.add_parser("wait", help="poll until a text appears")
+    s.add_argument("text")
+    s.add_argument("--count", type=int, default=1)
+    s.add_argument("--timeout", type=float, default=30.0)
+    s.add_argument("--interval", type=float, default=1.0)
+    s.set_defaults(func=cmd_wait)
+
+    s = sub.add_parser("peer", help="talk to the app's loopback server as a peer")
+    s.add_argument("what", choices=["public", "post", "onion"])
+    s.add_argument("--json", default="-", help="envelope file for post ('-' = stdin)")
+    s.set_defaults(func=cmd_peer)
+
+    s = sub.add_parser("onboard",
+                       help="reach the home screen from wherever the app is: "
+                            "first-run wizard, passcode unlock, or local-data reset")
+    s.add_argument("--pin", default="112233")
+    s.add_argument("--max-steps", type=int, default=30)
+    s.add_argument("--settle", type=float, default=2.0)
+    s.set_defaults(func=cmd_onboard)
+
+    s = sub.add_parser("shot", help="PNG of the Xvfb framebuffer")
+    s.add_argument("--out")
+    s.set_defaults(func=cmd_shot)
+
+    return p
+
+
+def main(argv: list[str]) -> int:
+    if not IN_CONTAINER and argv and argv[0] not in HOST_COMMANDS \
+            and not argv[0].startswith("-"):
+        return forward(argv)
+    args = build_parser().parse_args(argv)
+    try:
+        return args.func(args)
+    except Fail as exc:
+        print(f"prysmlab: {exc}", file=sys.stderr)
+        return 1
+    except KeyboardInterrupt:
+        return 130
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/tool/live/prysmlab
+++ b/tool/live/prysmlab
@@ -590,6 +590,11 @@ def cmd_up(args) -> int:
         print(f"container {CONTAINER} up ({res.stdout.strip()[:12]})")
 
     root = run(["docker", "exec", "-u", "0", CONTAINER, "/opt/lab/labroot.sh"])
+    if "PRYSMLAB_UPOWER_FAILED" in root.stdout:
+        die("system D-Bus is up but nothing claimed org.freedesktop.UPower. "
+            "battery_plus would hang AppBootstrap.initializeServices and "
+            "runApp would never be reached, so the app would open a window "
+            "and render nothing. Check /var/log/upowerd.log in the container.")
     if "PRYSMLAB_SYSTEM_BUS_UP" not in root.stdout:
         die("could not bring up the container's system D-Bus: "
             + (root.stderr or root.stdout).strip())


### PR DESCRIPTION
## What

Tooling that lets a developer — or an agent — drive the **real** Prysm app and read its widget tree back, instead of only running the test suite. Independent of the group-invite-mode PRs; based directly on `main`.

| Path | Role |
|---|---|
| `tool/live/Containerfile` | `prysm-lab` image: ubuntu 24.04 + Flutter 3.44.8 + GTK + Xvfb |
| `tool/live/labroot.sh` | root-side bootstrap: system D-Bus + `upowerd` |
| `tool/live/labd.sh` | in-container start: Xvfb, keyring, `flutter pub get`, `flutter run` |
| `tool/live/prysmlab` | Python 3 **stdlib-only** CLI, 23 commands, single entry point |
| `.agents/skills/live-app-testing/SKILL.md` | when to use it, the safety gate, and 12 traps with symptom and cause |

Three commands to a running, onboarded app:

```sh
./tool/live/prysmlab doctor
./tool/live/prysmlab up
./tool/live/prysmlab onboard --pin 112233
# ... work ...
./tool/live/prysmlab down --purge
```

Everything that is not lifecycle forwards itself into the container, so `prysmlab screen` typed on the host does a `docker exec` on itself.

## Why a container and not a sandbox directory

Not a preference — two mechanisms in the app make it mandatory:

- `TorManager._killOrphanTorForce` (`lib/util/tor_service.dart:497`) runs `pkill -9 tor` **with no pattern**. Only the PID namespace contains that; outside a container it kills the developer's system tor.
- The app's server binds `127.0.0.1:12345`. Only the network namespace stops it colliding with a real Prysm on the same machine.

The first five layers are byte-identical to `.l3e2e/Containerfile` so Docker reuses the cache and the ~1 GB Flutter SDK download does not repeat. **If `.l3e2e/Containerfile` changes, keep them aligned** or the build goes back to ~20 minutes.

## Design notes worth knowing before changing it

- **`evaluate` context is `package:flutter/src/widgets/binding.dart`**, not `package:prysm/main.dart`. That library already imports foundation, gestures, rendering, scheduler and services, so `WidgetsBinding`, `Element`, `RenderBox`, `Offset`, `PointerDownEvent` and `HitTestResult` are all in scope at once.
- **Taps hit-test before firing.** `localToGlobal` returns coordinates for off-viewport widgets too, so a naive driver reports success for a tap at y=1417 on a 720px-high window. `NOTFOUND` (absent) and `OCCLUDED` (covered) are now distinguishable, and autoscroll is the default.
- **`onboard` reacts to what is on screen** instead of replaying a fixed key sequence, which is why it handles the first-run wizard, the PIN unlock and "Reset local data and continue" with one code path.
- **Stdlib only**, including a hand-written RFC 6455 client (~100 lines). Zero new dependencies for the project.

## Three claims in the previous manual runbook that turned out to be false

| Claimed | Actual |
|---|---|
| First start needs a human click on the keyring dialog | Launcher bug: `printf ''` sends EOF with no newline, so the daemon never creates `login.keyring`. With `printf '\n'` it is fully headless — two `dbus-run-session` store+lookup cycles took 0.06 s total |
| Every restart begins again from "Local data error" | Same bug. With a real keyring the identity persists: `restart` lands on `UnlockScreen` in 5.4 s |
| `evaluate` only fails with a precompiled bundle | It also fails under `flutter run` when you talk HTTP instead of WebSocket — `compileExpression` is registered on the WS session. Same error text, different cause |

Two environment faults with an identical mute symptom ("app compiles, window opens, `debugDumpApp` says `<no tree currently mounted>`") are fixed in the image: missing `xdg-user-dirs` → `MissingPlatformDirectoryException`; missing system D-Bus → `battery_plus` hangs `AppBootstrap.initializeServices` and `runApp` is never reached.

## Verification

Full cycle run from a completely empty state — image deleted, only the files in this PR, nothing installed warm:

| Step | Observed | Time |
|---|---|---|
| `up` (no image) | rebuild, stage, container, system bus, Xvfb, keyring, Linux bundle, `OnboardingScreen` rendered | ~100 s |
| `onboard --pin 112233` | `[9] home reached: ['HomeScreen']` | 22 s |
| `peer public` / `peer onion` | real identity JSON; real `.onion`, Tor bootstrapped in-container | — |
| `count` → `tap "Chat with myself"` → `count` | `1` → `2` | — |
| `type "hello-lab"` | `TYPED n=1 now=hello-lab` | — |
| `tap-widget --contains "Settings"` → `pop` | opens `SettingsScreen`, then `CANNOT-POP` | — |
| `restart` | `UnlockScreen`, identity intact | 5.4 s |
| `down --purge` | verification block reports everything removed | 2 s |

This tooling found a real defect: the pending-invite counters not refreshing, fixed in the `invite-mode/ui` PR of the group-invite-mode series.

## What this does not prove

Stated plainly because it is easy to over-claim:

- **Not graphical rendering.** `shot` writes a real PNG from the Xvfb framebuffer, but nothing here asserts what is in it.
- **Not the compositor's input path.** Taps are injected via `WidgetsBinding.handlePointerEvent`, which is below the platform input layer.
- **Not CI.** It needs Docker and a real Tor bootstrap.

## Hygiene

No user data was read or modified; the real identity was never unlocked and the real app was never launched — everything happened inside the container. The PIN `112233` is the CLI default for a throwaway identity, not a secret.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an isolated environment for validating the Prysm desktop app end to end.
  * Added tools to launch, monitor, and control the app, including navigation, tapping, scrolling, text entry, screenshots, logs, and status checks.
  * Added automated onboarding and peer-request workflows.
  * Added documentation describing supported testing workflows, safety guidelines, troubleshooting, and cleanup.

* **Chores**
  * Added container and environment setup for headless Linux desktop testing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->