### PR TITLE
Group invite mode: land the policy and UI topics on main

### DIFF
--- a/lib/screens/home/home_screen.dart
+++ b/lib/screens/home/home_screen.dart
@@ -46,6 +46,7 @@ import 'package:prysm/screens/group_chat.dart';
 import 'package:prysm/models/conversation.dart';
 import 'package:prysm/models/conversation_preferences.dart';
 import 'package:prysm/models/group.dart';
+import 'package:prysm/models/group_invite_mode.dart';
 import 'package:prysm/services/conversation_preferences_service.dart';
 import 'package:prysm/models/detached_chat_launch.dart';
 import 'package:prysm/models/share_target.dart';
@@ -409,8 +410,11 @@ class _HomeScreenState extends State<HomeScreen> with WidgetsBindingObserver {
     // Invites held while their sender was unknown apply themselves once the
     // contact exists — including when the user added them from somewhere
     // else entirely. Skipped in decoy mode: a panic session must not touch
-    // real group state.
-    if (!widget.decoyMode) {
+    // real group state. Also skipped in contactsOnly mode, where nothing
+    // may be stored or applied: the promoter itself refuses there too, but
+    // the sweep should not even start.
+    if (!widget.decoyMode &&
+        settings.groupInviteMode == GroupInviteMode.holdAsRequest) {
       unawaited(
         GroupInvitePromoter(
           userId: widget.onionAddress,

--- a/lib/screens/home/home_screen.dart
+++ b/lib/screens/home/home_screen.dart
@@ -22,6 +22,7 @@ import 'package:prysm/app/app_composition.dart';
 import 'package:prysm/app/conversation_list_repository.dart';
 import 'package:prysm/app/tor_connection_controller.dart';
 import 'package:prysm/screens/settings_screen.dart';
+import 'package:prysm/screens/invite_requests_screen.dart';
 import 'package:prysm/services/battery_saver_service.dart';
 import 'package:prysm/services/block_service.dart';
 import 'package:prysm/services/active_conversation_tracker.dart';
@@ -73,6 +74,7 @@ import 'package:prysm/ui/core/prysm_pressable.dart';
 import 'package:prysm/util/notification_service.dart';
 import 'package:prysm/util/conversation_refresh_notifier.dart';
 import 'package:prysm/util/group_membership_notifier.dart';
+import 'package:prysm/util/group_pending_invite_store.dart';
 import 'package:prysm/screens/widgets/add_contact_dialog.dart';
 import 'package:prysm/screens/widgets/qr_scanner_screen.dart';
 import 'package:prysm/screens/widgets/prysm_id_qr.dart';
@@ -156,6 +158,7 @@ class _HomeScreenState extends State<HomeScreen> with WidgetsBindingObserver {
   bool _loadUsersQueued = false;
   bool _loadUsersQueuedLight = false;
   bool _sharePickerOpen = false;
+  int _pendingInviteCount = 0;
 
   int get _archivedCount => conversations
       .where((c) => _conversationPrefs[c.id]?.isArchived ?? false)
@@ -180,6 +183,7 @@ class _HomeScreenState extends State<HomeScreen> with WidgetsBindingObserver {
       return 0;
     }
     var count = 0;
+    if (_pendingInviteCount > 0) count++;
     if (_archivedCount > 0) count++;
     if (_blockedCount > 0) count++;
     return count;
@@ -877,6 +881,10 @@ class _HomeScreenState extends State<HomeScreen> with WidgetsBindingObserver {
         _selfChatLastPreview = deferred[3] as String?;
       }
 
+      final pendingInvites = await GroupPendingInviteStore.count();
+      if (!mounted) return;
+      setState(() => _pendingInviteCount = pendingInvites);
+
       _applyLoadedUsers(
         userMaps: userMaps,
         timestamps: timestamps,
@@ -1482,8 +1490,39 @@ class _HomeScreenState extends State<HomeScreen> with WidgetsBindingObserver {
               itemBuilder: (_, index) {
                 if (index >= _filteredConversations.length) {
                   final footerIndex = index - _filteredConversations.length;
+                  if (_pendingInviteCount > 0 && footerIndex == 0) {
+                    return Padding(
+                      padding: const EdgeInsets.symmetric(
+                        horizontal: 8,
+                        vertical: 2,
+                      ),
+                      child: PrysmListRow(
+                        leading: Icon(
+                          PrysmIcons.group,
+                          color: context.prysmStyle.tokens.accent,
+                        ),
+                        title: 'Invite requests',
+                        subtitle:
+                            '$_pendingInviteCount request${_pendingInviteCount == 1 ? '' : 's'}',
+                        onTap: () {
+                          Navigator.push(
+                            context,
+                            PrysmPageRoute(
+                              page: InviteRequestsScreen(
+                                onClose: () => Navigator.of(context).pop(),
+                                onionAddress: widget.onionAddress,
+                                keyManager: widget.keyManager,
+                                onChanged: () => scheduleLoadUsers(light: true),
+                              ),
+                            ),
+                          );
+                        },
+                      ),
+                    );
+                  }
                   final showArchivedFooter = _archivedCount > 0;
-                  if (showArchivedFooter && footerIndex == 0) {
+                  if (showArchivedFooter &&
+                      footerIndex == (_pendingInviteCount > 0 ? 1 : 0)) {
                     return Padding(
                       padding: const EdgeInsets.symmetric(
                         horizontal: 8,

--- a/lib/screens/home/home_screen.dart
+++ b/lib/screens/home/home_screen.dart
@@ -54,6 +54,7 @@ import 'package:prysm/services/detached_chat_host.dart';
 import 'package:prysm/services/detached_chat_window_registry.dart';
 import 'package:prysm/screens/widgets/conversation_context_menu.dart';
 import 'package:prysm/screens/widgets/conversation_actions_sheet.dart';
+import 'package:prysm/services/group_invite_promoter.dart';
 import 'package:prysm/services/group_service.dart';
 import 'package:prysm/util/db_helper.dart';
 import 'package:prysm/util/desktop_platform.dart';
@@ -400,6 +401,27 @@ class _HomeScreenState extends State<HomeScreen> with WidgetsBindingObserver {
       if (!mounted) return;
       unawaited(AppUpdateService().checkOnStartup(context));
     });
+
+    // Invites held while their sender was unknown apply themselves once the
+    // contact exists — including when the user added them from somewhere
+    // else entirely. Skipped in decoy mode: a panic session must not touch
+    // real group state.
+    if (!widget.decoyMode) {
+      unawaited(
+        GroupInvitePromoter(
+          userId: widget.onionAddress,
+          keyManager: widget.keyManager,
+        )
+            .promoteResolvable()
+            .catchError((Object e, StackTrace st) {
+              Logging.error('Promoting held invites failed: $e\n$st', 'Main');
+              return 0;
+            })
+            .then((promoted) {
+              if (promoted > 0 && mounted) scheduleLoadUsers(light: true);
+            }),
+      );
+    }
 
     _startAutoRefresh();
     if (!widget.offlineMode) {

--- a/lib/screens/invite_requests_screen.dart
+++ b/lib/screens/invite_requests_screen.dart
@@ -14,6 +14,7 @@ import 'package:prysm/ui/core/prysm_progress.dart';
 import 'package:prysm/ui/prysm_scaffold.dart';
 import 'package:prysm/util/group_pending_invite_store.dart';
 import 'package:prysm/util/key_manager.dart';
+import 'package:prysm/util/logging.dart';
 import 'package:prysm/util/onion_id_codec.dart';
 
 /// Group invites received from senders who are not in the local contacts.
@@ -45,6 +46,7 @@ class _InviteRequestsScreenState extends State<InviteRequestsScreen> {
   List<Map<String, Object?>> _rows = const [];
   bool _loading = true;
   String? _busySenderId;
+  String? _error;
 
   @override
   void initState() {
@@ -53,12 +55,25 @@ class _InviteRequestsScreenState extends State<InviteRequestsScreen> {
   }
 
   Future<void> _load() async {
-    final rows = await GroupPendingInviteStore.pending();
-    if (!mounted) return;
-    setState(() {
-      _rows = rows;
-      _loading = false;
-    });
+    try {
+      final rows = await GroupPendingInviteStore.pending();
+      if (!mounted) return;
+      setState(() {
+        _rows = rows;
+        _loading = false;
+        _error = null;
+      });
+    } catch (e) {
+      // Without this the screen keeps the progress indicator forever and the
+      // exception escapes the unawaited future in initState.
+      Logging.error('Reading the pending invites failed: $e',
+          'InviteRequestsScreen');
+      if (!mounted) return;
+      setState(() {
+        _loading = false;
+        _error = 'Could not read the pending requests.';
+      });
+    }
     widget.onChanged?.call();
   }
 
@@ -82,33 +97,54 @@ class _InviteRequestsScreenState extends State<InviteRequestsScreen> {
   }
 
   Future<void> _accept(String senderId) async {
+    if (_busySenderId != null) return;
     setState(() => _busySenderId = senderId);
+    String? failTitle;
+    String? failBody;
     try {
       final added = await ContactAddService.instance.addContact(
         onionId: senderId,
         displayName: '',
       );
-      if (!mounted) return;
       if (!added) {
-        await showPrysmDialog<void>(
-          context: context,
-          title: 'Could not reach this contact',
-          content: const Text(
-            'The invite is still waiting. Try again when they are online.',
-          ),
-          confirmLabel: 'OK',
-          onConfirm: () => Navigator.of(context).pop(),
-        );
-        return;
+        failTitle = 'Could not reach this contact';
+        failBody = 'The invite is still waiting. '
+            'Try again when they are online.';
+      } else {
+        final joined = await GroupInvitePromoter(
+          userId: widget.onionAddress,
+          keyManager: widget.keyManager,
+        ).promote(senderId);
+        if (!joined) {
+          // promote() consumes the row either way — an envelope that fails to
+          // authenticate is garbage and retrying it forever is worse. Say so,
+          // or the request just disappears with no group to show for it and
+          // the contact silently added.
+          failTitle = 'Could not join the group';
+          failBody = 'The contact was added, but this invite could not be '
+              'applied and has been removed. Ask them to invite you again.';
+        }
       }
-      await GroupInvitePromoter(
-        userId: widget.onionAddress,
-        keyManager: widget.keyManager,
-      ).promote(senderId);
+    } catch (e) {
+      Logging.error(
+        'Accepting the invite from ${Logging.redactOnion(senderId)} failed: $e',
+        'InviteRequestsScreen',
+      );
+      failTitle = 'Could not join the group';
+      failBody = 'Something went wrong while accepting this invite.';
     } finally {
       if (mounted) setState(() => _busySenderId = null);
     }
+    // Always reload: the row may be gone whether or not the join succeeded.
     await _load();
+    if (!mounted || failTitle == null) return;
+    await showPrysmDialog<void>(
+      context: context,
+      title: failTitle,
+      content: Text(failBody!),
+      confirmLabel: 'OK',
+      onConfirm: () => Navigator.of(context).pop(),
+    );
   }
 
   Future<void> _discard(String senderId) async {
@@ -134,7 +170,16 @@ class _InviteRequestsScreenState extends State<InviteRequestsScreen> {
       ),
       body: _loading
           ? const Center(child: PrysmProgressIndicator())
-          : _rows.isEmpty
+          : _error != null
+              ? Center(
+                  child: Text(
+                    _error!,
+                    style: TextStyle(
+                      color: context.prysmStyle.tokens.textMuted,
+                    ),
+                  ),
+                )
+              : _rows.isEmpty
               ? Center(
                   child: Text(
                     'No invite requests',
@@ -152,6 +197,11 @@ class _InviteRequestsScreenState extends State<InviteRequestsScreen> {
                     final senderId = row['senderId'] as String;
                     final short = _shortOnion(senderId);
                     final busy = _busySenderId == senderId;
+                    // Every row is locked while any accept runs, not just the
+                    // busy one: _busySenderId holds a single sender, so a
+                    // second tap would steal it, drop the first row's spinner
+                    // and leave two accept flows racing the same store.
+                    final locked = _busySenderId != null;
 
                     return PrysmListRow(
                       leading: ContactAvatar(name: short, avatarBase64: null),
@@ -167,11 +217,13 @@ class _InviteRequestsScreenState extends State<InviteRequestsScreen> {
                               children: [
                                 PrysmTextButton(
                                   label: 'Discard',
-                                  onPressed: () => _discard(senderId),
+                                  onPressed:
+                                      locked ? null : () => _discard(senderId),
                                 ),
                                 PrysmTextButton(
                                   label: 'Add contact and join',
-                                  onPressed: () => _accept(senderId),
+                                  onPressed:
+                                      locked ? null : () => _accept(senderId),
                                 ),
                               ],
                             ),

--- a/lib/screens/invite_requests_screen.dart
+++ b/lib/screens/invite_requests_screen.dart
@@ -1,0 +1,183 @@
+import 'dart:async';
+
+import 'package:flutter/widgets.dart';
+import 'package:prysm/screens/widgets/contact_avatar.dart';
+import 'package:prysm/services/contact_add_service.dart';
+import 'package:prysm/services/group_invite_promoter.dart';
+import 'package:prysm/theme/prysm_style_scope.dart';
+import 'package:prysm/ui/core/prysm_button.dart';
+import 'package:prysm/ui/core/prysm_dialog.dart';
+import 'package:prysm/ui/core/prysm_divider.dart';
+import 'package:prysm/ui/core/prysm_icons.dart';
+import 'package:prysm/ui/core/prysm_list_row.dart';
+import 'package:prysm/ui/core/prysm_progress.dart';
+import 'package:prysm/ui/prysm_scaffold.dart';
+import 'package:prysm/util/group_pending_invite_store.dart';
+import 'package:prysm/util/key_manager.dart';
+import 'package:prysm/util/onion_id_codec.dart';
+
+/// Group invites received from senders who are not in the local contacts.
+///
+/// Only the sender's address and the arrival time are shown: the invite
+/// itself is still encrypted and unauthenticated, so nothing inside it —
+/// group name, avatar, roster — may be displayed. Accepting adds the contact
+/// (the only network call in this flow, and it is the user's own action) and
+/// then replays the invite through the authenticated path.
+class InviteRequestsScreen extends StatefulWidget {
+  final VoidCallback onClose;
+  final String onionAddress;
+  final KeyManager keyManager;
+  final VoidCallback? onChanged;
+
+  const InviteRequestsScreen({
+    required this.onClose,
+    required this.onionAddress,
+    required this.keyManager,
+    this.onChanged,
+    super.key,
+  });
+
+  @override
+  State<InviteRequestsScreen> createState() => _InviteRequestsScreenState();
+}
+
+class _InviteRequestsScreenState extends State<InviteRequestsScreen> {
+  List<Map<String, Object?>> _rows = const [];
+  bool _loading = true;
+  String? _busySenderId;
+
+  @override
+  void initState() {
+    super.initState();
+    unawaited(_load());
+  }
+
+  Future<void> _load() async {
+    final rows = await GroupPendingInviteStore.pending();
+    if (!mounted) return;
+    setState(() {
+      _rows = rows;
+      _loading = false;
+    });
+    widget.onChanged?.call();
+  }
+
+  String _shortOnion(String onion) {
+    try {
+      final encoded = encodeOnionToBase58(onion);
+      if (encoded.length <= 12) return encoded;
+      return '${encoded.substring(0, 6)}…${encoded.substring(encoded.length - 4)}';
+    } catch (_) {
+      if (onion.length <= 12) return onion;
+      return '${onion.substring(0, 6)}…';
+    }
+  }
+
+  static String _two(int v) => v.toString().padLeft(2, '0');
+
+  String _receivedLabel(int receivedAt) {
+    final at = DateTime.fromMillisecondsSinceEpoch(receivedAt);
+    return '${at.year}-${_two(at.month)}-${_two(at.day)} '
+        '${_two(at.hour)}:${_two(at.minute)}';
+  }
+
+  Future<void> _accept(String senderId) async {
+    setState(() => _busySenderId = senderId);
+    try {
+      final added = await ContactAddService.instance.addContact(
+        onionId: senderId,
+        displayName: '',
+      );
+      if (!mounted) return;
+      if (!added) {
+        await showPrysmDialog<void>(
+          context: context,
+          title: 'Could not reach this contact',
+          content: const Text(
+            'The invite is still waiting. Try again when they are online.',
+          ),
+          confirmLabel: 'OK',
+          onConfirm: () => Navigator.of(context).pop(),
+        );
+        return;
+      }
+      await GroupInvitePromoter(
+        userId: widget.onionAddress,
+        keyManager: widget.keyManager,
+      ).promote(senderId);
+    } finally {
+      if (mounted) setState(() => _busySenderId = null);
+    }
+    await _load();
+  }
+
+  Future<void> _discard(String senderId) async {
+    final confirmed = await showPrysmConfirmDialog(
+      context: context,
+      title: 'Discard invite',
+      content: const Text('This request will be removed.'),
+      cancelLabel: 'Cancel',
+      confirmLabel: 'Discard',
+    );
+    if (confirmed != true) return;
+    await GroupPendingInviteStore.discard(senderId);
+    await _load();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return PrysmPage(
+      title: 'Invite requests',
+      leading: PrysmIconButton(
+        icon: PrysmIcons.arrowBack,
+        onPressed: widget.onClose,
+      ),
+      body: _loading
+          ? const Center(child: PrysmProgressIndicator())
+          : _rows.isEmpty
+              ? Center(
+                  child: Text(
+                    'No invite requests',
+                    style: TextStyle(
+                      color: context.prysmStyle.tokens.textMuted,
+                    ),
+                  ),
+                )
+              : ListView.separated(
+                  padding: const EdgeInsets.symmetric(vertical: 8),
+                  itemCount: _rows.length,
+                  separatorBuilder: (context, index) => const PrysmDivider(),
+                  itemBuilder: (context, index) {
+                    final row = _rows[index];
+                    final senderId = row['senderId'] as String;
+                    final short = _shortOnion(senderId);
+                    final busy = _busySenderId == senderId;
+
+                    return PrysmListRow(
+                      leading: ContactAvatar(name: short, avatarBase64: null),
+                      title: short,
+                      subtitleWidget: Text(
+                        'Group invite · ${_receivedLabel(row['receivedAt'] as int)}',
+                        style: const TextStyle(fontSize: 12),
+                      ),
+                      trailing: busy
+                          ? const PrysmProgressIndicator()
+                          : Row(
+                              mainAxisSize: MainAxisSize.min,
+                              children: [
+                                PrysmTextButton(
+                                  label: 'Discard',
+                                  onPressed: () => _discard(senderId),
+                                ),
+                                PrysmTextButton(
+                                  label: 'Add contact and join',
+                                  onPressed: () => _accept(senderId),
+                                ),
+                              ],
+                            ),
+                    );
+                  },
+                ),
+    );
+  }
+}

--- a/lib/screens/privacy_settings_screen.dart
+++ b/lib/screens/privacy_settings_screen.dart
@@ -10,6 +10,7 @@ import 'package:prysm/theme/prysm_tokens.dart';
 import 'package:prysm/screens/panic_pin_settings_screen.dart';
 import 'package:prysm/services/panic_pin_service.dart';
 import 'package:prysm/services/settings_service.dart';
+import 'package:prysm/util/group_pending_invite_store.dart';
 import 'package:prysm/util/key_manager.dart';
 import 'package:prysm/ui/core/prysm_button.dart';
 import 'package:prysm/ui/prysm_scaffold.dart';
@@ -82,6 +83,12 @@ class _PrivacySettingsScreenState extends State<PrivacySettingsScreen> {
     if (value == null || value == _groupInviteMode) return;
     setState(() => _groupInviteMode = value);
     await settings.setGroupInviteMode(value);
+    if (value == GroupInviteMode.contactsOnly) {
+      // The mode promises nothing is stored: switching to it discards what
+      // was held, so the requests screen cannot keep showing rows the user
+      // just asked not to keep.
+      await GroupPendingInviteStore.clear();
+    }
   }
 
   void _onLastSeenToggle(bool value) {
@@ -143,22 +150,22 @@ class _PrivacySettingsScreenState extends State<PrivacySettingsScreen> {
                   ),
                 ],
               ),
-              const SizedBox(height: 30),
-              Text('Group invites', style: style.headlineStyle),
-              const SizedBox(height: 12),
-              PrysmSection(
-                children: [
-                  for (final mode in GroupInviteMode.values)
-                    PrysmRadioRow<GroupInviteMode>(
-                      value: mode,
-                      groupValue: _groupInviteMode,
-                      title: mode.label,
-                      subtitle: mode.description,
-                      onChanged: _onGroupInviteModeChanged,
-                    ),
-                ],
-              ),
               if (widget.keyManager != null) ...[
+                const SizedBox(height: 30),
+                Text('Group invites', style: style.headlineStyle),
+                const SizedBox(height: 12),
+                PrysmSection(
+                  children: [
+                    for (final mode in GroupInviteMode.values)
+                      PrysmRadioRow<GroupInviteMode>(
+                        value: mode,
+                        groupValue: _groupInviteMode,
+                        title: mode.label,
+                        subtitle: mode.description,
+                        onChanged: _onGroupInviteModeChanged,
+                      ),
+                  ],
+                ),
                 const SizedBox(height: 30),
                 Text('Emergency', style: style.headlineStyle),
                 const SizedBox(height: 12),

--- a/lib/screens/privacy_settings_screen.dart
+++ b/lib/screens/privacy_settings_screen.dart
@@ -2,7 +2,9 @@ import 'package:flutter/widgets.dart';
 import 'package:prysm/ui/core/prysm_icons.dart';
 import 'package:prysm/ui/core/prysm_app.dart';
 import 'package:prysm/ui/core/prysm_list_row.dart';
+import 'package:prysm/ui/core/prysm_radio.dart';
 import 'package:prysm/ui/core/prysm_switch.dart';
+import 'package:prysm/models/group_invite_mode.dart';
 import 'package:prysm/theme/prysm_style_scope.dart';
 import 'package:prysm/theme/prysm_tokens.dart';
 import 'package:prysm/screens/panic_pin_settings_screen.dart';
@@ -36,6 +38,7 @@ class _PrivacySettingsScreenState extends State<PrivacySettingsScreen> {
   bool _typingIndicators = true;
   bool _lastSeen = true;
   bool _profilePhoto = true;
+  GroupInviteMode _groupInviteMode = SettingsService().groupInviteMode;
 
   @override
   void initState() {
@@ -73,6 +76,12 @@ class _PrivacySettingsScreenState extends State<PrivacySettingsScreen> {
   Future<void> _onTypingIndicatorsToggle(bool value) async {
     setState(() => _typingIndicators = value);
     await settings.setEnableTypingIndicators(value);
+  }
+
+  Future<void> _onGroupInviteModeChanged(GroupInviteMode? value) async {
+    if (value == null || value == _groupInviteMode) return;
+    setState(() => _groupInviteMode = value);
+    await settings.setGroupInviteMode(value);
   }
 
   void _onLastSeenToggle(bool value) {
@@ -132,6 +141,21 @@ class _PrivacySettingsScreenState extends State<PrivacySettingsScreen> {
                     value: _profilePhoto,
                     onChanged: _onProfilePhotoToggle,
                   ),
+                ],
+              ),
+              const SizedBox(height: 30),
+              Text('Group invites', style: style.headlineStyle),
+              const SizedBox(height: 12),
+              PrysmSection(
+                children: [
+                  for (final mode in GroupInviteMode.values)
+                    PrysmRadioRow<GroupInviteMode>(
+                      value: mode,
+                      groupValue: _groupInviteMode,
+                      title: mode.label,
+                      subtitle: mode.description,
+                      onChanged: _onGroupInviteModeChanged,
+                    ),
                 ],
               ),
               if (widget.keyManager != null) ...[

--- a/lib/screens/privacy_settings_screen.dart
+++ b/lib/screens/privacy_settings_screen.dart
@@ -10,6 +10,7 @@ import 'package:prysm/theme/prysm_tokens.dart';
 import 'package:prysm/screens/panic_pin_settings_screen.dart';
 import 'package:prysm/services/panic_pin_service.dart';
 import 'package:prysm/services/settings_service.dart';
+import 'package:prysm/util/conversation_refresh_notifier.dart';
 import 'package:prysm/util/group_pending_invite_store.dart';
 import 'package:prysm/util/key_manager.dart';
 import 'package:prysm/ui/core/prysm_button.dart';
@@ -88,6 +89,10 @@ class _PrivacySettingsScreenState extends State<PrivacySettingsScreen> {
       // was held, so the requests screen cannot keep showing rows the user
       // just asked not to keep.
       await GroupPendingInviteStore.clear();
+      // The sidebar caches the pending count and would keep advertising
+      // requests that no longer exist; this is the notifier the home screen
+      // already listens to for a light reload.
+      ConversationRefreshNotifier.instance.notifyInboundMessage();
     }
   }
 

--- a/lib/screens/privacy_settings_screen.dart
+++ b/lib/screens/privacy_settings_screen.dart
@@ -42,6 +42,10 @@ class _PrivacySettingsScreenState extends State<PrivacySettingsScreen> {
   bool _profilePhoto = true;
   GroupInviteMode _groupInviteMode = SettingsService().groupInviteMode;
 
+  /// True while a mode change is being persisted. Blocks a second selection
+  /// from racing the first one's `GroupPendingInviteStore.clear()`.
+  bool _applyingInviteMode = false;
+
   @override
   void initState() {
     super.initState();
@@ -82,17 +86,32 @@ class _PrivacySettingsScreenState extends State<PrivacySettingsScreen> {
 
   Future<void> _onGroupInviteModeChanged(GroupInviteMode? value) async {
     if (value == null || value == _groupInviteMode) return;
-    setState(() => _groupInviteMode = value);
-    await settings.setGroupInviteMode(value);
-    if (value == GroupInviteMode.contactsOnly) {
-      // The mode promises nothing is stored: switching to it discards what
-      // was held, so the requests screen cannot keep showing rows the user
-      // just asked not to keep.
-      await GroupPendingInviteStore.clear();
-      // The sidebar caches the pending count and would keep advertising
-      // requests that no longer exist; this is the notifier the home screen
-      // already listens to for a light reload.
-      ConversationRefreshNotifier.instance.notifyInboundMessage();
+    // Reentrancy guard, not decoration. Without it: tap contactsOnly, tap
+    // holdAsRequest before the first await returns, and the first invocation
+    // resumes with its own captured `value` still == contactsOnly and wipes
+    // the store — while the committed mode is the one that allows holding.
+    if (_applyingInviteMode) return;
+    setState(() {
+      _groupInviteMode = value;
+      _applyingInviteMode = true;
+    });
+    try {
+      await settings.setGroupInviteMode(value);
+      // Re-read what was actually committed instead of trusting `value`: the
+      // clear is destructive and must follow the persisted mode, not the
+      // intent this closure was created with.
+      if (settings.groupInviteMode == GroupInviteMode.contactsOnly) {
+        // The mode promises nothing is stored: switching to it discards what
+        // was held, so the requests screen cannot keep showing rows the user
+        // just asked not to keep.
+        await GroupPendingInviteStore.clear();
+        // The sidebar caches the pending count and would keep advertising
+        // requests that no longer exist; this is the notifier the home screen
+        // already listens to for a light reload.
+        ConversationRefreshNotifier.instance.notifyInboundMessage();
+      }
+    } finally {
+      if (mounted) setState(() => _applyingInviteMode = false);
     }
   }
 
@@ -167,7 +186,9 @@ class _PrivacySettingsScreenState extends State<PrivacySettingsScreen> {
                         groupValue: _groupInviteMode,
                         title: mode.label,
                         subtitle: mode.description,
-                        onChanged: _onGroupInviteModeChanged,
+                        onChanged: _applyingInviteMode
+                            ? null
+                            : _onGroupInviteModeChanged,
                       ),
                   ],
                 ),

--- a/lib/screens/settings_screen.dart
+++ b/lib/screens/settings_screen.dart
@@ -15,6 +15,7 @@ import 'package:url_launcher/url_launcher.dart';
 import 'package:file_picker/file_picker.dart';
 import 'package:path/path.dart' as p;
 import 'package:prysm/util/download_location.dart';
+import 'package:prysm/util/group_pending_invite_store.dart';
 import 'package:prysm/util/key_manager.dart';
 import 'package:prysm/util/log_export_helper.dart';
 import 'package:prysm/models/unlock_type.dart';
@@ -84,6 +85,7 @@ class _SettingsScreenState extends State<SettingsScreen> {
   bool _enableLinkUnfurling = false;
   bool _biometricsEnabled = false;
   bool _biometricsAvailable = false;
+  int _pendingInviteCount = 0;
   String _downloadLocationDisplay = 'Loading...';
   List<LinuxAudioDevice> _linuxInputDevices = const [];
   String? _linuxSelectedDeviceId;
@@ -95,6 +97,7 @@ class _SettingsScreenState extends State<SettingsScreen> {
     super.initState();
     _loadSettings();
     _loadDownloadLocationDisplay();
+    unawaited(_loadPendingInviteCount());
     if (Platform.isAndroid) {
       unawaited(_loadBiometricsState());
     }
@@ -130,6 +133,12 @@ class _SettingsScreenState extends State<SettingsScreen> {
     if (mounted) {
       setState(() => _biometricsAvailable = available);
     }
+  }
+
+  Future<void> _loadPendingInviteCount() async {
+    final count = await GroupPendingInviteStore.count();
+    if (!mounted) return;
+    setState(() => _pendingInviteCount = count);
   }
 
   Future<void> _onBiometricsToggled(bool value) async {
@@ -696,10 +705,13 @@ class _SettingsScreenState extends State<SettingsScreen> {
                             onClose: () => Navigator.of(context).pop(),
                             onionAddress: widget.onionAddress!,
                             keyManager: widget.keyManager!,
+                            onChanged: _loadPendingInviteCount,
                           ),
                         ),
                       );
                     },
+                    subtitle:
+                        '$_pendingInviteCount request${_pendingInviteCount == 1 ? '' : 's'}',
                   ),
                   const PrysmDivider(),
                 ],

--- a/lib/screens/settings_screen.dart
+++ b/lib/screens/settings_screen.dart
@@ -22,6 +22,7 @@ import 'package:prysm/services/biometric_unlock_service.dart';
 import 'package:prysm/screens/widgets/change_passcode_flow.dart';
 import 'privacy_settings_screen.dart';
 import 'blocked_contacts_screen.dart';
+import 'invite_requests_screen.dart';
 import 'call_history_screen.dart';
 import 'package:prysm/screens/widgets/appearance_settings_section.dart';
 import 'package:prysm/theme/prysm_theme.dart';
@@ -683,6 +684,25 @@ class _SettingsScreenState extends State<SettingsScreen> {
                   },
                 ),
                 const PrysmDivider(),
+                if (widget.keyManager != null && widget.onionAddress != null) ...[
+                  _buildNavigationTile(
+                    'Invite requests',
+                    PrysmIcons.group,
+                    () {
+                      Navigator.push(
+                        context,
+                        PrysmPageRoute(
+                          page: InviteRequestsScreen(
+                            onClose: () => Navigator.of(context).pop(),
+                            onionAddress: widget.onionAddress!,
+                            keyManager: widget.keyManager!,
+                          ),
+                        ),
+                      );
+                    },
+                  ),
+                  const PrysmDivider(),
+                ],
                 _buildNavigationTile(
                   'Advanced Privacy',
                   PrysmIcons.privacyTip,

--- a/lib/screens/settings_screen.dart
+++ b/lib/screens/settings_screen.dart
@@ -719,6 +719,9 @@ class _SettingsScreenState extends State<SettingsScreen> {
                   'Advanced Privacy',
                   PrysmIcons.privacyTip,
                   () {
+                    // Switching to the strict mode inside this screen
+                    // discards every held invite, so the count on the tile
+                    // above is stale the moment we come back.
                     Navigator.push(
                       context,
                       PrysmPageRoute(page: PrivacySettingsScreen(
@@ -726,7 +729,7 @@ class _SettingsScreenState extends State<SettingsScreen> {
                           keyManager: widget.keyManager,
                         ),
                       ),
-                    );
+                    ).then((_) => _loadPendingInviteCount());
                   },
                 ),
               ]),

--- a/lib/services/contact_add_service.dart
+++ b/lib/services/contact_add_service.dart
@@ -112,9 +112,20 @@ class ContactAddService {
       return false;
     }
 
+    // Keep whatever name the row already carries. insertOrUpdateUser is
+    // INSERT OR REPLACE, i.e. a whole-row write, so hardcoding name:'' here
+    // does not "leave the name empty" — it destroys what was there. The row
+    // normally exists before this call: ensureUserExist creates it on every
+    // inbound handler with 'Unknown - xxxxxx', which is the only display name
+    // a contact added from an invite request ever has, because that flow
+    // passes displayName:'' (a nickname it has no business inventing) and
+    // _enrichFromProfile is unawaited and writes 'name' only when the peer
+    // actually serves a username.
+    final existing = await DBHelper.getUserById(onionId);
+
     final newUser = Contact(
       id: onionId,
-      name: '',
+      name: (existing?['name'] as String?) ?? '',
       avatarUrl: '',
       avatarBase64: null,
       customName: displayName.isNotEmpty ? displayName : null,

--- a/lib/services/contact_add_service.dart
+++ b/lib/services/contact_add_service.dart
@@ -112,30 +112,38 @@ class ContactAddService {
       return false;
     }
 
-    // Keep whatever name the row already carries. insertOrUpdateUser is
-    // INSERT OR REPLACE, i.e. a whole-row write, so hardcoding name:'' here
-    // does not "leave the name empty" — it destroys what was there. The row
-    // normally exists before this call: ensureUserExist creates it on every
-    // inbound handler with 'Unknown - xxxxxx', which is the only display name
-    // a contact added from an invite request ever has, because that flow
-    // passes displayName:'' (a nickname it has no business inventing) and
-    // _enrichFromProfile is unawaited and writes 'name' only when the peer
-    // actually serves a username.
+    // insertOrUpdateUser is INSERT OR REPLACE, i.e. a whole-row write: every
+    // column not carried over here is destroyed. Only the identity is meant
+    // to be overwritten by this call, so the row is read first and merged —
+    // the same shape PeerIdentityResolver already uses for this exact
+    // operation (peer_identity_resolver.dart:113-121).
+    //
+    // This is not defensive: the row normally exists before the call, because
+    // ensureUserExist runs on every inbound handler and seeds
+    // 'Unknown - xxxxxx'. And the invite-request flow passes displayName:''
+    // on purpose — a nickname is the user's to choose, not a screen's to
+    // invent — so without the merge that flow would blank both the only
+    // display name the contact has and any nickname already set for them.
     final existing = await DBHelper.getUserById(onionId);
 
     final newUser = Contact(
       id: onionId,
       name: (existing?['name'] as String?) ?? '',
-      avatarUrl: '',
-      avatarBase64: null,
-      customName: displayName.isNotEmpty ? displayName : null,
+      avatarUrl: (existing?['avatarUrl'] as String?) ?? '',
+      avatarBase64: existing?['avatarBase64'] as String?,
+      // Nothing ever restores a nickname: _enrichFromProfile writes only
+      // 'name' and 'avatarBase64'. Replace it only when this caller actually
+      // supplies one.
+      customName: displayName.isNotEmpty
+          ? displayName
+          : existing?['customName'] as String?,
       identityJson: identityJson,
     );
     await DBHelper.insertOrUpdateUser({
       'id': newUser.id,
       'name': newUser.name,
       'avatarUrl': newUser.avatarUrl,
-      'avatarBase64': null,
+      'avatarBase64': newUser.avatarBase64,
       'customName': newUser.customName,
       'identityJson': identityJson,
       'publicKeyPem': identityJson,

--- a/lib/services/group_invite_promoter.dart
+++ b/lib/services/group_invite_promoter.dart
@@ -40,7 +40,19 @@ class GroupInvitePromoter {
   final KeyManager keyManager;
   final GroupService _groupService;
 
+  /// Applies the invite held for [senderId], if any. Returns whether a group
+  /// was actually joined.
+  ///
+  /// Refuses while the mode is `contactsOnly`. The gate belongs **here**, on
+  /// the effect, and not only on [promoteResolvable]: that mode promises
+  /// nothing is applied, `take` removes the row even when nothing can be done
+  /// with it, and this method is reachable from a screen that was already open
+  /// when the user changed the mode — its rows are whatever the last load
+  /// returned, not what the store holds now.
   Future<bool> promote(String senderId) async {
+    if (SettingsService().groupInviteMode == GroupInviteMode.contactsOnly) {
+      return false;
+    }
     final wire = await GroupPendingInviteStore.take(senderId);
     if (wire == null) return false;
     try {
@@ -62,9 +74,9 @@ class GroupInvitePromoter {
   /// Promotes every pending invite whose sender is now locally known.
   /// Returns how many were applied.
   ///
-  /// A no-op while the mode is `contactsOnly`: that mode promises nothing is
-  /// stored and nothing is applied, and any rows still present (e.g. held
-  /// before the mode changed) must not be promoted behind the user's back.
+  /// A no-op while the mode is `contactsOnly`. [promote] refuses there too, so
+  /// this is a fast path that skips the store read and the identity lookups —
+  /// not the guarantee itself.
   Future<int> promoteResolvable() async {
     if (SettingsService().groupInviteMode == GroupInviteMode.contactsOnly) {
       return 0;

--- a/lib/services/group_invite_promoter.dart
+++ b/lib/services/group_invite_promoter.dart
@@ -1,5 +1,7 @@
 import 'package:prysm/constants/group_constants.dart';
+import 'package:prysm/models/group_invite_mode.dart';
 import 'package:prysm/services/group_service.dart';
+import 'package:prysm/services/settings_service.dart';
 import 'package:prysm/util/group_pending_invite_store.dart';
 import 'package:prysm/util/key_manager.dart';
 import 'package:prysm/util/logging.dart';
@@ -59,7 +61,14 @@ class GroupInvitePromoter {
 
   /// Promotes every pending invite whose sender is now locally known.
   /// Returns how many were applied.
+  ///
+  /// A no-op while the mode is `contactsOnly`: that mode promises nothing is
+  /// stored and nothing is applied, and any rows still present (e.g. held
+  /// before the mode changed) must not be promoted behind the user's back.
   Future<int> promoteResolvable() async {
+    if (SettingsService().groupInviteMode == GroupInviteMode.contactsOnly) {
+      return 0;
+    }
     final rows = await GroupPendingInviteStore.pending();
     var promoted = 0;
     for (final row in rows) {

--- a/lib/services/group_invite_promoter.dart
+++ b/lib/services/group_invite_promoter.dart
@@ -1,0 +1,72 @@
+import 'package:prysm/constants/group_constants.dart';
+import 'package:prysm/services/group_service.dart';
+import 'package:prysm/util/group_pending_invite_store.dart';
+import 'package:prysm/util/key_manager.dart';
+import 'package:prysm/util/logging.dart';
+import 'package:prysm/util/peer_identity_loader.dart';
+
+/// Replays a held first-contact invite once its sender's identity is in the
+/// local user store.
+///
+/// Promotion never bypasses authentication: the held envelope goes through
+/// [GroupService.handleIncomingControlMessage], the same path the message
+/// would have taken had the sender been known when it arrived. The row is
+/// removed either way — an envelope that fails to authenticate is garbage,
+/// and keeping it would let a failed attempt be retried forever.
+///
+/// Known limitation, deliberately not fixed here because it is not this
+/// class's to fix: an invite is a point-in-time snapshot of a group's roster
+/// and key version, and `_handleInvite`'s staleness guards read only local
+/// state (`group_service.dart:626-639`). So a snapshot applied late can
+/// re-create a group the user has since left — `deleteGroupLocal` removes the
+/// `group_keys` row, which sets `localKeyVersion` back to 0 and disarms the
+/// version guard — and can drop members who joined after it was taken, since
+/// adding a member does not rotate the key. This is a pre-existing property
+/// of the live path: a queued invite envelope re-delivered by the transport
+/// after the user left does exactly the same thing. Promotion does not widen
+/// it beyond `GroupPendingInviteStore.retention`, which bounds how stale a
+/// replayed snapshot can be.
+class GroupInvitePromoter {
+  GroupInvitePromoter({
+    required this.userId,
+    required this.keyManager,
+    GroupService? groupService,
+  }) : _groupService = groupService ??
+            GroupService(userId: userId, keyManager: keyManager);
+
+  final String userId;
+  final KeyManager keyManager;
+  final GroupService _groupService;
+
+  Future<bool> promote(String senderId) async {
+    final wire = await GroupPendingInviteStore.take(senderId);
+    if (wire == null) return false;
+    try {
+      return await _groupService.handleIncomingControlMessage(
+        groupInviteType,
+        wire,
+        senderId,
+      );
+    } catch (e) {
+      Logging.error(
+        'Promoting the held invite from ${Logging.redactOnion(senderId)} '
+        'failed: $e',
+        'GroupInvitePromoter',
+      );
+      return false;
+    }
+  }
+
+  /// Promotes every pending invite whose sender is now locally known.
+  /// Returns how many were applied.
+  Future<int> promoteResolvable() async {
+    final rows = await GroupPendingInviteStore.pending();
+    var promoted = 0;
+    for (final row in rows) {
+      final senderId = row['senderId'] as String;
+      if (await loadPeerIdentityFromDb(keyManager, senderId) == null) continue;
+      if (await promote(senderId)) promoted++;
+    }
+    return promoted;
+  }
+}

--- a/lib/services/group_service.dart
+++ b/lib/services/group_service.dart
@@ -6,13 +6,16 @@ import 'package:prysm/util/logging.dart';
 import 'package:prysm/constants/group_constants.dart';
 import 'package:prysm/database/messages.dart';
 import 'package:prysm/models/group.dart';
+import 'package:prysm/models/group_invite_mode.dart';
 import 'package:prysm/services/conversation_preferences_service.dart';
 import 'package:prysm/services/disappearing_timer_service.dart';
 import 'package:prysm/services/group_control_channel.dart';
 import 'package:prysm/services/group_key_provider.dart';
+import 'package:prysm/services/settings_service.dart';
 import 'package:prysm/util/db_helper.dart';
 import 'package:prysm/crypto/group_crypto.dart';
 import 'package:prysm/crypto/identity.dart';
+import 'package:prysm/util/group_pending_invite_store.dart';
 import 'package:prysm/util/group_sender_index_store.dart';
 import 'package:prysm/util/key_manager.dart';
 import 'package:prysm/util/group_membership_notifier.dart';
@@ -37,6 +40,7 @@ class GroupServiceException implements Exception {
 class GroupService {
   final String userId;
   final KeyManager keyManager;
+  final SettingsService _settings = SettingsService();
 
   late final GroupKeyProvider _keyProvider;
   late final GroupControlChannel _controlChannel;
@@ -480,16 +484,46 @@ class GroupService {
   ) async {
     final senderKeys = await _resolveSenderIdentity(senderId);
     // Accepted policy (option 1, PR #128): a control message from a sender
-    // whose identity is not in the local store is deliberately dropped —
-    // the invitee sees nothing today. The identity is not merely unverified
-    // but required: decryptControlPayload below authenticates the payload
-    // against it, so the payload cannot even be read without it. Do not
-    // "fix" this by resolving the sender over the network on cache-miss:
-    // that would reopen the M2 profile-fetch oracle (an unauthenticated
-    // sender forcing GET /profile as an implicit delivery receipt) before
-    // any signature check. A pending-invite flow is the tracked follow-up
-    // (https://github.com/xmreur/prysm/pull/128#issuecomment-5205552544).
+    // whose identity is not in the local store is not processed. The
+    // identity is required to *authenticate* it: decryptControlPayload
+    // below verifies the control-wrap-2 signature against it, so without it
+    // the payload can only be read unverified — which is exactly what must
+    // not happen. Do not "fix" this by resolving the sender over the network
+    // on cache-miss: that would reopen the M2 profile-fetch oracle (an
+    // unauthenticated sender forcing GET /profile as an implicit delivery
+    // receipt) before any signature check.
+    //
+    // What the user can choose (GroupInviteMode) is only what happens to an
+    // *invite* afterwards: dropped outright, or held opaque and bounded for
+    // the user to accept — never processed, never decrypted, and never a
+    // reason to send anything.
     if (senderKeys == null) {
+      if (type == groupInviteType &&
+          _settings.groupInviteMode == GroupInviteMode.holdAsRequest) {
+        // A store failure must not change the sender-visible outcome: on
+        // this ingress a status difference is an oracle, so a broken store
+        // (DB error, locked file) degrades to the plain drop, exactly like
+        // a full one.
+        try {
+          final held = await GroupPendingInviteStore.hold(
+            senderId: senderId,
+            wire: encryptedPayload,
+          );
+          if (!held) {
+            Logging.error(
+              'Pending invite store full, dropping invite from '
+              '${Logging.redactOnion(senderId)}',
+              'GroupService',
+            );
+          }
+        } catch (e) {
+          Logging.error(
+            'Pending invite store failed, dropping invite from '
+            '${Logging.redactOnion(senderId)}: $e',
+            'GroupService',
+          );
+        }
+      }
       Logging.error(
         'Dropping $type from ${Logging.redactOnion(senderId)}: '
         'sender identity unresolvable',

--- a/test/contact_add_service_characterization_test.dart
+++ b/test/contact_add_service_characterization_test.dart
@@ -215,6 +215,65 @@ void main() {
       expect(row?['customName'], isNull);
     });
 
+    test(
+        'an empty displayName keeps the existing nickname and avatar instead '
+        'of nulling them', () async {
+      // Re-adding someone who is already a contact: the invite flow passes
+      // displayName:'' and the write is INSERT OR REPLACE, so without the
+      // merge this nulls a user-chosen nickname. Nothing restores it —
+      // _enrichFromProfile writes only 'name' and 'avatarBase64'.
+      await DBHelper.insertOrUpdateUser({
+        'id': onionId,
+        'name': 'Alice B.',
+        'avatarUrl': '',
+        'avatarBase64': 'YWJj',
+        'customName': 'Bob',
+        'identityJson': null,
+        'publicKeyPem': null,
+      });
+
+      final service = ContactAddService.forTesting(
+        fetchPublic: (_) async => peerIdentityJson,
+        fetchProfile: (_) async => '{}',
+      );
+
+      expect(
+        await service.addContact(onionId: onionId, displayName: ''),
+        isTrue,
+      );
+
+      final row = await DBHelper.getUserById(onionId);
+      expect(row?['customName'], 'Bob');
+      expect(row?['name'], 'Alice B.');
+      expect(row?['avatarBase64'], 'YWJj');
+      // The identity is the one thing this call is meant to overwrite.
+      expect(row?['identityJson'], peerIdentityJson);
+    });
+
+    test('a non-empty displayName still replaces the nickname', () async {
+      await DBHelper.insertOrUpdateUser({
+        'id': onionId,
+        'name': 'Alice B.',
+        'avatarUrl': '',
+        'avatarBase64': null,
+        'customName': 'Bob',
+        'identityJson': null,
+        'publicKeyPem': null,
+      });
+
+      final service = ContactAddService.forTesting(
+        fetchPublic: (_) async => peerIdentityJson,
+        fetchProfile: (_) async => '{}',
+      );
+
+      expect(
+        await service.addContact(onionId: onionId, displayName: 'Carol'),
+        isTrue,
+      );
+
+      expect((await DBHelper.getUserById(onionId))?['customName'], 'Carol');
+    });
+
     test('returns false when the fetched identity JSON is malformed',
         () async {
       final service = ContactAddService.forTesting(

--- a/test/contact_add_service_characterization_test.dart
+++ b/test/contact_add_service_characterization_test.dart
@@ -185,6 +185,36 @@ void main() {
       expect(row['publicKeyPem'], peerIdentityJson);
     });
 
+    test(
+        'keeps the name the row already had instead of clobbering it with an '
+        'empty string', () async {
+      // The real sequence behind an invite request: inbound traffic created
+      // the row through ensureUserExist long before the user accepted. Since
+      // insertOrUpdateUser is INSERT OR REPLACE, a hardcoded name:'' would
+      // not "leave the name empty", it would destroy the only display name
+      // this contact has — the invite flow passes displayName:'' on purpose
+      // (a nickname is the user's to choose), so there is no customName to
+      // fall back to and enrichment may never supply a username.
+      await DBHelper.ensureUserExist(onionId);
+      final fallback = 'Unknown - ${onionId.substring(0, 6)}';
+      expect((await DBHelper.getUserById(onionId))?['name'], fallback);
+
+      final service = ContactAddService.forTesting(
+        fetchPublic: (_) async => peerIdentityJson,
+        fetchProfile: (_) async => '{}',
+      );
+
+      final added = await service.addContact(
+        onionId: onionId,
+        displayName: '',
+      );
+
+      expect(added, isTrue);
+      final row = await DBHelper.getUserById(onionId);
+      expect(row?['name'], fallback);
+      expect(row?['customName'], isNull);
+    });
+
     test('returns false when the fetched identity JSON is malformed',
         () async {
       final service = ContactAddService.forTesting(

--- a/test/group_control_auth_test.dart
+++ b/test/group_control_auth_test.dart
@@ -11,6 +11,7 @@ import 'package:prysm/crypto/wire.dart';
 import 'package:prysm/database/messages.dart';
 import 'package:prysm/services/group_service.dart';
 import 'package:prysm/util/db_helper.dart';
+import 'package:prysm/util/group_pending_invite_store.dart';
 import 'package:prysm/util/group_sender_index_store.dart';
 import 'package:prysm/util/key_manager.dart';
 import 'package:prysm/util/tor_runtime_gate.dart';
@@ -86,6 +87,7 @@ Future<Database> _openTestDb() async {
           )
         ''');
         await GroupSenderIndexStore.ensureTable(db);
+        await GroupPendingInviteStore.ensureTable(db);
         await RatchetSessionStore.ensureTable(db);
       },
     ),

--- a/test/group_invite_mode_screens_test.dart
+++ b/test/group_invite_mode_screens_test.dart
@@ -20,6 +20,7 @@ import 'package:prysm/models/group_invite_mode.dart';
 import 'package:prysm/screens/privacy_settings_screen.dart';
 import 'package:prysm/theme/prysm_style_resolver.dart';
 import 'package:prysm/theme/prysm_style_scope.dart';
+import 'package:prysm/util/key_manager.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
 Widget wrapWithStyle(Widget child) {
@@ -38,7 +39,9 @@ void main() {
     SharedPreferences.setMockInitialValues({});
 
     await tester.pumpWidget(
-      wrapWithStyle(PrivacySettingsScreen(onClose: () {})),
+      wrapWithStyle(
+        PrivacySettingsScreen(onClose: () {}, keyManager: KeyManager()),
+      ),
     );
     await tester.pumpAndSettle();
 
@@ -52,6 +55,27 @@ void main() {
         find.text(mode.description),
         findsOneWidget,
         reason: 'the ${mode.name} row must say what it implies',
+      );
+    }
+  });
+
+  testWidgets('a panic session cannot reach the invite mode rows',
+      (tester) async {
+    SharedPreferences.setMockInitialValues({});
+
+    // The home screen passes keyManager: null in decoy mode, so the rows
+    // must not exist: a panic session must not change the real policy.
+    await tester.pumpWidget(
+      wrapWithStyle(PrivacySettingsScreen(onClose: () {})),
+    );
+    await tester.pumpAndSettle();
+
+    for (final mode in GroupInviteMode.values) {
+      expect(
+        find.text(mode.label),
+        findsNothing,
+        reason: 'the ${mode.name} row must not be offered without a key '
+            'manager',
       );
     }
   });

--- a/test/group_invite_mode_screens_test.dart
+++ b/test/group_invite_mode_screens_test.dart
@@ -1,0 +1,58 @@
+// Widget test for the group-invite-mode setting UI.
+// Style follows view_once_image_screen_test.dart (hand-resolved
+// PrysmStyleScope, no app bootstrap).
+//
+// It defends a requirement, not an implementation detail: the privacy
+// screen must state what BOTH modes imply before the user picks one — the
+// whole reason the setting is two radio rows with descriptions instead of a
+// switch or a bottom sheet. A tidy-up that drops the subtitles would
+// silently remove the informed part of an informed choice.
+//
+// The requests screen is NOT covered here on purpose. Its first frame is a
+// PrysmProgressIndicator and its content arrives from a real sqflite read in
+// initState; under testWidgets' fake-async zone that future never completes,
+// so any assertion on the list would hang rather than fail. It is verified
+// on the running desktop app instead.
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:prysm/models/appearance_settings.dart';
+import 'package:prysm/models/group_invite_mode.dart';
+import 'package:prysm/screens/privacy_settings_screen.dart';
+import 'package:prysm/theme/prysm_style_resolver.dart';
+import 'package:prysm/theme/prysm_style_scope.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+Widget wrapWithStyle(Widget child) {
+  final style = PrysmStyleResolver.resolve(
+    themePalette: 0,
+    appearance: const AppearanceSettings(),
+  );
+  return PrysmStyleScope(
+    style: style,
+    child: MaterialApp(home: child),
+  );
+}
+
+void main() {
+  testWidgets('the privacy screen explains both invite modes', (tester) async {
+    SharedPreferences.setMockInitialValues({});
+
+    await tester.pumpWidget(
+      wrapWithStyle(PrivacySettingsScreen(onClose: () {})),
+    );
+    await tester.pumpAndSettle();
+
+    for (final mode in GroupInviteMode.values) {
+      expect(
+        find.text(mode.label),
+        findsOneWidget,
+        reason: 'the ${mode.name} row must be offered',
+      );
+      expect(
+        find.text(mode.description),
+        findsOneWidget,
+        reason: 'the ${mode.name} row must say what it implies',
+      );
+    }
+  });
+}

--- a/test/security/group_invite_mode_test.dart
+++ b/test/security/group_invite_mode_test.dart
@@ -1,0 +1,430 @@
+// Task 3 (group invite mode): the single ingress change of the
+// pending-invite flow.
+//
+// `GroupService.handleIncomingControlMessage` drops control messages from
+// senders whose identity is not in the local user store (M2: never resolve
+// the sender over the network on inbound traffic). The GroupInviteMode
+// setting chooses what happens to a *group_invite* at that drop:
+// contactsOnly drops it with nothing stored; holdAsRequest keeps exactly
+// one opaque, still-encrypted `control-wrap-2` envelope per sender in
+// GroupPendingInviteStore — never decrypted, never parsed, and never a
+// reason to fetch anything.
+//
+// The fake HTTP layer is the same one the POLICY tests use: it serves the
+// registered peer profiles, so a restored network identity-resolve would
+// succeed (and these tests go red) instead of failing silently. It is inert
+// while the DB-only resolve holds.
+import 'dart:async';
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:prysm/constants/group_constants.dart';
+import 'package:prysm/crypto/crypto.dart';
+import 'package:prysm/database/conversation_preferences_db.dart';
+import 'package:prysm/database/message_schema_migrations.dart';
+import 'package:prysm/database/messages.dart';
+import 'package:prysm/models/group_invite_mode.dart';
+import 'package:prysm/server/inbound_message_router.dart';
+import 'package:prysm/services/settings_service.dart';
+import 'package:prysm/util/db_helper.dart';
+import 'package:prysm/util/group_pending_invite_store.dart';
+import 'package:prysm/util/group_sender_index_store.dart';
+import 'package:prysm/util/key_manager.dart';
+import 'package:prysm/util/tor_runtime_gate.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:sqflite_common_ffi/sqflite_ffi.dart';
+
+Future<Database> _openMessagesDb() async {
+  return databaseFactory.openDatabase(
+    '${inMemoryDatabasePath}_${DateTime.now().microsecondsSinceEpoch}',
+    options: OpenDatabaseOptions(
+      version: MessageSchemaMigrations.dbVersion,
+      onCreate: MessageSchemaMigrations.onCreate,
+    ),
+  );
+}
+
+Future<Database> _openDbHelperDb() async {
+  final db = await databaseFactory.openDatabase(
+    '${inMemoryDatabasePath}_${DateTime.now().microsecondsSinceEpoch}',
+    options: OpenDatabaseOptions(
+      version: 1,
+      onCreate: (db, _) async {
+        await db.execute('''
+          CREATE TABLE users (
+            id TEXT PRIMARY KEY,
+            name TEXT,
+            avatarUrl TEXT,
+            avatarBase64 TEXT,
+            customName TEXT,
+            publicKeyPem TEXT,
+            identityJson TEXT
+          )
+        ''');
+        await db.execute('''
+          CREATE TABLE group_members (
+            groupId TEXT NOT NULL,
+            memberId TEXT NOT NULL,
+            role TEXT NOT NULL,
+            joinedAt INTEGER NOT NULL,
+            PRIMARY KEY (groupId, memberId)
+          )
+        ''');
+        await db.execute('''
+          CREATE TABLE groups (
+            id TEXT PRIMARY KEY,
+            name TEXT NOT NULL,
+            avatarBase64 TEXT,
+            createdBy TEXT NOT NULL,
+            createdAt INTEGER NOT NULL
+          )
+        ''');
+        await db.execute('''
+          CREATE TABLE group_keys (
+            groupId TEXT PRIMARY KEY,
+            encryptedKey TEXT NOT NULL,
+            keyVersion INTEGER NOT NULL DEFAULT 1
+          )
+        ''');
+        await ConversationPreferencesDb.createTable(db);
+      },
+    ),
+  );
+  await GroupSenderIndexStore.ensureTable(db);
+  await GroupPendingInviteStore.ensureTable(db);
+  return db;
+}
+
+/// Serves the peer profiles registered by the tests over fake HTTP.
+///
+/// The flutter_test binding replaces all outbound HTTP with an instant
+/// empty 400. That would make a restored network identity-resolve (the
+/// behavior the tests below forbid) fail silently and the tests would stay
+/// green. This fake stands in for the Tor network instead: it serves the
+/// registered profiles keyed by onion, so the tests only pass when the code
+/// under test never performs that fetch. It is inert while the policy
+/// holds — the DB-only resolve does no HTTP at all.
+class _ProfileNetworkOverrides extends HttpOverrides {
+  final Map<String, String> profilesByOnion;
+
+  _ProfileNetworkOverrides(this.profilesByOnion);
+
+  @override
+  HttpClient createHttpClient(SecurityContext? context) =>
+      _FakeHttpClient(profilesByOnion);
+}
+
+class _FakeHttpClient implements HttpClient {
+  final Map<String, String> profilesByOnion;
+
+  _FakeHttpClient(this.profilesByOnion);
+
+  @override
+  Future<HttpClientRequest> getUrl(Uri url) async =>
+      _FakeHttpClientRequest(profilesByOnion, url);
+
+  @override
+  Future<void> close({bool force = false}) async {}
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => null;
+}
+
+class _FakeHttpClientRequest implements HttpClientRequest {
+  final Map<String, String> profilesByOnion;
+  final Uri url;
+
+  _FakeHttpClientRequest(this.profilesByOnion, this.url);
+
+  @override
+  final HttpHeaders headers = _FakeHttpHeaders();
+
+  @override
+  Future<HttpClientResponse> close() async =>
+      _FakeHttpClientResponse(profilesByOnion, url);
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => null;
+}
+
+class _FakeHttpHeaders implements HttpHeaders {
+  @override
+  void set(String name, Object value, {bool preserveHeaderCase = false}) {}
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => null;
+}
+
+class _FakeHttpClientResponse implements HttpClientResponse {
+  final Map<String, String> profilesByOnion;
+  final Uri url;
+
+  _FakeHttpClientResponse(this.profilesByOnion, this.url);
+
+  String? get _body => profilesByOnion[url.host];
+
+  @override
+  int get statusCode => _body == null ? 400 : 200;
+
+  @override
+  int get contentLength => _body?.length ?? 0;
+
+  @override
+  Stream<S> transform<S>(StreamTransformer<List<int>, S> transformer) =>
+      Stream<List<int>>.fromIterable([utf8.encode(_body ?? '')])
+          .transform(transformer);
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => null;
+}
+
+/// Builds a `control-wrap-2` group invite exactly as a legitimate inviter
+/// sends it (`GroupControlChannel.sendInvite`): the fresh group key
+/// encrypted for the local user, the whole payload signed by the inviter.
+Future<Map<String, dynamic>> _inviteMessage({
+  required String id,
+  required String inviterId,
+  required IdentityKeyPair inviter,
+  required IdentityKeyPair recipient,
+  required String groupId,
+}) async {
+  final recipientAgreePublic = await recipient.agreePublicKey;
+  final groupKey = GroupCryptoV2.generateGroupKey();
+  final encryptedGroupKey = await GroupCryptoV2.encryptGroupKeyForStorage(
+    groupKey,
+    inviter,
+    peerAgreePublic: recipientAgreePublic,
+  );
+  final wire = await GroupCryptoV2.encryptControlPayload(
+    jsonEncode({
+      'groupId': groupId,
+      'name': 'Invited Group',
+      'createdBy': inviterId,
+      'members': [
+        {'id': 'local.onion', 'role': 'member'},
+        {'id': inviterId, 'role': 'admin'},
+      ],
+      'encryptedGroupKey': encryptedGroupKey,
+      'keyVersion': 1,
+    }),
+    inviter,
+    recipientAgreePublic,
+  );
+  return {
+    'id': id,
+    'senderId': inviterId,
+    'receiverId': 'local.onion',
+    'message': wire,
+    'type': groupInviteType,
+    'timestamp': 1000,
+  };
+}
+
+void main() {
+  late Database messagesDb;
+  late Database dbHelperDb;
+  late InboundMessageRouter router;
+  late IdentityKeyPair localIdentity;
+  late Map<String, IdentityPublicKeys> peers;
+  late List<String> fetched;
+
+  // Profiles the fake network serves, keyed by onion — populated by the
+  // tests so a restored network identity-resolve would succeed (and the
+  // tests go red) instead of failing silently.
+  final peerProfiles = <String, String>{};
+  late HttpOverrides? originalOverrides;
+
+  setUpAll(() {
+    TestWidgetsFlutterBinding.ensureInitialized();
+    sqfliteFfiInit();
+    databaseFactory = databaseFactoryFfi;
+    originalOverrides = HttpOverrides.current;
+    HttpOverrides.global = _ProfileNetworkOverrides(peerProfiles);
+  });
+
+  tearDownAll(() {
+    HttpOverrides.global = originalOverrides;
+  });
+
+  setUp(() async {
+    // The Tor runtime gate starts `stopped`, which would silently block any
+    // (forbidden) network identity-resolve — and mask a restored one. Ready
+    // keeps the tests honest: only the DB-only gate may drop.
+    TorRuntimeGate.resetForTest();
+    localIdentity = await IdentityKeyPair.generate();
+    peers = {};
+
+    messagesDb = await _openMessagesDb();
+    MessagesDb.setDatabaseForTest(messagesDb);
+
+    dbHelperDb = await _openDbHelperDb();
+    DBHelper.setDatabaseForTest(dbHelperDb);
+
+    fetched = [];
+    router = InboundMessageRouter(
+      keyManager: KeyManager.fromIdentity(localIdentity),
+      settings: SettingsService(),
+      localOnionAddress: () => 'local.onion',
+      fetchSenderProfile: (senderId) => fetched.add(senderId),
+      resolvePeerIdentity: (senderId) async => peers[senderId],
+    );
+  });
+
+  tearDown(() async {
+    // Claim ownership is process-global: a claim left by one case would
+    // refuse the same triple in the next, so it must be cleared between
+    // cases.
+    GroupSenderIndexStore.resetForTest();
+    await messagesDb.close();
+    MessagesDb.setDatabaseForTest(null);
+
+    await dbHelperDb.close();
+    DBHelper.setDatabaseForTest(null);
+  });
+
+  group('group invite mode', () {
+    setUp(() {
+      SharedPreferences.setMockInitialValues({});
+      // Profiles registered by the tests are keyed by onion, so a profile
+      // left behind by an earlier case would be served for a different
+      // identity later. Each case starts clean.
+      peerProfiles.clear();
+    });
+
+    tearDown(() async {
+      await SettingsService().setGroupInviteMode(GroupInviteMode.holdAsRequest);
+    });
+
+    test(
+      'contactsOnly: an invite from an unresolvable sender is dropped and '
+      'nothing is stored', () async {
+        await SettingsService().setGroupInviteMode(
+          GroupInviteMode.contactsOnly,
+        );
+        final inviter = await IdentityKeyPair.generate();
+        peerProfiles['stranger.onion'] =
+            jsonEncode(await inviter.toPublicJson());
+
+        final result = await router.handleMessage(await _inviteMessage(
+          id: 'm1',
+          inviterId: 'stranger.onion',
+          inviter: inviter,
+          recipient: localIdentity,
+          groupId: 'g1',
+        ));
+
+        expect(result.statusCode, 200);
+        expect(await GroupPendingInviteStore.count(), 0);
+        expect(await dbHelperDb.query('groups'), isEmpty);
+        expect(fetched, isEmpty);
+      },
+    );
+
+    test(
+      'holdAsRequest: the same invite is held exactly once, and still creates '
+      'no group and no fetch', () async {
+        final inviter = await IdentityKeyPair.generate();
+        peerProfiles['stranger.onion'] =
+            jsonEncode(await inviter.toPublicJson());
+        final invite = await _inviteMessage(
+          id: 'm1',
+          inviterId: 'stranger.onion',
+          inviter: inviter,
+          recipient: localIdentity,
+          groupId: 'g1',
+        );
+
+        final result = await router.handleMessage(invite);
+        // A retry of the same envelope must not create a second row.
+        await router.handleMessage({...invite, 'id': 'm2'});
+
+        expect(result.statusCode, 200);
+        final rows = await GroupPendingInviteStore.pending();
+        expect(rows, hasLength(1));
+        expect(rows.single['senderId'], 'stranger.onion');
+        expect(rows.single['wire'], invite['message']);
+        expect(await dbHelperDb.query('groups'), isEmpty);
+        expect(await dbHelperDb.query('group_members'), isEmpty);
+        expect(await dbHelperDb.query('group_keys'), isEmpty);
+        expect(fetched, isEmpty);
+      },
+    );
+
+    test(
+      'holdAsRequest: a failing pending-invite store degrades to the plain '
+      'drop — the sender sees the same 200 as a drop', () async {
+        await SettingsService().setGroupInviteMode(
+          GroupInviteMode.holdAsRequest,
+        );
+        final inviter = await IdentityKeyPair.generate();
+        peerProfiles['stranger.onion'] =
+            jsonEncode(await inviter.toPublicJson());
+
+        // Point the DB helper at a database that has no
+        // group_pending_invites table — the real failure mode of a stale or
+        // partial database — so hold() throws instead of writing. The
+        // ingress must not turn that into a 500 the sender can observe: it
+        // degrades to the drop.
+        final brokenDb = await databaseFactory.openDatabase(
+          '${inMemoryDatabasePath}_${DateTime.now().microsecondsSinceEpoch}',
+          options: OpenDatabaseOptions(
+            version: 1,
+            onCreate: (db, _) async {
+              await db.execute('''
+                CREATE TABLE users (
+                  id TEXT PRIMARY KEY,
+                  name TEXT,
+                  avatarUrl TEXT,
+                  avatarBase64 TEXT,
+                  customName TEXT,
+                  publicKeyPem TEXT,
+                  identityJson TEXT
+                )
+              ''');
+            },
+          ),
+        );
+        DBHelper.setDatabaseForTest(brokenDb);
+
+        final result = await router.handleMessage(await _inviteMessage(
+          id: 'm1',
+          inviterId: 'stranger.onion',
+          inviter: inviter,
+          recipient: localIdentity,
+          groupId: 'g1',
+        ));
+
+        expect(result.statusCode, 200);
+        // The exact ok-ack the plain drop answers with: status received and
+        // no error key (the unguarded failure used to surface as a 500
+        // {'error': ...} body instead).
+        expect(result.jsonBody, containsPair('status', 'received'));
+        expect(result.jsonBody, isNot(containsPair('error', anything)));
+        await brokenDb.close();
+      },
+    );
+
+    test(
+      'holdAsRequest holds invites only: a key rotate from an unresolvable '
+      'sender is dropped and stored nowhere', () async {
+        final stranger = await IdentityKeyPair.generate();
+        final result = await router.handleMessage({
+          'id': 'm1',
+          'senderId': 'stranger.onion',
+          'receiverId': 'local.onion',
+          'message': await GroupCryptoV2.encryptControlPayload(
+            jsonEncode({'groupId': 'g1', 'keyVersion': 2}),
+            stranger,
+            await localIdentity.agreePublicKey,
+          ),
+          'type': groupKeyRotateType,
+          'timestamp': 1000,
+        });
+
+        expect(result.statusCode, 200);
+        expect(await GroupPendingInviteStore.count(), 0);
+      },
+    );
+  });
+}

--- a/test/security/group_invite_mode_test.dart
+++ b/test/security/group_invite_mode_test.dart
@@ -434,6 +434,17 @@ void main() {
       },
     );
 
+    test('clear empties a populated store', () async {
+      await GroupPendingInviteStore.hold(senderId: 'a.onion', wire: 'wire-a');
+      await GroupPendingInviteStore.hold(senderId: 'b.onion', wire: 'wire-b');
+      expect(await GroupPendingInviteStore.count(), 2);
+
+      await GroupPendingInviteStore.clear();
+
+      expect(await GroupPendingInviteStore.count(), 0);
+      expect(await GroupPendingInviteStore.pending(), isEmpty);
+    });
+
     group('promotion', () {
       test(
         'once the inviter identity is stored, the held invite applies and '
@@ -531,6 +542,44 @@ void main() {
         final rows = await GroupPendingInviteStore.pending();
         expect(rows.single['senderId'], 'unknown.onion');
       });
+
+      test(
+        'contactsOnly: the sweep promotes nothing even with a resolvable '
+        'held sender', () async {
+          final inviter = await IdentityKeyPair.generate();
+          final invite = await _inviteMessage(
+            id: 'm1',
+            inviterId: 'stranger.onion',
+            inviter: inviter,
+            recipient: localIdentity,
+            groupId: 'g1',
+          );
+          await router.handleMessage(invite);
+          // The invite was held while the mode was the default; the switch
+          // to contactsOnly must stop the sweep from applying it even
+          // though the sender has meanwhile become resolvable.
+          expect(await GroupPendingInviteStore.count(), 1);
+          await SettingsService().setGroupInviteMode(
+            GroupInviteMode.contactsOnly,
+          );
+          final json = jsonEncode(await inviter.toPublicJson());
+          await DBHelper.insertOrUpdateUser({
+            'id': 'stranger.onion',
+            'name': 'Stranger',
+            'identityJson': json,
+            'publicKeyPem': json,
+          });
+
+          final promoted = await GroupInvitePromoter(
+            userId: 'local.onion',
+            keyManager: KeyManager.fromIdentity(localIdentity),
+          ).promoteResolvable();
+
+          expect(promoted, 0);
+          expect(await GroupPendingInviteStore.count(), 1);
+          expect(await dbHelperDb.query('groups'), isEmpty);
+        },
+      );
     });
   });
 }

--- a/test/security/group_invite_mode_test.dart
+++ b/test/security/group_invite_mode_test.dart
@@ -14,6 +14,12 @@
 // registered peer profiles, so a restored network identity-resolve would
 // succeed (and these tests go red) instead of failing silently. It is inert
 // while the DB-only resolve holds.
+//
+// Task 4 (group invite mode): promotion. Once the sender's identity is in
+// the local user store, the held envelope is replayed through the
+// authenticated path (`GroupInvitePromoter` -> `handleIncomingControlMessage`)
+// — never decrypted while pending, never resolved over the network, and the
+// row is gone whether the replay authenticates or not.
 import 'dart:async';
 import 'dart:convert';
 import 'dart:io';
@@ -26,6 +32,7 @@ import 'package:prysm/database/message_schema_migrations.dart';
 import 'package:prysm/database/messages.dart';
 import 'package:prysm/models/group_invite_mode.dart';
 import 'package:prysm/server/inbound_message_router.dart';
+import 'package:prysm/services/group_invite_promoter.dart';
 import 'package:prysm/services/settings_service.dart';
 import 'package:prysm/util/db_helper.dart';
 import 'package:prysm/util/group_pending_invite_store.dart';
@@ -426,5 +433,104 @@ void main() {
         expect(await GroupPendingInviteStore.count(), 0);
       },
     );
+
+    group('promotion', () {
+      test(
+        'once the inviter identity is stored, the held invite applies and '
+        'the row is gone', () async {
+          final inviter = await IdentityKeyPair.generate();
+          final invite = await _inviteMessage(
+            id: 'm1',
+            inviterId: 'stranger.onion',
+            inviter: inviter,
+            recipient: localIdentity,
+            groupId: 'g1',
+          );
+          await router.handleMessage(invite);
+          expect(await GroupPendingInviteStore.count(), 1);
+
+          // What "the user added the contact" leaves behind.
+          final json = jsonEncode(await inviter.toPublicJson());
+          await DBHelper.insertOrUpdateUser({
+            'id': 'stranger.onion',
+            'name': 'Stranger',
+            'identityJson': json,
+            'publicKeyPem': json,
+          });
+
+          final promoter = GroupInvitePromoter(
+            userId: 'local.onion',
+            keyManager: KeyManager.fromIdentity(localIdentity),
+          );
+          expect(await promoter.promote('stranger.onion'), isTrue);
+
+          expect(await GroupPendingInviteStore.count(), 0);
+          expect((await dbHelperDb.query('groups')).single['id'], 'g1');
+          expect(await dbHelperDb.query('group_members'), hasLength(2));
+        },
+      );
+
+      test('a tampered held envelope is discarded and creates no group',
+          () async {
+        final inviter = await IdentityKeyPair.generate();
+        final json = jsonEncode(await inviter.toPublicJson());
+        await DBHelper.insertOrUpdateUser({
+          'id': 'stranger.onion',
+          'name': 'Stranger',
+          'identityJson': json,
+          'publicKeyPem': json,
+        });
+        await GroupPendingInviteStore.hold(
+          senderId: 'stranger.onion',
+          wire: 'not-a-control-envelope',
+        );
+
+        final promoter = GroupInvitePromoter(
+          userId: 'local.onion',
+          keyManager: KeyManager.fromIdentity(localIdentity),
+        );
+        expect(await promoter.promote('stranger.onion'), isFalse);
+
+        expect(await GroupPendingInviteStore.count(), 0);
+        expect(await dbHelperDb.query('groups'), isEmpty);
+      });
+
+      test('the sweep promotes only the senders that became resolvable',
+          () async {
+        final known = await IdentityKeyPair.generate();
+        final unknown = await IdentityKeyPair.generate();
+        await router.handleMessage(await _inviteMessage(
+          id: 'm1',
+          inviterId: 'known.onion',
+          inviter: known,
+          recipient: localIdentity,
+          groupId: 'g1',
+        ));
+        await router.handleMessage(await _inviteMessage(
+          id: 'm2',
+          inviterId: 'unknown.onion',
+          inviter: unknown,
+          recipient: localIdentity,
+          groupId: 'g2',
+        ));
+        final json = jsonEncode(await known.toPublicJson());
+        await DBHelper.insertOrUpdateUser({
+          'id': 'known.onion',
+          'name': 'Known',
+          'identityJson': json,
+          'publicKeyPem': json,
+        });
+
+        final promoted = await GroupInvitePromoter(
+          userId: 'local.onion',
+          keyManager: KeyManager.fromIdentity(localIdentity),
+        ).promoteResolvable();
+
+        expect(promoted, 1);
+        expect((await dbHelperDb.query('groups')).single['id'], 'g1');
+        final rows = await GroupPendingInviteStore.pending();
+        expect(rows.single['senderId'], 'unknown.onion');
+      });
+    });
   });
 }

--- a/test/security/group_invite_mode_test.dart
+++ b/test/security/group_invite_mode_test.dart
@@ -580,6 +580,45 @@ void main() {
           expect(await dbHelperDb.query('groups'), isEmpty);
         },
       );
+
+      test(
+        'contactsOnly: a direct promote applies nothing and keeps the row',
+        () async {
+          final inviter = await IdentityKeyPair.generate();
+          await router.handleMessage(await _inviteMessage(
+            id: 'm1',
+            inviterId: 'stranger.onion',
+            inviter: inviter,
+            recipient: localIdentity,
+            groupId: 'g1',
+          ));
+          expect(await GroupPendingInviteStore.count(), 1);
+          final json = jsonEncode(await inviter.toPublicJson());
+          await DBHelper.insertOrUpdateUser({
+            'id': 'stranger.onion',
+            'name': 'Stranger',
+            'identityJson': json,
+            'publicKeyPem': json,
+          });
+          await SettingsService().setGroupInviteMode(
+            GroupInviteMode.contactsOnly,
+          );
+
+          // promote() is what the invite requests screen calls. That screen
+          // can still be sitting on rows it loaded before the mode changed,
+          // so the gate has to hold here and not only in promoteResolvable —
+          // and it must refuse BEFORE take(), or the row is destroyed by the
+          // very call that was not allowed to apply it.
+          final joined = await GroupInvitePromoter(
+            userId: 'local.onion',
+            keyManager: KeyManager.fromIdentity(localIdentity),
+          ).promote('stranger.onion');
+
+          expect(joined, isFalse);
+          expect(await dbHelperDb.query('groups'), isEmpty);
+          expect(await GroupPendingInviteStore.count(), 1);
+        },
+      );
     });
   });
 }

--- a/test/security/group_profile_fetch_gate_test.dart
+++ b/test/security/group_profile_fetch_gate_test.dart
@@ -32,6 +32,7 @@ import 'package:prysm/database/messages.dart';
 import 'package:prysm/server/inbound_message_router.dart';
 import 'package:prysm/services/settings_service.dart';
 import 'package:prysm/util/db_helper.dart';
+import 'package:prysm/util/group_pending_invite_store.dart';
 import 'package:prysm/util/group_sender_index_store.dart';
 import 'package:prysm/util/key_manager.dart';
 import 'package:prysm/util/tor_runtime_gate.dart';
@@ -106,6 +107,7 @@ Future<Database> _openDbHelperDb() async {
     ),
   );
   await GroupSenderIndexStore.ensureTable(db);
+  await GroupPendingInviteStore.ensureTable(db);
   return db;
 }
 


### PR DESCRIPTION
## Why this PR exists

`main` currently has **half** of the group invite mode. #133 landed the data layer, but #134 and #135 merged into their stacked *base branches* instead of into `main`, because those bases were not deleted and GitHub therefore never retargeted them.

Verifiable on `main` right now:

```
lib/models/group_invite_mode.dart          present
lib/util/group_pending_invite_store.dart   present
lib/services/group_invite_promoter.dart    MISSING
lib/screens/invite_requests_screen.dart    MISSING

privacy_settings_screen.dart : 0 occurrences of GroupInviteMode
group_service.dart           : 0 occurrences of GroupPendingInviteStore.hold
```

So `main` has a `chat_app.db` v14 table nothing ever writes and a setting nothing ever reads. This PR lands the remaining two topics and makes the feature whole.

## What is in it

The seven commits already reviewed in #134 and #135, cherry-picked onto `main` in topic order — no merge commits, so the history stays linear and every commit keeps its original author:

| Topic | Commits |
|---|---|
| Service policy (was #134) | hold first-contact invites · promote held invites once the sender becomes known · keep the promoter from applying invites in the strict mode |
| UI (was #135) | mode picker in Privacy Settings · `InviteRequestsScreen` + entry points · discard held invites on switch to strict · refresh the pending-invite counters |

Nothing new: the resulting tree is byte-identical to a straight merge of `invite-mode/policy` into `main`, which is how it was verified.

## The property that decides this feature — do not regress it

This is **not** "reopen the profile fetch". M2 stays closed in **both** modes:

- `_resolveSenderIdentity` remains **DB-only**. No Tor fetch for an unknown sender, on any group control path.
- The held envelope stays encrypted and opaque until the user adds the contact, so the fetch starts from a **user gesture**, never from unauthenticated traffic.
- The two `POLICY:` tests in `test/security/group_profile_fetch_gate_test.dart` are unchanged from #128 — assertions intact. The positive one is load-bearing: without it the negative would pass even if invites were broken outright.

Anyone touching `group_service.dart:500-527` has to preserve this.

## Verification

- `flutter analyze`: 0 issues.
- `flutter test`: **961 passed + 1 skip** (the skip is the L3 harness, gated by `PRYSM_E2E`).
- Tree parity against the merge-based integration checked with `git diff --exit-code`.

## After merging

Delete `invite-mode/data`, `invite-mode/policy` and `invite-mode/ui`. Leaving them is what caused the mis-targeting in the first place.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable group invite modes, including contacts-only and pending request handling.
  * Added an Invite Requests screen to review, accept, or discard invitations from unknown senders.
  * Added pending invite counts and navigation entries on the Home and Settings screens.
  * Automatically processes held invites when invite settings allow it.
* **Bug Fixes**
  * Improved handling of unknown senders and invite storage failures without disrupting normal messaging.
  * Preserved existing contact names when adding contacts with empty display names.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->