### PR TITLE
feat(search): implement full-text search for messages

### DIFF
--- a/lib/app/app_composition.dart
+++ b/lib/app/app_composition.dart
@@ -3,6 +3,7 @@ import 'package:prysm/server/PrysmServer.dart';
 import 'package:prysm/services/block_service.dart';
 import 'package:prysm/services/call/call_manager.dart';
 import 'package:prysm/services/file_transfer_handler.dart';
+import 'package:prysm/services/message_search_backfill_service.dart';
 import 'package:prysm/services/read_receipt_service.dart';
 import 'package:prysm/services/sync_coordinator.dart';
 import 'package:prysm/services/wake_hint_service.dart';
@@ -106,5 +107,16 @@ class AppComposition {
   /// needs to know whether Tor was intentionally stopped.
   static void wireTorRuntimeGate(bool Function() isTorStopped) {
     TorRuntimeGate.isTorStopped = isTorStopped;
+  }
+
+  /// Starts background indexing of historical messages for FTS search.
+  static void startSearchBackfill({
+    required KeyManager keyManager,
+    required String userId,
+  }) {
+    MessageSearchBackfillService(
+      keyManager: keyManager,
+      userId: userId,
+    ).startIfNeeded();
   }
 }

--- a/lib/app/app_composition.dart
+++ b/lib/app/app_composition.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:prysm/crypto/peer_proof.dart';
 import 'package:prysm/server/PrysmServer.dart';
 import 'package:prysm/services/block_service.dart';
@@ -10,6 +12,7 @@ import 'package:prysm/services/wake_hint_service.dart';
 import 'package:prysm/transport/transport_provider.dart';
 import 'package:prysm/util/key_manager.dart';
 import 'package:prysm/util/local_onion_address.dart';
+import 'package:prysm/util/logging.dart';
 import 'package:prysm/util/tor_runtime_gate.dart';
 import 'package:prysm/util/tor_service.dart';
 
@@ -114,9 +117,12 @@ class AppComposition {
     required KeyManager keyManager,
     required String userId,
   }) {
-    MessageSearchBackfillService(
+    final backfill = MessageSearchBackfillService(
       keyManager: keyManager,
       userId: userId,
     ).startIfNeeded();
+    unawaited(backfill.catchError((Object e, StackTrace stack) {
+      Logging.error('Search backfill failed: $e\n$stack', 'SearchBackfill');
+    }));
   }
 }

--- a/lib/database/conversation_queries_dao.dart
+++ b/lib/database/conversation_queries_dao.dart
@@ -1,11 +1,15 @@
 import 'package:prysm/database/message_query_filters.dart';
+import 'package:prysm/database/message_search_dao.dart';
 import 'package:prysm/database/messages_database.dart';
 import 'package:sqflite/sqflite.dart';
 
 /// Direct/group conversation message queries (batched + paginated reads) and
 /// their bulk deletes.
 class ConversationQueriesDao {
-  const ConversationQueriesDao();
+  const ConversationQueriesDao({MessageSearchDao? searchDao})
+      : _searchDao = searchDao ?? const MessageSearchDao();
+
+  final MessageSearchDao _searchDao;
 
   Future<Database> get _database => MessagesDatabase.database;
 
@@ -109,6 +113,8 @@ class ConversationQueriesDao {
             "groupId IS NULL AND ${MessageQueryFilters.directChatTypeFilter} AND ((senderId = ? AND receiverId = ?) OR (senderId = ? AND receiverId = ?) OR (senderId = ? AND receiverId = ? AND status = 'system') OR (senderId = ? AND receiverId = ? AND status = 'system'))",
         whereArgs: [userId, receiverId, receiverId, userId, userId, receiverId, receiverId, userId],
       );
+      await _searchDao.removeForConversationUnprotected(userId, 'direct');
+      await _searchDao.removeForConversationUnprotected(receiverId, 'direct');
     });
   }
 
@@ -155,6 +161,7 @@ class ConversationQueriesDao {
     await _protect(() async {
       final db = await _database;
       await db.delete('messages', where: 'groupId = ?', whereArgs: [groupId]);
+      await _searchDao.removeForConversationUnprotected(groupId, 'group');
     });
   }
 
@@ -168,6 +175,11 @@ class ConversationQueriesDao {
         'messages',
         where: 'groupId = ? AND timestamp < ?',
         whereArgs: [groupId, beforeTimestamp],
+      );
+      await _searchDao.removeForConversationUnprotected(
+        groupId,
+        'group',
+        beforeTimestamp: beforeTimestamp,
       );
     });
   }

--- a/lib/database/message_crud_dao.dart
+++ b/lib/database/message_crud_dao.dart
@@ -46,6 +46,50 @@ class MessageCrudDao {
     return normalized;
   }
 
+  /// Removes a message's FTS row, scoped to its conversation. The caller must
+  /// already hold [MessagesDatabase.mutex]. Pass [row] when the `messages` row
+  /// is about to be (or has already been) deleted; otherwise it is read here.
+  ///
+  /// A direct row's conversationId is the peer, which is one of the two
+  /// participants — both are tried, so the delete is never widened to a bare
+  /// `messageId` match. That matters because the wire id is chosen by the
+  /// sender: an unscoped delete lets a peer wipe search rows of unrelated
+  /// conversations by reusing an id it has seen.
+  Future<void> _removeSearchRow(
+    Database db, {
+    required String storageId,
+    required String wireId,
+    Map<String, Object?>? row,
+  }) async {
+    if (row == null) {
+      final rows = await db.query(
+        'messages',
+        columns: const ['groupId', 'senderId', 'receiverId'],
+        where: 'id = ?',
+        whereArgs: [storageId],
+        limit: 1,
+      );
+      if (rows.isEmpty) return;
+      row = rows.first;
+    }
+    final groupId = row['groupId'] as String?;
+    if (groupId != null) {
+      await _searchDao.removeUnprotected(
+        wireId,
+        conversationId: groupId,
+        scope: 'group',
+      );
+      return;
+    }
+    for (final side in const ['senderId', 'receiverId']) {
+      await _searchDao.removeUnprotected(
+        wireId,
+        conversationId: row[side] as String,
+        scope: 'direct',
+      );
+    }
+  }
+
   /// Mark a view-once message as viewed and wipe its content
   Future<void> markViewOnceViewed(
     String messageId, {
@@ -60,11 +104,7 @@ class MessageCrudDao {
         where: 'id = ? AND viewOnce = 1',
         whereArgs: [storageId],
       );
-      await _searchDao.removeUnprotected(
-        messageId,
-        conversationId: groupId,
-        scope: groupId != null ? 'group' : null,
-      );
+      await _removeSearchRow(db, storageId: storageId, wireId: messageId);
     });
   }
 
@@ -266,11 +306,7 @@ class MessageCrudDao {
         whereArgs: [storageId],
       );
       await MessageBlobStore.delete(storageId);
-      await _searchDao.removeUnprotected(
-        wireId,
-        conversationId: groupId,
-        scope: groupId != null ? 'group' : null,
-      );
+      await _removeSearchRow(db, storageId: storageId, wireId: wireId);
     });
   }
 
@@ -296,6 +332,13 @@ class MessageCrudDao {
   Future<void> deleteMessageById(String id) async {
     await _protect(() async {
       final db = await _database;
+      final rows = await db.query(
+        'messages',
+        columns: const ['groupId', 'senderId', 'receiverId'],
+        where: 'id = ?',
+        whereArgs: [id],
+        limit: 1,
+      );
       await db.transaction((txn) async {
         await txn.update(
           'messages',
@@ -305,6 +348,18 @@ class MessageCrudDao {
         );
         await txn.delete('messages', where: 'id = ?', whereArgs: [id]);
       });
+      if (rows.isEmpty) return;
+      // De-index AFTER the row is gone: a broken search index must not be able
+      // to block a delete. Strip the row's own groupId prefix rather than
+      // re-parsing via the codec — the wire id is sender-chosen and may itself
+      // contain '::'.
+      final groupId = rows.first['groupId'] as String?;
+      await _removeSearchRow(
+        db,
+        storageId: id,
+        wireId: groupId == null ? id : id.substring(groupId.length + 2),
+        row: rows.first,
+      );
     });
   }
 
@@ -321,11 +376,6 @@ class MessageCrudDao {
     );
     await deleteMessageById(storageId);
     await MessageBlobStore.delete(storageId);
-    await _searchDao.remove(
-      wireId,
-      conversationId: groupId,
-      scope: groupId != null ? 'group' : null,
-    );
   }
 
   Future<void> updateMessageStatus(

--- a/lib/database/message_crud_dao.dart
+++ b/lib/database/message_crud_dao.dart
@@ -3,6 +3,7 @@ import 'package:prysm/database/message_query_filters.dart';
 import 'package:prysm/database/message_reactions.dart';
 import 'package:prysm/database/message_read_receipts.dart';
 import 'package:prysm/database/message_schema_migrations.dart';
+import 'package:prysm/database/message_search_dao.dart';
 import 'package:prysm/database/messages_database.dart';
 import 'package:prysm/util/logging.dart';
 import 'package:prysm/util/message_blob_store.dart';
@@ -12,7 +13,10 @@ import 'package:sqflite/sqflite.dart';
 /// including the encrypted wire payload (`getMessageWire`/`getMessageById`
 /// share the blob-store fallback so they stay together).
 class MessageCrudDao {
-  const MessageCrudDao();
+  const MessageCrudDao({MessageSearchDao? searchDao})
+      : _searchDao = searchDao ?? const MessageSearchDao();
+
+  final MessageSearchDao _searchDao;
 
   Future<Database> get _database => MessagesDatabase.database;
 
@@ -56,6 +60,7 @@ class MessageCrudDao {
         where: 'id = ? AND viewOnce = 1',
         whereArgs: [storageId],
       );
+      await _searchDao.remove(messageId);
     });
   }
 
@@ -257,6 +262,7 @@ class MessageCrudDao {
         whereArgs: [storageId],
       );
       await MessageBlobStore.delete(storageId);
+      await _searchDao.remove(wireId);
     });
   }
 
@@ -307,6 +313,7 @@ class MessageCrudDao {
     );
     await deleteMessageById(storageId);
     await MessageBlobStore.delete(storageId);
+    await _searchDao.remove(wireId);
   }
 
   Future<void> updateMessageStatus(

--- a/lib/database/message_crud_dao.dart
+++ b/lib/database/message_crud_dao.dart
@@ -60,7 +60,11 @@ class MessageCrudDao {
         where: 'id = ? AND viewOnce = 1',
         whereArgs: [storageId],
       );
-      await _searchDao.remove(messageId);
+      await _searchDao.removeUnprotected(
+        messageId,
+        conversationId: groupId,
+        scope: groupId != null ? 'group' : null,
+      );
     });
   }
 
@@ -262,7 +266,11 @@ class MessageCrudDao {
         whereArgs: [storageId],
       );
       await MessageBlobStore.delete(storageId);
-      await _searchDao.remove(wireId);
+      await _searchDao.removeUnprotected(
+        wireId,
+        conversationId: groupId,
+        scope: groupId != null ? 'group' : null,
+      );
     });
   }
 
@@ -313,7 +321,11 @@ class MessageCrudDao {
     );
     await deleteMessageById(storageId);
     await MessageBlobStore.delete(storageId);
-    await _searchDao.remove(wireId);
+    await _searchDao.remove(
+      wireId,
+      conversationId: groupId,
+      scope: groupId != null ? 'group' : null,
+    );
   }
 
   Future<void> updateMessageStatus(

--- a/lib/database/message_schema_migrations.dart
+++ b/lib/database/message_schema_migrations.dart
@@ -11,7 +11,7 @@ class MessageSchemaMigrations {
   MessageSchemaMigrations._();
 
   /// Current schema version. Bump alongside a new _upgradeToVN step.
-  static const int dbVersion = 13;
+  static const int dbVersion = 14;
 
   static Future<void> onCreate(Database db, int version) async {
     await _createV2(db);
@@ -33,6 +33,7 @@ class MessageSchemaMigrations {
     if (oldVersion < 10) await _upgradeToV10(db);
     if (oldVersion < 12) await _upgradeToV12(db);
     if (oldVersion < 13) await _upgradeToV13(db);
+    if (oldVersion < 14) await _upgradeToV14(db);
   }
 
   static Future<void> migrateOversizedMessagePayloads(Database db) async {
@@ -132,6 +133,7 @@ class MessageSchemaMigrations {
     await createReadReceiptsTable(db);
     await createSelfMessagesTable(db);
     await createScheduledMessagesTable(db);
+    await createMessageSearchFtsTable(db);
   }
 
   /// CHANGES: added readAt timestamp
@@ -254,6 +256,25 @@ class MessageSchemaMigrations {
       'CREATE INDEX IF NOT EXISTS idx_messages_expires_at '
       'ON messages(expiresAt) WHERE expiresAt IS NOT NULL AND deletedAt IS NULL',
     );
+  }
+
+  static Future<void> _upgradeToV14(Database db) async {
+    Logging.info('UPGRADING DB TO v14', 'MessagesDb');
+    await createMessageSearchFtsTable(db);
+  }
+
+  /// Plaintext FTS5 index for local message search (protected by SQLCipher).
+  static Future<void> createMessageSearchFtsTable(Database db) async {
+    await db.execute('''
+      CREATE VIRTUAL TABLE IF NOT EXISTS message_search_fts USING fts5(
+        messageId UNINDEXED,
+        conversationId UNINDEXED,
+        scope UNINDEXED,
+        timestamp UNINDEXED,
+        body,
+        tokenize = 'unicode61 remove_diacritics 2'
+      )
+    ''');
   }
 
   /// Owns message_reactions' schema; MessageReactionsDb.createTable delegates here.

--- a/lib/database/message_search_dao.dart
+++ b/lib/database/message_search_dao.dart
@@ -37,16 +37,16 @@ class MessageSearchDao {
     required int timestamp,
     required String body,
   }) async {
-    final trimmed = body.trim();
-    if (trimmed.isEmpty) return;
-
     await _protect(() async {
       final db = await _database;
-      await db.delete(
-        'message_search_fts',
-        where: 'messageId = ?',
-        whereArgs: [messageId],
+      await _deleteRow(
+        db,
+        messageId,
+        conversationId: conversationId,
+        scope: scope,
       );
+      final trimmed = body.trim();
+      if (trimmed.isEmpty) return;
       await db.insert('message_search_fts', {
         'messageId': messageId,
         'conversationId': conversationId,
@@ -57,15 +57,53 @@ class MessageSearchDao {
     });
   }
 
-  Future<void> remove(String messageId) async {
-    await _protect(() async {
-      final db = await _database;
-      await db.delete(
-        'message_search_fts',
-        where: 'messageId = ?',
-        whereArgs: [messageId],
+  Future<void> remove(
+    String messageId, {
+    String? conversationId,
+    String? scope,
+  }) =>
+      _protect(
+        () => removeUnprotected(
+          messageId,
+          conversationId: conversationId,
+          scope: scope,
+        ),
       );
-    });
+
+  /// Lock-free search-row deletion: the caller must already hold
+  /// [MessagesDatabase.mutex] (via [_protect]) before invoking this.
+  Future<void> removeUnprotected(
+    String messageId, {
+    String? conversationId,
+    String? scope,
+  }) async {
+    final db = await _database;
+    await _deleteRow(
+      db,
+      messageId,
+      conversationId: conversationId,
+      scope: scope,
+    );
+  }
+
+  Future<void> _deleteRow(
+    Database db,
+    String messageId, {
+    String? conversationId,
+    String? scope,
+  }) {
+    if (conversationId != null && scope != null) {
+      return db.delete(
+        'message_search_fts',
+        where: 'messageId = ? AND conversationId = ? AND scope = ?',
+        whereArgs: [messageId, conversationId, scope],
+      );
+    }
+    return db.delete(
+      'message_search_fts',
+      where: 'messageId = ?',
+      whereArgs: [messageId],
+    );
   }
 
   Future<bool> exists(String messageId) async {

--- a/lib/database/message_search_dao.dart
+++ b/lib/database/message_search_dao.dart
@@ -1,0 +1,139 @@
+import 'package:prysm/database/messages_database.dart';
+import 'package:prysm/models/message_search_hit.dart';
+import 'package:sqflite/sqflite.dart';
+
+/// FTS5-backed local message search index.
+class MessageSearchDao {
+  const MessageSearchDao();
+
+  Future<Database> get _database => MessagesDatabase.database;
+
+  Future<T> _protect<T>(Future<T> Function() action) =>
+      MessagesDatabase.mutex.protect(action);
+
+  /// Escapes user input and builds a prefix FTS5 query.
+  static String escapeFtsQuery(String userInput) {
+    final tokens = userInput
+        .trim()
+        .split(RegExp(r'\s+'))
+        .where((t) => t.isNotEmpty)
+        .map(_escapeFtsToken)
+        .where((t) => t.isNotEmpty)
+        .toList();
+    if (tokens.isEmpty) return '';
+    return tokens.map((t) => '$t*').join(' OR ');
+  }
+
+  static String _escapeFtsToken(String token) {
+    final cleaned = token.replaceAll(RegExp(r'["*():^]'), ' ').trim();
+    if (cleaned.isEmpty) return '';
+    return '"$cleaned"';
+  }
+
+  Future<void> upsert({
+    required String messageId,
+    required String conversationId,
+    required String scope,
+    required int timestamp,
+    required String body,
+  }) async {
+    final trimmed = body.trim();
+    if (trimmed.isEmpty) return;
+
+    await _protect(() async {
+      final db = await _database;
+      await db.delete(
+        'message_search_fts',
+        where: 'messageId = ?',
+        whereArgs: [messageId],
+      );
+      await db.insert('message_search_fts', {
+        'messageId': messageId,
+        'conversationId': conversationId,
+        'scope': scope,
+        'timestamp': timestamp,
+        'body': trimmed,
+      });
+    });
+  }
+
+  Future<void> remove(String messageId) async {
+    await _protect(() async {
+      final db = await _database;
+      await db.delete(
+        'message_search_fts',
+        where: 'messageId = ?',
+        whereArgs: [messageId],
+      );
+    });
+  }
+
+  Future<bool> exists(String messageId) async {
+    return _protect(() async {
+      final db = await _database;
+      final rows = await db.query(
+        'message_search_fts',
+        columns: const ['messageId'],
+        where: 'messageId = ?',
+        whereArgs: [messageId],
+        limit: 1,
+      );
+      return rows.isNotEmpty;
+    });
+  }
+
+  Future<List<MessageSearchHit>> searchGlobal(
+    String query, {
+    int limit = 30,
+  }) async {
+    final ftsQuery = escapeFtsQuery(query);
+    if (ftsQuery.isEmpty) return const [];
+
+    return _protect(() async {
+      final db = await _database;
+      final rows = await db.rawQuery(
+        '''
+        SELECT messageId, conversationId, scope, timestamp, body
+        FROM message_search_fts
+        WHERE message_search_fts MATCH ?
+        ORDER BY timestamp DESC
+        LIMIT ?
+        ''',
+        [ftsQuery, limit],
+      );
+      return rows.map(_rowToHit).toList();
+    });
+  }
+
+  Future<List<MessageSearchHit>> searchInConversation(
+    String conversationId,
+    String query, {
+    int limit = 50,
+  }) async {
+    final ftsQuery = escapeFtsQuery(query);
+    if (ftsQuery.isEmpty) return const [];
+
+    return _protect(() async {
+      final db = await _database;
+      final rows = await db.rawQuery(
+        '''
+        SELECT messageId, conversationId, scope, timestamp, body
+        FROM message_search_fts
+        WHERE conversationId = ? AND message_search_fts MATCH ?
+        ORDER BY timestamp ASC
+        LIMIT ?
+        ''',
+        [conversationId, ftsQuery, limit],
+      );
+      return rows.map(_rowToHit).toList();
+    });
+  }
+
+  MessageSearchHit _rowToHit(Map<String, Object?> row) => MessageSearchHit(
+        messageId: row['messageId'] as String,
+        conversationId: row['conversationId'] as String,
+        scope: row['scope'] as String,
+        timestamp: row['timestamp'] as int,
+        body: row['body'] as String,
+      );
+}

--- a/lib/database/message_search_dao.dart
+++ b/lib/database/message_search_dao.dart
@@ -59,8 +59,8 @@ class MessageSearchDao {
 
   Future<void> remove(
     String messageId, {
-    String? conversationId,
-    String? scope,
+    required String conversationId,
+    required String scope,
   }) =>
       _protect(
         () => removeUnprotected(
@@ -74,8 +74,8 @@ class MessageSearchDao {
   /// [MessagesDatabase.mutex] (via [_protect]) before invoking this.
   Future<void> removeUnprotected(
     String messageId, {
-    String? conversationId,
-    String? scope,
+    required String conversationId,
+    required String scope,
   }) async {
     final db = await _database;
     await _deleteRow(
@@ -89,20 +89,32 @@ class MessageSearchDao {
   Future<void> _deleteRow(
     Database db,
     String messageId, {
-    String? conversationId,
-    String? scope,
+    required String conversationId,
+    required String scope,
   }) {
-    if (conversationId != null && scope != null) {
-      return db.delete(
-        'message_search_fts',
-        where: 'messageId = ? AND conversationId = ? AND scope = ?',
-        whereArgs: [messageId, conversationId, scope],
-      );
-    }
     return db.delete(
       'message_search_fts',
-      where: 'messageId = ?',
-      whereArgs: [messageId],
+      where: 'messageId = ? AND conversationId = ? AND scope = ?',
+      whereArgs: [messageId, conversationId, scope],
+    );
+  }
+
+  /// Lock-free conversation-scoped search-row deletion: the caller must
+  /// already hold [MessagesDatabase.mutex] (via [_protect]) before invoking.
+  Future<void> removeForConversationUnprotected(
+    String conversationId,
+    String scope, {
+    int? beforeTimestamp,
+  }) async {
+    final db = await _database;
+    await db.delete(
+      'message_search_fts',
+      where: beforeTimestamp != null
+          ? 'conversationId = ? AND scope = ? AND timestamp < ?'
+          : 'conversationId = ? AND scope = ?',
+      whereArgs: beforeTimestamp != null
+          ? [conversationId, scope, beforeTimestamp]
+          : [conversationId, scope],
     );
   }
 

--- a/lib/database/message_search_dao.dart
+++ b/lib/database/message_search_dao.dart
@@ -106,14 +106,18 @@ class MessageSearchDao {
     );
   }
 
-  Future<bool> exists(String messageId) async {
+  Future<bool> exists({
+    required String messageId,
+    required String conversationId,
+    required String scope,
+  }) async {
     return _protect(() async {
       final db = await _database;
       final rows = await db.query(
         'message_search_fts',
         columns: const ['messageId'],
-        where: 'messageId = ?',
-        whereArgs: [messageId],
+        where: 'messageId = ? AND conversationId = ? AND scope = ?',
+        whereArgs: [messageId, conversationId, scope],
         limit: 1,
       );
       return rows.isNotEmpty;

--- a/lib/database/messages.dart
+++ b/lib/database/messages.dart
@@ -4,9 +4,11 @@ import 'package:prysm/database/conversation_queries_dao.dart';
 import 'package:prysm/database/media_gallery_queries_dao.dart';
 import 'package:prysm/database/message_crud_dao.dart';
 import 'package:prysm/database/message_id_codec.dart';
+import 'package:prysm/database/message_search_dao.dart';
 import 'package:prysm/database/messages_database.dart';
 import 'package:prysm/database/read_receipt_queries_dao.dart';
 import 'package:prysm/util/message_insert_bus.dart';
+import 'package:prysm/models/message_search_hit.dart';
 import 'package:prysm/util/message_preview_label.dart' as preview_label;
 import 'package:prysm/util/read_waterline_mark.dart';
 import 'package:sqflite/sqflite.dart';
@@ -22,6 +24,7 @@ class MessagesDb {
   static const ReadReceiptQueriesDao _readReceiptDao = ReadReceiptQueriesDao();
   static final ConversationListQueriesDao _conversationListDao = ConversationListQueriesDao();
   static const MediaGalleryQueriesDao _mediaDao = MediaGalleryQueriesDao();
+  static const MessageSearchDao _searchDao = MessageSearchDao();
 
   /// Stream that emits the normalized row whenever a message is inserted locally.
   static Stream<Map<String, dynamic>> get onMessageInserted =>
@@ -313,4 +316,17 @@ class MessagesDb {
 
   /// Close the db
   static Future<void> close() => MessagesDatabase.close();
+
+  static Future<List<MessageSearchHit>> searchMessagesGlobal(
+    String query, {
+    int limit = 30,
+  }) =>
+      _searchDao.searchGlobal(query, limit: limit);
+
+  static Future<List<MessageSearchHit>> searchMessagesInConversation(
+    String conversationId,
+    String query, {
+    int limit = 50,
+  }) =>
+      _searchDao.searchInConversation(conversationId, query, limit: limit);
 }

--- a/lib/database/self_messages_db.dart
+++ b/lib/database/self_messages_db.dart
@@ -2,6 +2,7 @@ import 'package:prysm/database/message_schema_migrations.dart';
 import 'package:prysm/database/message_search_dao.dart';
 import 'package:prysm/database/messages.dart';
 import 'package:prysm/database/messages_database.dart';
+import 'package:prysm/models/conversation.dart';
 import 'package:prysm/util/message_preview_label.dart';
 import 'package:sqflite/sqflite.dart';
 
@@ -115,7 +116,11 @@ class SelfMessagesDb {
         where: 'id = ?',
         whereArgs: [messageId],
       );
-      await _searchDao.remove(messageId);
+      await _searchDao.removeUnprotected(
+        messageId,
+        conversationId: SelfConversation.conversationId,
+        scope: 'self',
+      );
     });
   }
 
@@ -158,7 +163,11 @@ class SelfMessagesDb {
         where: 'id = ? AND viewOnce = 1',
         whereArgs: [messageId],
       );
-      await _searchDao.remove(messageId);
+      await _searchDao.removeUnprotected(
+        messageId,
+        conversationId: SelfConversation.conversationId,
+        scope: 'self',
+      );
     });
   }
 }

--- a/lib/database/self_messages_db.dart
+++ b/lib/database/self_messages_db.dart
@@ -1,4 +1,5 @@
 import 'package:prysm/database/message_schema_migrations.dart';
+import 'package:prysm/database/message_search_dao.dart';
 import 'package:prysm/database/messages.dart';
 import 'package:prysm/database/messages_database.dart';
 import 'package:prysm/util/message_preview_label.dart';
@@ -7,6 +8,8 @@ import 'package:sqflite/sqflite.dart';
 /// Local-only notes-to-self messages (no P2P).
 class SelfMessagesDb {
   SelfMessagesDb._();
+
+  static const MessageSearchDao _searchDao = MessageSearchDao();
 
   static Database? _testDatabase;
 
@@ -112,6 +115,7 @@ class SelfMessagesDb {
         where: 'id = ?',
         whereArgs: [messageId],
       );
+      await _searchDao.remove(messageId);
     });
   }
 
@@ -154,6 +158,7 @@ class SelfMessagesDb {
         where: 'id = ? AND viewOnce = 1',
         whereArgs: [messageId],
       );
+      await _searchDao.remove(messageId);
     });
   }
 }

--- a/lib/models/message_search_hit.dart
+++ b/lib/models/message_search_hit.dart
@@ -1,0 +1,26 @@
+class MessageSearchHit {
+  const MessageSearchHit({
+    required this.messageId,
+    required this.conversationId,
+    required this.scope,
+    required this.timestamp,
+    required this.body,
+    this.snippet = '',
+  });
+
+  final String messageId;
+  final String conversationId;
+  final String scope;
+  final int timestamp;
+  final String body;
+  final String snippet;
+
+  MessageSearchHit copyWith({String? snippet}) => MessageSearchHit(
+        messageId: messageId,
+        conversationId: conversationId,
+        scope: scope,
+        timestamp: timestamp,
+        body: body,
+        snippet: snippet ?? this.snippet,
+      );
+}

--- a/lib/screens/chat.dart
+++ b/lib/screens/chat.dart
@@ -31,6 +31,7 @@ import 'package:prysm/screens/chat_profile_screen.dart';
 import 'package:prysm/ui/chat/prysm_bubble_renderer.dart';
 import 'package:prysm/ui/chat/prysm_chat_composer_column.dart';
 import 'package:prysm/ui/chat/prysm_chat_list.dart';
+import 'package:prysm/ui/chat/chat_search_bar.dart';
 import 'package:prysm/ui/chat/prysm_date_header.dart';
 import 'package:prysm/ui/chat/prysm_message_row.dart';
 import 'package:prysm/theme/prysm_style_scope.dart';
@@ -103,6 +104,7 @@ class ChatScreen extends StatefulWidget {
   final Function()? onCloseChat;
   final Widget? torStatusAction;
   final DetachedChatClient? detachedClient;
+  final String? initialScrollToMessageId;
 
   const ChatScreen({
     required this.userId,
@@ -119,6 +121,7 @@ class ChatScreen extends StatefulWidget {
     this.onCloseChat,
     this.torStatusAction,
     this.detachedClient,
+    this.initialScrollToMessageId,
     super.key,
   });
 
@@ -169,6 +172,8 @@ class _ChatScreenState extends State<ChatScreen> {
   late MessageActionsService _actionsService;
   String? _highlightedMessageId;
   Timer? _highlightTimer;
+  bool _showChatSearch = false;
+  String _chatHighlightQuery = '';
   late TypingIndicatorService _typingService;
   final _typingTracker = TypingStateTracker();
   StreamSubscription<TypingIndicatorEvent>? _typingSub;
@@ -421,6 +426,13 @@ class _ChatScreenState extends State<ChatScreen> {
 
     if (mounted && _controller.messages.messages.isNotEmpty) {
       _controller.scheduleScrollToBottomAfterSend();
+    }
+
+    final initialId = widget.initialScrollToMessageId;
+    if (initialId != null && mounted) {
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        unawaited(_scrollToMessage(initialId));
+      });
     }
 
     // ✅ Start ChatService background tasks (main window only)
@@ -1651,6 +1663,10 @@ class _ChatScreenState extends State<ChatScreen> {
     return [
       if (widget.torStatusAction != null) widget.torStatusAction!,
       PrysmIconButton(
+        icon: PrysmIcons.search,
+        onPressed: () => setState(() => _showChatSearch = !_showChatSearch),
+      ),
+      PrysmIconButton(
         icon: PrysmIcons.phone,
         onPressed: _canStartCall ? _startAudioCall : null,
       ),
@@ -1677,6 +1693,20 @@ class _ChatScreenState extends State<ChatScreen> {
       ),
       titleWidget: _buildChatTitle(),
       actions: _buildAppBarActions(),
+      bottom: _showChatSearch
+          ? ChatSearchBar(
+              conversationId: widget.peerId,
+              onClose: () => setState(() {
+                _showChatSearch = false;
+                _chatHighlightQuery = '';
+              }),
+              onQueryChanged: (query) =>
+                  setState(() => _chatHighlightQuery = query),
+              onResultSelected: (hit, _) {
+                unawaited(_scrollToMessage(hit.messageId));
+              },
+            )
+          : null,
       body: PrysmChatDropTarget(
         enabled: !_isPeerBlocked,
         onFileDropped: _handleDroppedFile,
@@ -2159,6 +2189,8 @@ class _ChatScreenState extends State<ChatScreen> {
               textColor: textColor,
               fontSize: bodyStyle.fontSize ?? 15,
               onOpenUrl: _openUrl,
+              highlightQuery:
+                  _showChatSearch ? _chatHighlightQuery : null,
             ),
             const SizedBox(height: 4),
             Align(

--- a/lib/screens/chat.dart
+++ b/lib/screens/chat.dart
@@ -717,6 +717,16 @@ class _ChatScreenState extends State<ChatScreen> {
     if (oldWidget.peerAvatarBase64 != widget.peerAvatarBase64) {
       setState(() => _peerAvatarBase64 = widget.peerAvatarBase64);
     }
+
+    final scrollId = widget.initialScrollToMessageId;
+    if (scrollId != null &&
+        scrollId != oldWidget.initialScrollToMessageId &&
+        oldWidget.peerId == widget.peerId) {
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        if (!mounted) return;
+        unawaited(_scrollToMessage(scrollId));
+      });
+    }
   }
 
   void _applyModifyUpdate(MessageModifyUpdate update) {

--- a/lib/screens/chat.dart
+++ b/lib/screens/chat.dart
@@ -431,6 +431,7 @@ class _ChatScreenState extends State<ChatScreen> {
     final initialId = widget.initialScrollToMessageId;
     if (initialId != null && mounted) {
       WidgetsBinding.instance.addPostFrameCallback((_) {
+        if (!mounted) return;
         unawaited(_scrollToMessage(initialId));
       });
     }
@@ -1664,7 +1665,10 @@ class _ChatScreenState extends State<ChatScreen> {
       if (widget.torStatusAction != null) widget.torStatusAction!,
       PrysmIconButton(
         icon: PrysmIcons.search,
-        onPressed: () => setState(() => _showChatSearch = !_showChatSearch),
+        onPressed: () => setState(() {
+          _showChatSearch = !_showChatSearch;
+          if (!_showChatSearch) _chatHighlightQuery = '';
+        }),
       ),
       PrysmIconButton(
         icon: PrysmIcons.phone,

--- a/lib/screens/group_chat.dart
+++ b/lib/screens/group_chat.dart
@@ -410,6 +410,7 @@ class _GroupChatScreenState extends State<GroupChatScreen> {
     final initialId = widget.initialScrollToMessageId;
     if (initialId != null && mounted) {
       WidgetsBinding.instance.addPostFrameCallback((_) {
+        if (!mounted) return;
         unawaited(_scrollToMessage(initialId));
       });
     }
@@ -1624,7 +1625,10 @@ class _GroupChatScreenState extends State<GroupChatScreen> {
         if (widget.torStatusAction != null) widget.torStatusAction!,
         PrysmIconButton(
           icon: PrysmIcons.search,
-          onPressed: () => setState(() => _showChatSearch = !_showChatSearch),
+          onPressed: () => setState(() {
+            _showChatSearch = !_showChatSearch;
+            if (!_showChatSearch) _chatHighlightQuery = '';
+          }),
         ),
         if (selectedMessageIds.isNotEmpty)
           PrysmIconButton(

--- a/lib/screens/group_chat.dart
+++ b/lib/screens/group_chat.dart
@@ -21,7 +21,6 @@ import 'package:image_picker/image_picker.dart';
 import 'package:prysm/constants/group_constants.dart';
 import 'package:prysm/database/messages.dart';
 import 'package:prysm/models/contact.dart';
-import 'package:prysm/models/conversation.dart';
 import 'package:prysm/models/group.dart';
 import 'package:prysm/screens/group_settings_screen.dart';
 import 'package:prysm/ui/chat/prysm_bubble_renderer.dart';

--- a/lib/screens/group_chat.dart
+++ b/lib/screens/group_chat.dart
@@ -307,6 +307,14 @@ class _GroupChatScreenState extends State<GroupChatScreen> {
       _senderNames.clear();
       _memberCount = 0;
       _bootstrapForGroup();
+      return;
+    }
+    final scrollId = widget.initialScrollToMessageId;
+    if (scrollId != null && scrollId != oldWidget.initialScrollToMessageId) {
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        if (!mounted) return;
+        unawaited(_scrollToMessage(scrollId));
+      });
     }
   }
 

--- a/lib/screens/group_chat.dart
+++ b/lib/screens/group_chat.dart
@@ -21,12 +21,14 @@ import 'package:image_picker/image_picker.dart';
 import 'package:prysm/constants/group_constants.dart';
 import 'package:prysm/database/messages.dart';
 import 'package:prysm/models/contact.dart';
+import 'package:prysm/models/conversation.dart';
 import 'package:prysm/models/group.dart';
 import 'package:prysm/screens/group_settings_screen.dart';
 import 'package:prysm/ui/chat/prysm_bubble_renderer.dart';
 import 'package:prysm/ui/chat/prysm_chat_composer_column.dart';
 import 'package:prysm/ui/chat/prysm_date_header.dart';
 import 'package:prysm/ui/chat/prysm_chat_list.dart';
+import 'package:prysm/ui/chat/chat_search_bar.dart';
 import 'package:prysm/ui/chat/prysm_message_row.dart';
 import 'package:prysm/util/logging.dart';
 import 'package:prysm/util/scroll_to_chat_message.dart';
@@ -86,6 +88,7 @@ class GroupChatScreen extends StatefulWidget {
   final VoidCallback? onCloseChat;
   final Widget? torStatusAction;
   final DetachedChatClient? detachedClient;
+  final String? initialScrollToMessageId;
 
   const GroupChatScreen({
     required this.userId,
@@ -96,6 +99,7 @@ class GroupChatScreen extends StatefulWidget {
     this.onCloseChat,
     this.torStatusAction,
     this.detachedClient,
+    this.initialScrollToMessageId,
     super.key,
   });
 
@@ -132,6 +136,8 @@ class _GroupChatScreenState extends State<GroupChatScreen> {
   List<String> _groupMemberIds = [];
   String? _highlightedMessageId;
   Timer? _highlightTimer;
+  bool _showChatSearch = false;
+  String _chatHighlightQuery = '';
 
   Set<String> get selectedMessageIds => _controller.selectedMessageIds;
   PrysmChatMessageList get _messages => _controller.messages;
@@ -400,6 +406,13 @@ class _GroupChatScreenState extends State<GroupChatScreen> {
 
     if (mounted && _controller.messages.messages.isNotEmpty) {
       _controller.scheduleScrollToBottomAfterSend();
+    }
+
+    final initialId = widget.initialScrollToMessageId;
+    if (initialId != null && mounted) {
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        unawaited(_scrollToMessage(initialId));
+      });
     }
 
     if (mounted) setState(() {});
@@ -1294,6 +1307,8 @@ class _GroupChatScreenState extends State<GroupChatScreen> {
                       : context.prysmStyle.tokens.textPrimary,
                   fontSize: 16,
                   onOpenUrl: _openUrl,
+                  highlightQuery:
+                      _showChatSearch ? _chatHighlightQuery : null,
                 ),
                 const SizedBox(height: 4),
                 Row(
@@ -1608,6 +1623,10 @@ class _GroupChatScreenState extends State<GroupChatScreen> {
       titleWidget: _buildGroupTitle(),
       actions: [
         if (widget.torStatusAction != null) widget.torStatusAction!,
+        PrysmIconButton(
+          icon: PrysmIcons.search,
+          onPressed: () => setState(() => _showChatSearch = !_showChatSearch),
+        ),
         if (selectedMessageIds.isNotEmpty)
           PrysmIconButton(
             icon: PrysmIcons.deleteOutline,
@@ -1618,6 +1637,20 @@ class _GroupChatScreenState extends State<GroupChatScreen> {
           onPressed: _openSettings,
         ),
       ],
+      bottom: _showChatSearch
+          ? ChatSearchBar(
+              conversationId: widget.group.id,
+              onClose: () => setState(() {
+                _showChatSearch = false;
+                _chatHighlightQuery = '';
+              }),
+              onQueryChanged: (query) =>
+                  setState(() => _chatHighlightQuery = query),
+              onResultSelected: (hit, _) {
+                unawaited(_scrollToMessage(hit.messageId));
+              },
+            )
+          : null,
       body: PrysmChatDropTarget(
         onFileDropped: _handleDroppedFile,
         child: Column(

--- a/lib/screens/home/home_screen.dart
+++ b/lib/screens/home/home_screen.dart
@@ -219,23 +219,34 @@ class _HomeScreenState extends State<HomeScreen> with WidgetsBindingObserver {
       });
       return;
     }
-    setState(() => _messageSearchLoading = true);
+    setState(() {
+      _messageSearchResults = [];
+      _messageSearchLoading = true;
+    });
     _messageSearchDebounce = Timer(const Duration(milliseconds: 300), () async {
       final submitted = query;
-      final hits = await MessagesDb.searchMessagesGlobal(submitted);
-      if (!mounted || submitted != _searchQuery) return;
-      final enriched = hits
-          .where((h) => !BlockService.instance.isBlocked(h.conversationId))
-          .map(
-            (h) => h.copyWith(
-              snippet: MessageSearchIndexService.buildSnippet(h.body, submitted),
-            ),
-          )
-          .toList();
-      setState(() {
-        _messageSearchResults = enriched;
-        _messageSearchLoading = false;
-      });
+      try {
+        final hits = await MessagesDb.searchMessagesGlobal(submitted);
+        if (!mounted || submitted != _searchQuery) return;
+        final enriched = hits
+            .where((h) => !BlockService.instance.isBlocked(h.conversationId))
+            .map(
+              (h) => h.copyWith(
+                snippet: MessageSearchIndexService.buildSnippet(h.body, submitted),
+              ),
+            )
+            .toList();
+        setState(() {
+          _messageSearchResults = enriched;
+          _messageSearchLoading = false;
+        });
+      } catch (e) {
+        if (!mounted || submitted != _searchQuery) return;
+        setState(() {
+          _messageSearchResults = [];
+          _messageSearchLoading = false;
+        });
+      }
     });
   }
 
@@ -257,8 +268,9 @@ class _HomeScreenState extends State<HomeScreen> with WidgetsBindingObserver {
   }
 
   void _openMessageSearchResult(MessageSearchHit hit) {
-    _pendingScrollToMessageId = hit.messageId;
+    _pendingScrollToMessageId = null;
     if (hit.scope == 'self') {
+      _pendingScrollToMessageId = hit.messageId;
       onSelectSelfChat();
       return;
     }
@@ -268,6 +280,7 @@ class _HomeScreenState extends State<HomeScreen> with WidgetsBindingObserver {
             orElse: () => null,
           );
       if (group != null) {
+        _pendingScrollToMessageId = hit.messageId;
         onSelectGroup(group);
       }
       return;
@@ -277,6 +290,7 @@ class _HomeScreenState extends State<HomeScreen> with WidgetsBindingObserver {
           orElse: () => null,
         );
     if (contact != null) {
+      _pendingScrollToMessageId = hit.messageId;
       onSelectContact(contact);
     }
   }
@@ -298,10 +312,13 @@ class _HomeScreenState extends State<HomeScreen> with WidgetsBindingObserver {
   Widget _buildSearchSidebarItem(int index) {
     var cursor = 0;
     if (_messageSearchLoading && _messageSearchResults.isEmpty) {
-      return const Padding(
-        padding: EdgeInsets.all(16),
-        child: Center(child: PrysmProgressIndicator()),
-      );
+      if (index == cursor) {
+        return const Padding(
+          padding: EdgeInsets.all(16),
+          child: Center(child: PrysmProgressIndicator()),
+        );
+      }
+      cursor++;
     }
     if (_filteredConversations.isNotEmpty) {
       if (index == cursor) return _buildSearchSectionHeader('Chats');

--- a/lib/screens/home/home_screen.dart
+++ b/lib/screens/home/home_screen.dart
@@ -221,12 +221,14 @@ class _HomeScreenState extends State<HomeScreen> with WidgetsBindingObserver {
     }
     setState(() => _messageSearchLoading = true);
     _messageSearchDebounce = Timer(const Duration(milliseconds: 300), () async {
-      final hits = await MessagesDb.searchMessagesGlobal(query);
-      if (!mounted) return;
+      final submitted = query;
+      final hits = await MessagesDb.searchMessagesGlobal(submitted);
+      if (!mounted || submitted != _searchQuery) return;
       final enriched = hits
+          .where((h) => !BlockService.instance.isBlocked(h.conversationId))
           .map(
             (h) => h.copyWith(
-              snippet: MessageSearchIndexService.buildSnippet(h.body, query),
+              snippet: MessageSearchIndexService.buildSnippet(h.body, submitted),
             ),
           )
           .toList();

--- a/lib/screens/home/home_screen.dart
+++ b/lib/screens/home/home_screen.dart
@@ -64,6 +64,10 @@ import 'package:prysm/screens/widgets/contact_avatar.dart';
 import 'package:prysm/models/contact.dart';
 import 'package:prysm/theme/prysm_theme.dart';
 import 'package:prysm/screens/home/empty_home_state.dart';
+import 'package:prysm/database/messages.dart';
+import 'package:prysm/models/message_search_hit.dart';
+import 'package:prysm/screens/home/message_search_result_row.dart';
+import 'package:prysm/services/message_search_index_service.dart';
 import 'package:prysm/ui/prysm_list_row.dart';
 import 'package:prysm/ui/prysm_search_field.dart';
 import 'package:prysm/ui/core/prysm_app.dart';
@@ -137,6 +141,10 @@ class _HomeScreenState extends State<HomeScreen> with WidgetsBindingObserver {
       0; // 0: Light, 1: Dark, 2: Pink, 3: Cyan, 4: Purple, 5 Orange
   String _searchQuery = '';
   final _searchController = TextEditingController();
+  List<MessageSearchHit> _messageSearchResults = [];
+  bool _messageSearchLoading = false;
+  Timer? _messageSearchDebounce;
+  String? _pendingScrollToMessageId;
   Map<String, String> _lastMessagePreviews = {};
   Map<String, int> _unreadCounts = {};
   Map<String, ConversationPreferences> _conversationPrefs = {};
@@ -182,6 +190,142 @@ class _HomeScreenState extends State<HomeScreen> with WidgetsBindingObserver {
     if (_archivedCount > 0) count++;
     if (_blockedCount > 0) count++;
     return count;
+  }
+
+  bool get _showMessageSearch =>
+      _searchQuery.length >= 2 && !_viewingArchived && !_viewingBlocked;
+
+  int get _sidebarSearchItemCount {
+    if (!_showMessageSearch) {
+      return _filteredConversations.length + _sidebarFooterCount;
+    }
+    var count = 0;
+    if (_messageSearchLoading && _messageSearchResults.isEmpty) count++;
+    if (_filteredConversations.isNotEmpty) {
+      count += 1 + _filteredConversations.length;
+    }
+    if (_messageSearchResults.isNotEmpty) {
+      count += 1 + _messageSearchResults.length;
+    }
+    return count;
+  }
+
+  void _scheduleMessageSearch(String query) {
+    _messageSearchDebounce?.cancel();
+    if (query.length < 2 || widget.decoyMode) {
+      setState(() {
+        _messageSearchResults = [];
+        _messageSearchLoading = false;
+      });
+      return;
+    }
+    setState(() => _messageSearchLoading = true);
+    _messageSearchDebounce = Timer(const Duration(milliseconds: 300), () async {
+      final hits = await MessagesDb.searchMessagesGlobal(query);
+      if (!mounted) return;
+      final enriched = hits
+          .map(
+            (h) => h.copyWith(
+              snippet: MessageSearchIndexService.buildSnippet(h.body, query),
+            ),
+          )
+          .toList();
+      setState(() {
+        _messageSearchResults = enriched;
+        _messageSearchLoading = false;
+      });
+    });
+  }
+
+  String _conversationNameForHit(MessageSearchHit hit) {
+    if (hit.scope == 'self') return 'Chat with myself';
+    for (final conv in conversations) {
+      if (conv.id == hit.conversationId) return conv.displayName;
+    }
+    return hit.conversationId;
+  }
+
+  String? _avatarForHit(MessageSearchHit hit) {
+    for (final conv in conversations) {
+      if (conv.id != hit.conversationId) continue;
+      if (conv is DirectConversation) return conv.contact.avatarBase64;
+      if (conv is GroupConversation) return conv.group.avatarBase64;
+    }
+    return null;
+  }
+
+  void _openMessageSearchResult(MessageSearchHit hit) {
+    _pendingScrollToMessageId = hit.messageId;
+    if (hit.scope == 'self') {
+      onSelectSelfChat();
+      return;
+    }
+    if (hit.scope == 'group') {
+      final group = groups.cast<Group?>().firstWhere(
+            (g) => g?.id == hit.conversationId,
+            orElse: () => null,
+          );
+      if (group != null) {
+        onSelectGroup(group);
+      }
+      return;
+    }
+    final contact = contacts.cast<Contact?>().firstWhere(
+          (c) => c?.id == hit.conversationId,
+          orElse: () => null,
+        );
+    if (contact != null) {
+      onSelectContact(contact);
+    }
+  }
+
+  Widget _buildSearchSectionHeader(String title) {
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(16, 12, 16, 4),
+      child: Text(
+        title,
+        style: TextStyle(
+          fontSize: 12,
+          fontWeight: FontWeight.w600,
+          color: context.prysmStyle.tokens.textMuted,
+        ),
+      ),
+    );
+  }
+
+  Widget _buildSearchSidebarItem(int index) {
+    var cursor = 0;
+    if (_messageSearchLoading && _messageSearchResults.isEmpty) {
+      return const Padding(
+        padding: EdgeInsets.all(16),
+        child: Center(child: PrysmProgressIndicator()),
+      );
+    }
+    if (_filteredConversations.isNotEmpty) {
+      if (index == cursor) return _buildSearchSectionHeader('Chats');
+      cursor++;
+      final chatIndex = index - cursor;
+      if (chatIndex < _filteredConversations.length) {
+        return _buildConversationRow(_filteredConversations[chatIndex]);
+      }
+      cursor += _filteredConversations.length;
+    }
+    if (_messageSearchResults.isNotEmpty) {
+      if (index == cursor) return _buildSearchSectionHeader('Messages');
+      cursor++;
+      final messageIndex = index - cursor;
+      if (messageIndex < _messageSearchResults.length) {
+        final hit = _messageSearchResults[messageIndex];
+        return MessageSearchResultRow(
+          hit: hit,
+          conversationName: _conversationNameForHit(hit),
+          timeLabel: formatLastMessageTime(hit.timestamp),
+          avatarBase64: _avatarForHit(hit),
+          onTap: () => _openMessageSearchResult(hit),
+        );
+      }
+    }
+    return const SizedBox.shrink();
   }
 
   List<Conversation> get _filteredConversations {
@@ -431,6 +575,13 @@ class _HomeScreenState extends State<HomeScreen> with WidgetsBindingObserver {
     if (!Platform.isAndroid && !Platform.isIOS) {
       unawaited(TrayService.instance.start(userId: widget.onionAddress));
       _configureDetachedChat();
+    }
+
+    if (!widget.decoyMode) {
+      AppComposition.startSearchBackfill(
+        keyManager: widget.keyManager,
+        userId: widget.onionAddress,
+      );
     }
   }
 
@@ -1259,6 +1410,79 @@ class _HomeScreenState extends State<HomeScreen> with WidgetsBindingObserver {
     );
   }
 
+  Widget _buildConversationRow(Conversation conv) {
+    final tokens = context.prysmStyle.tokens;
+    final isSelected = selectedConversation?.id == conv.id;
+    final prefs = _conversationPrefs[conv.id];
+    final isPinned = prefs?.isPinned ?? false;
+    final Widget leading;
+    final String subtitle;
+
+    final unreadCount = _unreadCounts[conv.id] ?? 0;
+    final preview = _lastMessagePreviews[conv.id];
+    final timeLabel = formatLastMessageTime(conv.lastMessageTimestamp);
+
+    if (conv is DirectConversation) {
+      final contact = conv.contact;
+      final isBlockedContact = BlockService.instance.isBlocked(conv.id);
+      leading = ContactAvatar(
+        name: contact.displayName,
+        avatarBase64: contact.avatarBase64,
+      );
+      if (isBlockedContact) {
+        subtitle = timeLabel;
+      } else {
+        subtitle = preview != null ? '$preview · $timeLabel' : timeLabel;
+      }
+    } else {
+      final group = (conv as GroupConversation).group;
+      leading = ContactAvatar(
+        name: group.name,
+        avatarBase64: group.avatarBase64,
+      );
+      subtitle = preview != null
+          ? 'Group · $preview · $timeLabel'
+          : 'Group · $timeLabel';
+    }
+
+    final isBlockedContact =
+        conv is DirectConversation && BlockService.instance.isBlocked(conv.id);
+
+    return GestureDetector(
+      key: ValueKey(
+        '${conv.id}_${conv.lastMessageTimestamp ?? 0}_$unreadCount',
+      ),
+      onSecondaryTapDown: isDesktopPlatform
+          ? (details) =>
+              _showConversationContextMenu(details.globalPosition, conv)
+          : null,
+      onLongPress: () => _showConversationActions(conv),
+      child: PrysmListRow(
+        selected: isSelected,
+        onTap: () {
+          if (conv is DirectConversation) {
+            onSelectContact(conv.contact);
+          } else if (conv is GroupConversation) {
+            onSelectGroup(conv.group);
+          }
+        },
+        leading: SizedBox(width: 48, height: 48, child: leading),
+        title: conv.displayName,
+        subtitle: subtitle,
+        trailingSubtitle:
+            timeLabel.contains(' · ') ? timeLabel.split(' · ').last : timeLabel,
+        trailing: unreadCount > 0 && !isBlockedContact
+            ? PrysmUnreadBadge(count: unreadCount)
+            : isBlockedContact && _viewingBlocked
+                ? Icon(PrysmIcons.block, size: 18, color: tokens.textMuted)
+                : isPinned && !_viewingArchived && !_viewingBlocked
+                    ? Icon(PrysmIcons.pushPin,
+                        size: 16, color: tokens.textMuted)
+                    : null,
+      ),
+    );
+  }
+
   String formatLastMessageTime(int? timestamp) {
     if (timestamp == null) return "No message";
     final dt = DateTime.fromMillisecondsSinceEpoch(timestamp).toUtc().toLocal();
@@ -1438,15 +1662,20 @@ class _HomeScreenState extends State<HomeScreen> with WidgetsBindingObserver {
                   ? 'Search archived...'
                   : _viewingBlocked
                       ? 'Search blocked...'
-                      : 'Search chats...',
+                      : 'Search chats and messages...',
               onChanged: (value) {
-                setState(() => _searchQuery = value.trim().toLowerCase());
+                final query = value.trim().toLowerCase();
+                setState(() => _searchQuery = query);
+                _scheduleMessageSearch(query);
               },
               onClear: () {
                 setState(() {
                   _searchQuery = '';
                   _searchController.clear();
+                  _messageSearchResults = [];
+                  _messageSearchLoading = false;
                 });
+                _messageSearchDebounce?.cancel();
               },
             ),
           ),
@@ -1456,8 +1685,11 @@ class _HomeScreenState extends State<HomeScreen> with WidgetsBindingObserver {
           Expanded(
             child: ListView.builder(
               padding: const EdgeInsets.symmetric(vertical: 8),
-              itemCount: _filteredConversations.length + _sidebarFooterCount,
+              itemCount: _sidebarSearchItemCount,
               itemBuilder: (_, index) {
+                if (_showMessageSearch) {
+                  return _buildSearchSidebarItem(index);
+                }
                 if (index >= _filteredConversations.length) {
                   final footerIndex = index - _filteredConversations.length;
                   final showArchivedFooter = _archivedCount > 0;
@@ -1513,92 +1745,7 @@ class _HomeScreenState extends State<HomeScreen> with WidgetsBindingObserver {
                 }
 
                 final conv = _filteredConversations[index];
-                final isSelected = selectedConversation?.id == conv.id;
-                final prefs = _conversationPrefs[conv.id];
-                final isPinned = prefs?.isPinned ?? false;
-                final Widget leading;
-                final String subtitle;
-
-                final unreadCount = _unreadCounts[conv.id] ?? 0;
-                final preview = _lastMessagePreviews[conv.id];
-                final timeLabel = formatLastMessageTime(
-                  conv.lastMessageTimestamp,
-                );
-
-                if (conv is DirectConversation) {
-                  final contact = conv.contact;
-                  final isBlockedContact = BlockService.instance.isBlocked(
-                    conv.id,
-                  );
-                  leading = ContactAvatar(
-                    name: contact.displayName,
-                    avatarBase64: contact.avatarBase64,
-                  );
-                  if (isBlockedContact) {
-                    subtitle = timeLabel;
-                  } else {
-                    subtitle = preview != null
-                        ? '$preview · $timeLabel'
-                        : timeLabel;
-                  }
-                } else {
-                  final group = (conv as GroupConversation).group;
-                  leading = ContactAvatar(
-                    name: group.name,
-                    avatarBase64: group.avatarBase64,
-                  );
-                  subtitle = preview != null
-                      ? 'Group · $preview · $timeLabel'
-                      : 'Group · $timeLabel';
-                }
-
-                final isBlockedContact =
-                    conv is DirectConversation &&
-                    BlockService.instance.isBlocked(conv.id);
-
-                return GestureDetector(
-                  key: ValueKey(
-                    '${conv.id}_${conv.lastMessageTimestamp ?? 0}_$unreadCount',
-                  ),
-                  onSecondaryTapDown: isDesktopPlatform
-                      ? (details) => _showConversationContextMenu(
-                          details.globalPosition,
-                          conv,
-                        )
-                      : null,
-                  onLongPress: () => _showConversationActions(conv),
-                  child: PrysmListRow(
-                    selected: isSelected,
-                    onTap: () {
-                      if (conv is DirectConversation) {
-                        onSelectContact(conv.contact);
-                      } else if (conv is GroupConversation) {
-                        onSelectGroup(conv.group);
-                      }
-                    },
-                    leading: SizedBox(
-                      width: 48,
-                      height: 48,
-                      child: leading,
-                    ),
-                    title: conv.displayName,
-                    subtitle: subtitle,
-                    trailingSubtitle: timeLabel.contains(' · ')
-                        ? timeLabel.split(' · ').last
-                        : timeLabel,
-                    trailing: unreadCount > 0 && !isBlockedContact
-                        ? PrysmUnreadBadge(count: unreadCount)
-                        : isBlockedContact && _viewingBlocked
-                            ? Icon(PrysmIcons.block,
-                                size: 18, color: tokens.textMuted)
-                            : isPinned &&
-                                    !_viewingArchived &&
-                                    !_viewingBlocked
-                                ? Icon(PrysmIcons.pushPin,
-                                    size: 16, color: tokens.textMuted)
-                                : null,
-                  ),
-                );
+                return _buildConversationRow(conv);
               },
             ),
           ),
@@ -1649,6 +1796,7 @@ class _HomeScreenState extends State<HomeScreen> with WidgetsBindingObserver {
     widget.torConnectionController.clearReconnectCallbacks();
     _refreshTimer?.cancel();
     _loadUsersDebounce?.cancel();
+    _messageSearchDebounce?.cancel();
     _batterySaverSub?.cancel();
     _inboundRefreshSub?.cancel();
     _groupMembershipSub?.cancel();
@@ -2093,6 +2241,8 @@ class _HomeScreenState extends State<HomeScreen> with WidgetsBindingObserver {
       );
     }
     if (showSelfChat && !widget.decoyMode) {
+      final scrollId = _pendingScrollToMessageId;
+      _pendingScrollToMessageId = null;
       return SelfChatScreen(
         key: const ValueKey('self_chat'),
         userId: appUser.id,
@@ -2101,6 +2251,7 @@ class _HomeScreenState extends State<HomeScreen> with WidgetsBindingObserver {
         keyManager: widget.keyManager,
         onCloseChat: () => clearChat(),
         reloadSidebar: () => loadUsers(),
+        initialScrollToMessageId: scrollId,
       );
     }
     if (selectedConversation is GroupConversation) {
@@ -2118,6 +2269,8 @@ class _HomeScreenState extends State<HomeScreen> with WidgetsBindingObserver {
           torStatusAction: _buildTorAppBarAction(),
         );
       }
+      final scrollId = _pendingScrollToMessageId;
+      _pendingScrollToMessageId = null;
       return GroupChatScreen(
         key: ValueKey('group_${group.id}'),
         userId: appUser.id,
@@ -2127,6 +2280,7 @@ class _HomeScreenState extends State<HomeScreen> with WidgetsBindingObserver {
         reloadConversations: () => loadUsers(),
         onCloseChat: () => clearChat(),
         torStatusAction: widget.decoyMode ? null : _buildTorAppBarAction(),
+        initialScrollToMessageId: scrollId,
       );
     }
     if (selectedContact != null) {
@@ -2143,6 +2297,8 @@ class _HomeScreenState extends State<HomeScreen> with WidgetsBindingObserver {
           torStatusAction: _buildTorAppBarAction(),
         );
       }
+      final scrollId = _pendingScrollToMessageId;
+      _pendingScrollToMessageId = null;
       return ChatScreen(
         key: ValueKey('dm_${selectedContact!.id}'),
         userId: appUser.id,
@@ -2158,6 +2314,7 @@ class _HomeScreenState extends State<HomeScreen> with WidgetsBindingObserver {
         reloadUsers: () => loadUsers(),
         onCloseChat: () => clearChat(),
         torStatusAction: widget.decoyMode ? null : _buildTorAppBarAction(),
+        initialScrollToMessageId: scrollId,
       );
     }
     return _buildEmptyHomeState();

--- a/lib/screens/home/message_search_result_row.dart
+++ b/lib/screens/home/message_search_result_row.dart
@@ -1,0 +1,52 @@
+import 'package:flutter/widgets.dart';
+import 'package:prysm/models/message_search_hit.dart';
+import 'package:prysm/screens/widgets/contact_avatar.dart';
+import 'package:prysm/theme/prysm_style_scope.dart';
+import 'package:prysm/ui/core/prysm_icons.dart';
+import 'package:prysm/ui/core/prysm_list_row.dart';
+
+class MessageSearchResultRow extends StatelessWidget {
+  const MessageSearchResultRow({
+    required this.hit,
+    required this.conversationName,
+    required this.timeLabel,
+    this.avatarBase64,
+    required this.onTap,
+    super.key,
+  });
+
+  final MessageSearchHit hit;
+  final String conversationName;
+  final String timeLabel;
+  final String? avatarBase64;
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    final tokens = context.prysmStyle.tokens;
+    final snippet = hit.snippet.isNotEmpty ? hit.snippet : hit.body;
+
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 2),
+      child: PrysmListRow(
+        onTap: onTap,
+        leading: SizedBox(
+          width: 48,
+          height: 48,
+          child: ContactAvatar(
+            name: conversationName,
+            avatarBase64: avatarBase64,
+          ),
+        ),
+        title: conversationName,
+        subtitle: snippet,
+        trailingSubtitle: timeLabel,
+        trailing: Icon(
+          PrysmIcons.search,
+          size: 16,
+          color: tokens.textMuted,
+        ),
+      ),
+    );
+  }
+}

--- a/lib/screens/self_chat_screen.dart
+++ b/lib/screens/self_chat_screen.dart
@@ -168,6 +168,7 @@ class _SelfChatScreenState extends State<SelfChatScreen> {
     final initialId = widget.initialScrollToMessageId;
     if (initialId != null && mounted) {
       WidgetsBinding.instance.addPostFrameCallback((_) {
+        if (!mounted) return;
         unawaited(_scrollToMessage(initialId));
       });
     }
@@ -615,7 +616,10 @@ class _SelfChatScreenState extends State<SelfChatScreen> {
       actions: [
         PrysmIconButton(
           icon: PrysmIcons.search,
-          onPressed: () => setState(() => _showChatSearch = !_showChatSearch),
+          onPressed: () => setState(() {
+            _showChatSearch = !_showChatSearch;
+            if (!_showChatSearch) _chatHighlightQuery = '';
+          }),
         ),
       ],
       bottom: _showChatSearch

--- a/lib/screens/self_chat_screen.dart
+++ b/lib/screens/self_chat_screen.dart
@@ -674,20 +674,32 @@ class _SelfChatScreenState extends State<SelfChatScreen> {
                     child = const SizedBox.shrink();
                   }
 
+                  final isHighlighted = _highlightedMessageId == message.id;
+                  final tokens = context.prysmStyle.tokens;
+
                   return Column(
                     children: [
                       if (showHeader) PrysmDateHeader(date: msgDate),
                       GestureDetector(
                         onLongPress: () => _showMessageMenu(context, message),
-                        child: Padding(
-                          padding: const EdgeInsets.symmetric(vertical: 4),
-                          child: Row(
-                            mainAxisAlignment: MainAxisAlignment.end,
-                            children: [
-                              Flexible(
-                                child: _displayChildForMessage(message, child),
-                              ),
-                            ],
+                        child: ColoredBox(
+                          color: isHighlighted
+                              ? Color.lerp(
+                                  tokens.background,
+                                  tokens.accentMuted,
+                                  0.25,
+                                )!
+                              : const Color(0x00000000),
+                          child: Padding(
+                            padding: const EdgeInsets.symmetric(vertical: 4),
+                            child: Row(
+                              mainAxisAlignment: MainAxisAlignment.end,
+                              children: [
+                                Flexible(
+                                  child: _displayChildForMessage(message, child),
+                                ),
+                              ],
+                            ),
                           ),
                         ),
                       ),

--- a/lib/screens/self_chat_screen.dart
+++ b/lib/screens/self_chat_screen.dart
@@ -29,6 +29,9 @@ import 'package:prysm/util/chat_attachment_ingress.dart';
 import 'package:prysm/theme/prysm_theme.dart';
 import 'package:prysm/ui/chat/prysm_chat_composer_column.dart';
 import 'package:prysm/ui/chat/prysm_chat_list.dart';
+import 'package:prysm/ui/chat/chat_search_bar.dart';
+import 'package:prysm/models/conversation.dart';
+import 'package:prysm/util/scroll_to_chat_message.dart';
 import 'package:prysm/ui/chat/prysm_date_header.dart';
 import 'package:prysm/ui/prysm_scaffold.dart';
 import 'package:prysm/util/chat_scroll.dart';
@@ -45,6 +48,7 @@ class SelfChatScreen extends StatefulWidget {
   final VoidCallback onCloseChat;
   final VoidCallback reloadSidebar;
   final DetachedChatClient? detachedClient;
+  final String? initialScrollToMessageId;
 
   const SelfChatScreen({
     required this.userId,
@@ -54,6 +58,7 @@ class SelfChatScreen extends StatefulWidget {
     required this.onCloseChat,
     required this.reloadSidebar,
     this.detachedClient,
+    this.initialScrollToMessageId,
     super.key,
   });
 
@@ -67,6 +72,10 @@ class _SelfChatScreenState extends State<SelfChatScreen> {
   final _scrollController = ScrollController();
 
   StreamSubscription? _detachedInboundSub;
+  String? _highlightedMessageId;
+  Timer? _highlightTimer;
+  bool _showChatSearch = false;
+  String _chatHighlightQuery = '';
 
   Future<List<Message>> _decryptForDisplay(
     List<Map<String, dynamic>> rows,
@@ -139,6 +148,7 @@ class _SelfChatScreenState extends State<SelfChatScreen> {
 
   @override
   void dispose() {
+    _highlightTimer?.cancel();
     _detachedInboundSub?.cancel();
     _scrollController.removeListener(_controller.onListScroll);
     _scrollController.dispose();
@@ -154,6 +164,35 @@ class _SelfChatScreenState extends State<SelfChatScreen> {
         _controller.messages,
         isMounted: () => mounted,
       );
+    }
+    final initialId = widget.initialScrollToMessageId;
+    if (initialId != null && mounted) {
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        unawaited(_scrollToMessage(initialId));
+      });
+    }
+  }
+
+  Future<void> _scrollToMessage(String messageId) async {
+    final found = await scrollToChatMessage(
+      controller: _controller.messages,
+      messageId: messageId,
+      loadMore: () async {
+        if (!_controller.hasMore || _controller.loading) return false;
+        final countBefore = _controller.messages.messages.length;
+        await _controller.loadMoreMessages();
+        return _controller.messages.messages.length > countBefore;
+      },
+    );
+    if (!mounted) return;
+    if (found) {
+      setState(() => _highlightedMessageId = messageId);
+      _highlightTimer?.cancel();
+      _highlightTimer = Timer(const Duration(seconds: 2), () {
+        if (mounted) {
+          setState(() => _highlightedMessageId = null);
+        }
+      });
     }
   }
 
@@ -367,6 +406,8 @@ class _SelfChatScreenState extends State<SelfChatScreen> {
               textColor: tokens.onAccent,
               fontSize: 14,
               onOpenUrl: _openUrl,
+              highlightQuery:
+                  _showChatSearch ? _chatHighlightQuery : null,
             ),
             const SizedBox(height: 4),
             Align(
@@ -571,6 +612,26 @@ class _SelfChatScreenState extends State<SelfChatScreen> {
       ),
       title: 'Chat with myself',
       subtitle: 'Notes to yourself',
+      actions: [
+        PrysmIconButton(
+          icon: PrysmIcons.search,
+          onPressed: () => setState(() => _showChatSearch = !_showChatSearch),
+        ),
+      ],
+      bottom: _showChatSearch
+          ? ChatSearchBar(
+              conversationId: SelfConversation.conversationId,
+              onClose: () => setState(() {
+                _showChatSearch = false;
+                _chatHighlightQuery = '';
+              }),
+              onQueryChanged: (query) =>
+                  setState(() => _chatHighlightQuery = query),
+              onResultSelected: (hit, _) {
+                unawaited(_scrollToMessage(hit.messageId));
+              },
+            )
+          : null,
       body: PrysmChatDropTarget(
         onFileDropped: _handleDroppedFile,
         child: Column(

--- a/lib/screens/self_chat_screen.dart
+++ b/lib/screens/self_chat_screen.dart
@@ -147,6 +147,18 @@ class _SelfChatScreenState extends State<SelfChatScreen> {
   }
 
   @override
+  void didUpdateWidget(covariant SelfChatScreen oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    final scrollId = widget.initialScrollToMessageId;
+    if (scrollId != null && scrollId != oldWidget.initialScrollToMessageId) {
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        if (!mounted) return;
+        unawaited(_scrollToMessage(scrollId));
+      });
+    }
+  }
+
+  @override
   void dispose() {
     _highlightTimer?.cancel();
     _detachedInboundSub?.cancel();

--- a/lib/screens/widgets/linked_message_text.dart
+++ b/lib/screens/widgets/linked_message_text.dart
@@ -81,7 +81,7 @@ class LinkedMessageText extends StatelessWidget {
 
     appendHighlightedSegment(lastEnd, text.length);
 
-    return RichText(text: TextSpan(children: spans));
+    return Text.rich(TextSpan(children: spans));
   }
 
   /// Builds spans for [segment], highlighting query token matches when a

--- a/lib/screens/widgets/linked_message_text.dart
+++ b/lib/screens/widgets/linked_message_text.dart
@@ -42,24 +42,18 @@ class LinkedMessageText extends StatelessWidget {
 
   Widget _buildLinkedText(BuildContext context) {
     final query = highlightQuery?.trim().toLowerCase();
-    if (query != null && query.length >= 2) {
-      return _buildHighlightedPlainText(context, query);
-    }
-
     final matches = UrlDetector.urlRegex.allMatches(text).toList();
-    if (matches.isEmpty) {
-      return Text(text, style: TextStyle(color: textColor, fontSize: fontSize));
-    }
-
     final spans = <InlineSpan>[];
     var lastEnd = 0;
 
+    void appendHighlightedSegment(int start, int end) {
+      if (end <= start) return;
+      spans.addAll(_highlightSpans(text.substring(start, end), query: query));
+    }
+
     for (final match in matches) {
       if (match.start > lastEnd) {
-        spans.add(TextSpan(
-          text: text.substring(lastEnd, match.start),
-          style: TextStyle(color: textColor, fontSize: fontSize),
-        ));
+        appendHighlightedSegment(lastEnd, match.start);
       }
       final url = match.group(0)!;
       spans.add(WidgetSpan(
@@ -85,23 +79,31 @@ class LinkedMessageText extends StatelessWidget {
       lastEnd = match.end;
     }
 
-    if (lastEnd < text.length) {
-      spans.add(TextSpan(
-        text: text.substring(lastEnd),
-        style: TextStyle(color: textColor, fontSize: fontSize),
-      ));
-    }
+    appendHighlightedSegment(lastEnd, text.length);
 
     return RichText(text: TextSpan(children: spans));
   }
 
-  Widget _buildHighlightedPlainText(BuildContext context, String query) {
-    final lower = text.toLowerCase();
-    final tokens = query.split(RegExp(r'\s+')).where((t) => t.isNotEmpty).toList();
+  /// Builds spans for [segment], highlighting query token matches when a
+  /// non-empty query is active. [query] is pre-lowercased by the caller.
+  List<TextSpan> _highlightSpans(String segment, {String? query}) {
+    final highlight = query != null && query.length >= 2;
+    if (!highlight) {
+      return [
+        TextSpan(
+          text: segment,
+          style: TextStyle(color: textColor, fontSize: fontSize),
+        ),
+      ];
+    }
+
+    final lower = segment.toLowerCase();
+    final tokens =
+        query.split(RegExp(r'\s+')).where((t) => t.isNotEmpty).toList();
     final spans = <TextSpan>[];
     var cursor = 0;
 
-    while (cursor < text.length) {
+    while (cursor < segment.length) {
       var nextMatch = -1;
       var matchLen = 0;
       for (final token in tokens) {
@@ -113,19 +115,19 @@ class LinkedMessageText extends StatelessWidget {
       }
       if (nextMatch < 0) {
         spans.add(TextSpan(
-          text: text.substring(cursor),
+          text: segment.substring(cursor),
           style: TextStyle(color: textColor, fontSize: fontSize),
         ));
         break;
       }
       if (nextMatch > cursor) {
         spans.add(TextSpan(
-          text: text.substring(cursor, nextMatch),
+          text: segment.substring(cursor, nextMatch),
           style: TextStyle(color: textColor, fontSize: fontSize),
         ));
       }
       spans.add(TextSpan(
-        text: text.substring(nextMatch, nextMatch + matchLen),
+        text: segment.substring(nextMatch, nextMatch + matchLen),
         style: TextStyle(
           color: textColor,
           fontSize: fontSize,
@@ -135,6 +137,6 @@ class LinkedMessageText extends StatelessWidget {
       cursor = nextMatch + matchLen;
     }
 
-    return RichText(text: TextSpan(children: spans));
+    return spans;
   }
 }

--- a/lib/screens/widgets/linked_message_text.dart
+++ b/lib/screens/widgets/linked_message_text.dart
@@ -10,12 +10,14 @@ class LinkedMessageText extends StatelessWidget {
   final Color textColor;
   final double fontSize;
   final Future<void> Function(String url) onOpenUrl;
+  final String? highlightQuery;
 
   const LinkedMessageText({
     required this.text,
     required this.textColor,
     required this.fontSize,
     required this.onOpenUrl,
+    this.highlightQuery,
     super.key,
   });
 
@@ -39,6 +41,11 @@ class LinkedMessageText extends StatelessWidget {
   }
 
   Widget _buildLinkedText(BuildContext context) {
+    final query = highlightQuery?.trim().toLowerCase();
+    if (query != null && query.length >= 2) {
+      return _buildHighlightedPlainText(context, query);
+    }
+
     final matches = UrlDetector.urlRegex.allMatches(text).toList();
     if (matches.isEmpty) {
       return Text(text, style: TextStyle(color: textColor, fontSize: fontSize));
@@ -83,6 +90,49 @@ class LinkedMessageText extends StatelessWidget {
         text: text.substring(lastEnd),
         style: TextStyle(color: textColor, fontSize: fontSize),
       ));
+    }
+
+    return RichText(text: TextSpan(children: spans));
+  }
+
+  Widget _buildHighlightedPlainText(BuildContext context, String query) {
+    final lower = text.toLowerCase();
+    final tokens = query.split(RegExp(r'\s+')).where((t) => t.isNotEmpty).toList();
+    final spans = <TextSpan>[];
+    var cursor = 0;
+
+    while (cursor < text.length) {
+      var nextMatch = -1;
+      var matchLen = 0;
+      for (final token in tokens) {
+        final idx = lower.indexOf(token, cursor);
+        if (idx >= 0 && (nextMatch < 0 || idx < nextMatch)) {
+          nextMatch = idx;
+          matchLen = token.length;
+        }
+      }
+      if (nextMatch < 0) {
+        spans.add(TextSpan(
+          text: text.substring(cursor),
+          style: TextStyle(color: textColor, fontSize: fontSize),
+        ));
+        break;
+      }
+      if (nextMatch > cursor) {
+        spans.add(TextSpan(
+          text: text.substring(cursor, nextMatch),
+          style: TextStyle(color: textColor, fontSize: fontSize),
+        ));
+      }
+      spans.add(TextSpan(
+        text: text.substring(nextMatch, nextMatch + matchLen),
+        style: TextStyle(
+          color: textColor,
+          fontSize: fontSize,
+          backgroundColor: textColor.withValues(alpha: 0.25),
+        ),
+      ));
+      cursor = nextMatch + matchLen;
     }
 
     return RichText(text: TextSpan(children: spans));

--- a/lib/server/inbound_message_router.dart
+++ b/lib/server/inbound_message_router.dart
@@ -674,10 +674,13 @@ class InboundMessageRouter {
     }
 
     if (inserted != null && inserted['status'] != 'pending_auth') {
-      await MessageSearchIndexService(
-        keyManager: keyManager,
-        userId: localId,
-      ).indexInboundRow(inserted, localId);
+      final row = inserted;
+      await MessageSearchIndexService.indexBestEffort(
+        () => MessageSearchIndexService(
+          keyManager: keyManager,
+          userId: localId,
+        ).indexInboundRow(row, localId),
+      );
 
       InboundMessageNotifier.instance.notify(
         InboundMessageEvent.fromRow(inserted),

--- a/lib/server/inbound_message_router.dart
+++ b/lib/server/inbound_message_router.dart
@@ -9,6 +9,7 @@ import 'package:prysm/services/block_service.dart';
 import 'package:prysm/services/disappearing_timer_service.dart';
 import 'package:prysm/services/group_service.dart';
 import 'package:prysm/services/message_modify_service.dart';
+import 'package:prysm/services/message_search_index_service.dart';
 import 'package:prysm/services/notification_mute_service.dart';
 import 'package:prysm/services/pending_notification_route.dart';
 import 'package:prysm/services/reaction_service.dart';
@@ -376,6 +377,7 @@ class InboundMessageRouter {
     try {
       await MessageModifyService.applyInbound(
         keyManager: keyManager,
+        localUserId: localId,
         encrypted: data['message'] as String,
         senderId: senderId,
         type: type,
@@ -672,6 +674,11 @@ class InboundMessageRouter {
     }
 
     if (inserted != null && inserted['status'] != 'pending_auth') {
+      await MessageSearchIndexService(
+        keyManager: keyManager,
+        userId: localId,
+      ).indexInboundRow(inserted, localId);
+
       InboundMessageNotifier.instance.notify(
         InboundMessageEvent.fromRow(inserted),
       );

--- a/lib/services/chat_service.dart
+++ b/lib/services/chat_service.dart
@@ -15,6 +15,7 @@ import 'package:prysm/services/side_channel_postman.dart';
 import 'package:prysm/transport/transport_provider.dart';
 import 'package:prysm/services/block_service.dart';
 import 'package:prysm/services/disappearing_timer_service.dart';
+import 'package:prysm/services/message_search_index_service.dart';
 import 'package:prysm/util/battery_saver_policy.dart';
 import 'package:prysm/util/disappearing_activity_notifier.dart';
 import 'package:prysm/util/file_transfer_policy.dart';
@@ -239,6 +240,16 @@ class ChatService {
       'expiresAt': ?expiresAt,
     }, notifyListeners: false);
 
+    await MessageSearchIndexService(
+      keyManager: keyManager,
+      userId: userId,
+    ).indexOutboundDirectText(
+      messageId: id,
+      peerId: peerId,
+      timestamp: timestamp,
+      plaintext: text,
+    );
+
     if (expiresAt != null) {
       DisappearingActivityNotifier.instance.notify();
     }
@@ -322,11 +333,18 @@ class ChatService {
       'expiresAt': ?expiresAt,
     }, notifyListeners: false);
 
-    if (expiresAt != null) {
-      DisappearingActivityNotifier.instance.notify();
-    }
+    await MessageSearchIndexService(
+      keyManager: keyManager,
+      userId: userId,
+    ).indexOutboundFile(
+      messageId: id,
+      conversationId: peerId,
+      scope: 'direct',
+      timestamp: timestamp,
+      fileName: fileName,
+    );
 
-    if (TransportProvider.isConfigured) {
+    if (expiresAt != null) {
       final wsConnected =
           TransportProvider.instance.isRealtimeConnected(peerId);
       final peerSupports = TransportProvider.instance.wsManager

--- a/lib/services/chat_service.dart
+++ b/lib/services/chat_service.dart
@@ -335,18 +335,22 @@ class ChatService {
       'expiresAt': ?expiresAt,
     }, notifyListeners: false);
 
-    await MessageSearchIndexService.indexBestEffort(
-      () => MessageSearchIndexService(
-        keyManager: keyManager,
-        userId: userId,
-      ).indexOutboundFile(
-        messageId: id,
-        conversationId: peerId,
-        scope: 'direct',
-        timestamp: timestamp,
-        fileName: fileName,
-      ),
-    );
+    // ponytail: guard instead of a viewOnce param on indexOutboundFile — the
+    // sender of a view-once file can never open it, so its name stays indexed.
+    if (!viewOnce) {
+      await MessageSearchIndexService.indexBestEffort(
+        () => MessageSearchIndexService(
+          keyManager: keyManager,
+          userId: userId,
+        ).indexOutboundFile(
+          messageId: id,
+          conversationId: peerId,
+          scope: 'direct',
+          timestamp: timestamp,
+          fileName: fileName,
+        ),
+      );
+    }
 
     if (expiresAt != null) {
       DisappearingActivityNotifier.instance.notify();

--- a/lib/services/chat_service.dart
+++ b/lib/services/chat_service.dart
@@ -352,10 +352,11 @@ class ChatService {
       DisappearingActivityNotifier.instance.notify();
     }
 
-    final wsConnected =
+    final wsConnected = TransportProvider.isConfigured &&
         TransportProvider.instance.isRealtimeConnected(peerId);
-    final peerSupports = TransportProvider.instance.wsManager
-        .peerSupportsFileTransfer(peerId);
+    final peerSupports = TransportProvider.isConfigured &&
+        TransportProvider.instance.wsManager
+            .peerSupportsFileTransfer(peerId);
     if (FileTransferPolicy.shouldUseChunkedTransfer(
       fileSizeBytes: bytes.length,
       wsConnected: wsConnected,

--- a/lib/services/chat_service.dart
+++ b/lib/services/chat_service.dart
@@ -240,14 +240,16 @@ class ChatService {
       'expiresAt': ?expiresAt,
     }, notifyListeners: false);
 
-    await MessageSearchIndexService(
-      keyManager: keyManager,
-      userId: userId,
-    ).indexOutboundDirectText(
-      messageId: id,
-      peerId: peerId,
-      timestamp: timestamp,
-      plaintext: text,
+    await MessageSearchIndexService.indexBestEffort(
+      () => MessageSearchIndexService(
+        keyManager: keyManager,
+        userId: userId,
+      ).indexOutboundDirectText(
+        messageId: id,
+        peerId: peerId,
+        timestamp: timestamp,
+        plaintext: text,
+      ),
     );
 
     if (expiresAt != null) {
@@ -333,29 +335,33 @@ class ChatService {
       'expiresAt': ?expiresAt,
     }, notifyListeners: false);
 
-    await MessageSearchIndexService(
-      keyManager: keyManager,
-      userId: userId,
-    ).indexOutboundFile(
-      messageId: id,
-      conversationId: peerId,
-      scope: 'direct',
-      timestamp: timestamp,
-      fileName: fileName,
+    await MessageSearchIndexService.indexBestEffort(
+      () => MessageSearchIndexService(
+        keyManager: keyManager,
+        userId: userId,
+      ).indexOutboundFile(
+        messageId: id,
+        conversationId: peerId,
+        scope: 'direct',
+        timestamp: timestamp,
+        fileName: fileName,
+      ),
     );
 
     if (expiresAt != null) {
-      final wsConnected =
-          TransportProvider.instance.isRealtimeConnected(peerId);
-      final peerSupports = TransportProvider.instance.wsManager
-          .peerSupportsFileTransfer(peerId);
-      if (FileTransferPolicy.shouldUseChunkedTransfer(
-        fileSizeBytes: bytes.length,
-        wsConnected: wsConnected,
-        peerSupportsFileTransfer: peerSupports,
-      )) {
-        FileTransferProgress.uploadNotifier(id);
-      }
+      DisappearingActivityNotifier.instance.notify();
+    }
+
+    final wsConnected =
+        TransportProvider.instance.isRealtimeConnected(peerId);
+    final peerSupports = TransportProvider.instance.wsManager
+        .peerSupportsFileTransfer(peerId);
+    if (FileTransferPolicy.shouldUseChunkedTransfer(
+      fileSizeBytes: bytes.length,
+      wsConnected: wsConnected,
+      peerSupportsFileTransfer: peerSupports,
+    )) {
+      FileTransferProgress.uploadNotifier(id);
     }
 
     final success = await _sendOverTor(

--- a/lib/services/group_chat_service.dart
+++ b/lib/services/group_chat_service.dart
@@ -279,19 +279,21 @@ class GroupChatService {
       'expiresAt': ?expiresAt,
     });
 
-    await MessageSearchIndexService.indexBestEffort(
-      () => MessageSearchIndexService(
-        keyManager: keyManager,
-        userId: userId,
-        groupService: groupService,
-      ).indexOutboundFile(
-        messageId: id,
-        conversationId: groupId,
-        scope: 'group',
-        timestamp: timestamp,
-        fileName: fileName,
-      ),
-    );
+    if (!viewOnce) {
+      await MessageSearchIndexService.indexBestEffort(
+        () => MessageSearchIndexService(
+          keyManager: keyManager,
+          userId: userId,
+          groupService: groupService,
+        ).indexOutboundFile(
+          messageId: id,
+          conversationId: groupId,
+          scope: 'group',
+          timestamp: timestamp,
+          fileName: fileName,
+        ),
+      );
+    }
 
     if (expiresAt != null) {
       DisappearingActivityNotifier.instance.notify();

--- a/lib/services/group_chat_service.dart
+++ b/lib/services/group_chat_service.dart
@@ -6,6 +6,7 @@ import 'package:prysm/constants/group_constants.dart';
 import 'package:prysm/database/messages.dart';
 import 'package:prysm/crypto/group_crypto.dart';
 import 'package:prysm/services/disappearing_timer_service.dart';
+import 'package:prysm/services/message_search_index_service.dart';
 import 'package:prysm/services/group_service.dart';
 import 'package:prysm/services/side_channel_postman.dart';
 import 'package:prysm/util/battery_saver_policy.dart';
@@ -177,6 +178,17 @@ class GroupChatService {
       'expiresAt': ?expiresAt,
     });
 
+    await MessageSearchIndexService(
+      keyManager: keyManager,
+      userId: userId,
+      groupService: groupService,
+    ).indexOutboundGroupText(
+      messageId: id,
+      groupId: groupId,
+      timestamp: timestamp,
+      plaintext: text,
+    );
+
     if (expiresAt != null) {
       DisappearingActivityNotifier.instance.notify();
     }
@@ -264,6 +276,18 @@ class GroupChatService {
       'viewOnce': viewOnce ? 1 : 0,
       'expiresAt': ?expiresAt,
     });
+
+    await MessageSearchIndexService(
+      keyManager: keyManager,
+      userId: userId,
+      groupService: groupService,
+    ).indexOutboundFile(
+      messageId: id,
+      conversationId: groupId,
+      scope: 'group',
+      timestamp: timestamp,
+      fileName: fileName,
+    );
 
     if (expiresAt != null) {
       DisappearingActivityNotifier.instance.notify();

--- a/lib/services/group_chat_service.dart
+++ b/lib/services/group_chat_service.dart
@@ -178,15 +178,17 @@ class GroupChatService {
       'expiresAt': ?expiresAt,
     });
 
-    await MessageSearchIndexService(
-      keyManager: keyManager,
-      userId: userId,
-      groupService: groupService,
-    ).indexOutboundGroupText(
-      messageId: id,
-      groupId: groupId,
-      timestamp: timestamp,
-      plaintext: text,
+    await MessageSearchIndexService.indexBestEffort(
+      () => MessageSearchIndexService(
+        keyManager: keyManager,
+        userId: userId,
+        groupService: groupService,
+      ).indexOutboundGroupText(
+        messageId: id,
+        groupId: groupId,
+        timestamp: timestamp,
+        plaintext: text,
+      ),
     );
 
     if (expiresAt != null) {
@@ -277,16 +279,18 @@ class GroupChatService {
       'expiresAt': ?expiresAt,
     });
 
-    await MessageSearchIndexService(
-      keyManager: keyManager,
-      userId: userId,
-      groupService: groupService,
-    ).indexOutboundFile(
-      messageId: id,
-      conversationId: groupId,
-      scope: 'group',
-      timestamp: timestamp,
-      fileName: fileName,
+    await MessageSearchIndexService.indexBestEffort(
+      () => MessageSearchIndexService(
+        keyManager: keyManager,
+        userId: userId,
+        groupService: groupService,
+      ).indexOutboundFile(
+        messageId: id,
+        conversationId: groupId,
+        scope: 'group',
+        timestamp: timestamp,
+        fileName: fileName,
+      ),
     );
 
     if (expiresAt != null) {

--- a/lib/services/message_modify_service.dart
+++ b/lib/services/message_modify_service.dart
@@ -12,6 +12,7 @@ import 'package:prysm/crypto/group_crypto.dart';
 import 'package:prysm/util/db_helper.dart';
 import 'package:prysm/util/key_manager.dart';
 import 'package:prysm/util/message_content_wiper.dart';
+import 'package:prysm/services/message_search_index_service.dart';
 import 'package:prysm/util/message_modify_payload.dart';
 import 'package:prysm/util/message_modify_refresh_notifier.dart';
 import 'package:prysm/util/pending_message_db_helper.dart';
@@ -145,6 +146,21 @@ class MessageModifyService {
       editedAt: modifiedAt,
     );
 
+    final rows = await MessagesDb.getMessageById(targetMessageId);
+    final timestamp = rows.isNotEmpty
+        ? rows.first['timestamp'] as int
+        : modifiedAt;
+    await MessageSearchIndexService(
+      keyManager: keyManager,
+      userId: userId,
+    ).reindexEditedMessage(
+      messageId: targetMessageId,
+      conversationId: peerId!,
+      scope: 'direct',
+      timestamp: timestamp,
+      plaintext: newText,
+    );
+
     _notifyEdit(targetMessageId, newText, modifiedAt);
 
     final payload = MessageModifyPayload(
@@ -180,6 +196,25 @@ class MessageModifyService {
       groupId: groupId,
       encryptedMessage: encrypted,
       editedAt: modifiedAt,
+    );
+
+    final rows = await MessagesDb.getMessageById(
+      targetMessageId,
+      groupId: groupId,
+    );
+    final timestamp = rows.isNotEmpty
+        ? rows.first['timestamp'] as int
+        : modifiedAt;
+    await MessageSearchIndexService(
+      keyManager: keyManager,
+      userId: userId,
+      groupService: gs,
+    ).reindexEditedMessage(
+      messageId: targetMessageId,
+      conversationId: groupId!,
+      scope: 'group',
+      timestamp: timestamp,
+      plaintext: newText,
     );
 
     _notifyEdit(targetMessageId, newText, modifiedAt);
@@ -340,6 +375,7 @@ class MessageModifyService {
 
   static Future<void> applyInbound({
     required KeyManager keyManager,
+    required String localUserId,
     required String encrypted,
     required String senderId,
     required String type,
@@ -391,6 +427,19 @@ class MessageModifyService {
         groupId: groupId,
         groupService: groupService,
       );
+      if (newText != null) {
+        await MessageSearchIndexService(
+          keyManager: keyManager,
+          userId: localUserId,
+          groupService: groupService,
+        ).reindexEditedMessage(
+          messageId: payload.targetMessageId,
+          conversationId: groupId ?? senderId,
+          scope: groupId != null ? 'group' : 'direct',
+          timestamp: row['timestamp'] as int,
+          plaintext: newText,
+        );
+      }
     }
 
     MessageModifyRefreshNotifier.instance.notify(

--- a/lib/services/message_modify_service.dart
+++ b/lib/services/message_modify_service.dart
@@ -150,15 +150,17 @@ class MessageModifyService {
     final timestamp = rows.isNotEmpty
         ? rows.first['timestamp'] as int
         : modifiedAt;
-    await MessageSearchIndexService(
-      keyManager: keyManager,
-      userId: userId,
-    ).reindexEditedMessage(
-      messageId: targetMessageId,
-      conversationId: peerId!,
-      scope: 'direct',
-      timestamp: timestamp,
-      plaintext: newText,
+    await MessageSearchIndexService.indexBestEffort(
+      () => MessageSearchIndexService(
+        keyManager: keyManager,
+        userId: userId,
+      ).reindexEditedMessage(
+        messageId: targetMessageId,
+        conversationId: peerId!,
+        scope: 'direct',
+        timestamp: timestamp,
+        plaintext: newText,
+      ),
     );
 
     _notifyEdit(targetMessageId, newText, modifiedAt);
@@ -205,16 +207,18 @@ class MessageModifyService {
     final timestamp = rows.isNotEmpty
         ? rows.first['timestamp'] as int
         : modifiedAt;
-    await MessageSearchIndexService(
-      keyManager: keyManager,
-      userId: userId,
-      groupService: gs,
-    ).reindexEditedMessage(
-      messageId: targetMessageId,
-      conversationId: groupId!,
-      scope: 'group',
-      timestamp: timestamp,
-      plaintext: newText,
+    await MessageSearchIndexService.indexBestEffort(
+      () => MessageSearchIndexService(
+        keyManager: keyManager,
+        userId: userId,
+        groupService: gs,
+      ).reindexEditedMessage(
+        messageId: targetMessageId,
+        conversationId: groupId!,
+        scope: 'group',
+        timestamp: timestamp,
+        plaintext: newText,
+      ),
     );
 
     _notifyEdit(targetMessageId, newText, modifiedAt);
@@ -428,16 +432,19 @@ class MessageModifyService {
         groupService: groupService,
       );
       if (newText != null) {
-        await MessageSearchIndexService(
-          keyManager: keyManager,
-          userId: localUserId,
-          groupService: groupService,
-        ).reindexEditedMessage(
-          messageId: payload.targetMessageId,
-          conversationId: groupId ?? senderId,
-          scope: groupId != null ? 'group' : 'direct',
-          timestamp: row['timestamp'] as int,
-          plaintext: newText,
+        final indexedText = newText;
+        await MessageSearchIndexService.indexBestEffort(
+          () => MessageSearchIndexService(
+            keyManager: keyManager,
+            userId: localUserId,
+            groupService: groupService,
+          ).reindexEditedMessage(
+            messageId: payload.targetMessageId,
+            conversationId: groupId ?? senderId,
+            scope: groupId != null ? 'group' : 'direct',
+            timestamp: row['timestamp'] as int,
+            plaintext: indexedText,
+          ),
         );
       }
     }

--- a/lib/services/message_search_backfill_service.dart
+++ b/lib/services/message_search_backfill_service.dart
@@ -6,7 +6,6 @@ import 'package:prysm/services/message_search_index_service.dart';
 import 'package:prysm/services/settings_service.dart';
 import 'package:prysm/util/key_manager.dart';
 import 'package:prysm/util/logging.dart';
-import 'package:prysm/util/message_blob_store.dart';
 
 abstract class MessageSearchBackfillStore {
   Future<bool> isSearchBackfillComplete();
@@ -169,6 +168,9 @@ class MessageSearchBackfillService {
               '$messageId after $failures attempts',
               'MessageSearchBackfill',
             );
+          } else {
+            await _settings
+                .setSearchBackfillFailureCount(row['id'] as String, 0);
           }
           lastProcessed = row;
           continue;
@@ -215,6 +217,8 @@ class MessageSearchBackfillService {
             '$messageId after $failures attempts',
             'MessageSearchBackfill',
           );
+        } else {
+          await _settings.setSearchBackfillFailureCount(row['id'] as String, 0);
         }
         lastProcessed = row;
       }
@@ -251,7 +255,7 @@ class MessageSearchBackfillService {
       SELECT $_messageColumns
       FROM messages
       WHERE deletedAt IS NULL
-        AND (viewOnce IS NULL OR viewOnce = 0 OR viewed IS NULL OR viewed = 0)
+        AND (viewOnce IS NULL OR viewOnce = 0)
         AND (
           ${_typeInClause([
         ...MessageSearchIndexService.searchableDirectTypes,
@@ -274,7 +278,7 @@ class MessageSearchBackfillService {
         _batchSize,
       ],
     );
-    return _resolveMessageBlobs(rows);
+    return rows;
   }
 
   Future<List<Map<String, dynamic>>> _fetchSelfBatch(
@@ -287,7 +291,7 @@ class MessageSearchBackfillService {
       SELECT $_selfColumns
       FROM self_messages
       WHERE deletedAt IS NULL
-        AND (viewOnce IS NULL OR viewOnce = 0 OR viewed IS NULL OR viewed = 0)
+        AND (viewOnce IS NULL OR viewOnce = 0)
         AND (
           ${_typeInClause(MessageSearchIndexService.searchableDirectTypes)}
         )
@@ -306,20 +310,6 @@ class MessageSearchBackfillService {
         _batchSize,
       ],
     );
-    return _resolveMessageBlobs(rows);
-  }
-
-  /// Resolves `blob:` payload markers back into the original message payload
-  /// so decryption downstream receives the full ciphertext.
-  static Future<List<Map<String, dynamic>>> _resolveMessageBlobs(
-    List<Map<String, dynamic>> rows,
-  ) async {
-    for (final row in rows) {
-      final wire = row['message'] as String?;
-      if (wire != null && MessageBlobStore.isMarker(wire)) {
-        row['message'] = await MessageBlobStore.resolve(wire);
-      }
-    }
     return rows;
   }
 }

--- a/lib/services/message_search_backfill_service.dart
+++ b/lib/services/message_search_backfill_service.dart
@@ -1,6 +1,7 @@
 import 'package:prysm/database/message_id_codec.dart';
 import 'package:prysm/database/message_search_dao.dart';
 import 'package:prysm/database/messages.dart';
+import 'package:prysm/models/conversation.dart';
 import 'package:prysm/services/message_search_index_service.dart';
 import 'package:prysm/services/settings_service.dart';
 import 'package:prysm/util/key_manager.dart';
@@ -133,17 +134,63 @@ class MessageSearchBackfillService {
 
       var lastProcessed = <String, dynamic>{};
       for (final row in batch) {
-        final messageId = phase == 'self'
-            ? row['id'] as String
-            : MessageIdCodec.wireIdFromStorage(row['id'] as String);
-        if (await _searchDao.exists(messageId)) {
+        if (phase == 'self') {
+          final messageId = row['id'] as String;
+          if (await _searchDao.exists(
+            messageId: messageId,
+            conversationId: SelfConversation.conversationId,
+            scope: 'self',
+          )) {
+            lastProcessed = row;
+            continue;
+          }
+          final ok = await indexService.indexSelfRow(row);
+          if (!ok) {
+            final rowKey = row['id'] as String;
+            final failures =
+                await _settings.getSearchBackfillFailureCount(rowKey) + 1;
+            await _settings.setSearchBackfillFailureCount(rowKey, failures);
+            if (failures < _maxRowRetries) {
+              Logging.error(
+                'Search backfill failed for $messageId '
+                '($failures/$_maxRowRetries attempts), retrying next run',
+                'MessageSearchBackfill',
+              );
+              if (lastProcessed.isNotEmpty) {
+                await _settings.setSearchBackfillCursor(
+                  timestamp: lastProcessed['timestamp'] as int,
+                  id: lastProcessed['id'] as String,
+                );
+              }
+              return;
+            }
+            Logging.error(
+              'Search backfill permanently skipping un-indexable row '
+              '$messageId after $failures attempts',
+              'MessageSearchBackfill',
+            );
+          }
           lastProcessed = row;
           continue;
         }
 
-        final ok = phase == 'self'
-            ? await indexService.indexSelfRow(row)
-            : await indexService.indexInboundRow(row, userId);
+        final messageId = MessageIdCodec.wireIdFromStorage(row['id'] as String);
+        final groupId = row['groupId'] as String?;
+        final conversationId = groupId ??
+            (row['senderId'] == userId
+                ? row['receiverId'] as String
+                : row['senderId'] as String);
+        final scope = groupId != null ? 'group' : 'direct';
+        if (await _searchDao.exists(
+          messageId: messageId,
+          conversationId: conversationId,
+          scope: scope,
+        )) {
+          lastProcessed = row;
+          continue;
+        }
+
+        final ok = await indexService.indexInboundRow(row, userId);
         if (!ok) {
           final rowKey = row['id'] as String;
           final failures =

--- a/lib/services/message_search_backfill_service.dart
+++ b/lib/services/message_search_backfill_service.dart
@@ -1,0 +1,204 @@
+import 'package:prysm/constants/group_constants.dart';
+import 'package:prysm/database/message_id_codec.dart';
+import 'package:prysm/database/message_search_dao.dart';
+import 'package:prysm/database/messages.dart';
+import 'package:prysm/services/message_search_index_service.dart';
+import 'package:prysm/services/settings_service.dart';
+import 'package:prysm/util/key_manager.dart';
+import 'package:prysm/util/logging.dart';
+import 'package:sqflite/sqflite.dart';
+
+abstract class MessageSearchBackfillStore {
+  Future<bool> isSearchBackfillComplete();
+  Future<void> setSearchBackfillComplete(bool value);
+  Future<String> getSearchBackfillPhase();
+  Future<void> setSearchBackfillPhase(String phase);
+  Future<int> getSearchBackfillCursorTimestamp();
+  Future<String> getSearchBackfillCursorId();
+  Future<void> setSearchBackfillCursor({
+    required int timestamp,
+    required String id,
+  });
+}
+
+class SettingsMessageSearchBackfillStore implements MessageSearchBackfillStore {
+  SettingsMessageSearchBackfillStore(this._settings);
+
+  final SettingsService _settings;
+
+  @override
+  Future<bool> isSearchBackfillComplete() => _settings.isSearchBackfillComplete();
+
+  @override
+  Future<void> setSearchBackfillComplete(bool value) =>
+      _settings.setSearchBackfillComplete(value);
+
+  @override
+  Future<String> getSearchBackfillPhase() => _settings.getSearchBackfillPhase();
+
+  @override
+  Future<void> setSearchBackfillPhase(String phase) =>
+      _settings.setSearchBackfillPhase(phase);
+
+  @override
+  Future<int> getSearchBackfillCursorTimestamp() =>
+      _settings.getSearchBackfillCursorTimestamp();
+
+  @override
+  Future<String> getSearchBackfillCursorId() =>
+      _settings.getSearchBackfillCursorId();
+
+  @override
+  Future<void> setSearchBackfillCursor({
+    required int timestamp,
+    required String id,
+  }) =>
+      _settings.setSearchBackfillCursor(timestamp: timestamp, id: id);
+}
+
+/// Backfills the FTS index for messages stored before search was enabled.
+class MessageSearchBackfillService {
+  MessageSearchBackfillService({
+    required this.keyManager,
+    required this.userId,
+    MessageSearchDao? searchDao,
+    MessageSearchBackfillStore? store,
+  })  : _searchDao = searchDao ?? const MessageSearchDao(),
+        _settings = store ?? SettingsMessageSearchBackfillStore(SettingsService());
+
+  final KeyManager keyManager;
+  final String userId;
+  final MessageSearchDao _searchDao;
+  final MessageSearchBackfillStore _settings;
+
+  static const _batchSize = 200;
+  bool _running = false;
+
+  Future<void> startIfNeeded() async {
+    if (_running) return;
+    if (await _settings.isSearchBackfillComplete()) return;
+    _running = true;
+    try {
+      await _run();
+    } finally {
+      _running = false;
+    }
+  }
+
+  Future<void> _run() async {
+    final indexService = MessageSearchIndexService(
+      keyManager: keyManager,
+      userId: userId,
+      dao: _searchDao,
+    );
+
+    var phase = await _settings.getSearchBackfillPhase();
+    var cursorTs = await _settings.getSearchBackfillCursorTimestamp();
+    var cursorId = await _settings.getSearchBackfillCursorId();
+
+    while (phase != 'done') {
+      final batch = phase == 'self'
+          ? await _fetchSelfBatch(cursorTs, cursorId)
+          : await _fetchMessagesBatch(cursorTs, cursorId);
+      if (batch.isEmpty) {
+        if (phase == 'messages') {
+          phase = 'self';
+          cursorTs = 0;
+          cursorId = '';
+          await _settings.setSearchBackfillPhase(phase);
+          await _settings.setSearchBackfillCursor(timestamp: 0, id: '');
+          continue;
+        }
+        await _settings.setSearchBackfillComplete(true);
+        return;
+      }
+
+      for (final row in batch) {
+        final messageId = phase == 'self'
+            ? row['id'] as String
+            : MessageIdCodec.wireIdFromStorage(row['id'] as String);
+        if (await _searchDao.exists(messageId)) continue;
+
+        try {
+          if (phase == 'self') {
+            await indexService.indexSelfRow(row);
+          } else {
+            await indexService.indexInboundRow(row, userId);
+          }
+        } catch (e) {
+          Logging.error(
+            'Search backfill failed for $messageId: $e',
+            'MessageSearchBackfill',
+          );
+        }
+      }
+
+      final last = batch.last;
+      cursorTs = last['timestamp'] as int;
+      cursorId = last['id'] as String;
+      await _settings.setSearchBackfillCursor(
+        timestamp: cursorTs,
+        id: cursorId,
+      );
+      await Future<void>.delayed(const Duration(milliseconds: 16));
+    }
+  }
+
+  Future<List<Map<String, dynamic>>> _fetchMessagesBatch(
+    int cursorTs,
+    String cursorId,
+  ) async {
+    final db = await MessagesDb.database;
+    return db.rawQuery(
+      '''
+      SELECT *
+      FROM messages
+      WHERE deletedAt IS NULL
+        AND (viewOnce IS NULL OR viewOnce = 0 OR viewed IS NULL OR viewed = 0)
+        AND (
+          type IS NULL
+          OR type IN ('text', 'file', 'image', 'audio', ?, ?, ?, ?)
+        )
+        AND (
+          timestamp > ?
+          OR (timestamp = ? AND id > ?)
+        )
+      ORDER BY timestamp ASC, id ASC
+      LIMIT ?
+      ''',
+      [
+        groupTextType,
+        groupImageType,
+        groupFileType,
+        groupAudioType,
+        cursorTs,
+        cursorTs,
+        cursorId,
+        _batchSize,
+      ],
+    );
+  }
+
+  Future<List<Map<String, dynamic>>> _fetchSelfBatch(
+    int cursorTs,
+    String cursorId,
+  ) async {
+    final db = await MessagesDb.database;
+    return db.rawQuery(
+      '''
+      SELECT *
+      FROM self_messages
+      WHERE deletedAt IS NULL
+        AND (viewOnce IS NULL OR viewOnce = 0 OR viewed IS NULL OR viewed = 0)
+        AND (type IS NULL OR type IN ('text', 'file', 'image', 'audio'))
+        AND (
+          timestamp > ?
+          OR (timestamp = ? AND id > ?)
+        )
+      ORDER BY timestamp ASC, id ASC
+      LIMIT ?
+      ''',
+      [cursorTs, cursorTs, cursorId, _batchSize],
+    );
+  }
+}

--- a/lib/services/message_search_backfill_service.dart
+++ b/lib/services/message_search_backfill_service.dart
@@ -1,4 +1,3 @@
-import 'package:prysm/constants/group_constants.dart';
 import 'package:prysm/database/message_id_codec.dart';
 import 'package:prysm/database/message_search_dao.dart';
 import 'package:prysm/database/messages.dart';
@@ -6,6 +5,8 @@ import 'package:prysm/services/message_search_index_service.dart';
 import 'package:prysm/services/settings_service.dart';
 import 'package:prysm/util/key_manager.dart';
 import 'package:prysm/util/logging.dart';
+import 'package:prysm/util/message_blob_store.dart';
+
 abstract class MessageSearchBackfillStore {
   Future<bool> isSearchBackfillComplete();
   Future<void> setSearchBackfillComplete(bool value);
@@ -17,6 +18,8 @@ abstract class MessageSearchBackfillStore {
     required int timestamp,
     required String id,
   });
+  Future<int> getSearchBackfillFailureCount(String rowKey);
+  Future<void> setSearchBackfillFailureCount(String rowKey, int count);
 }
 
 class SettingsMessageSearchBackfillStore implements MessageSearchBackfillStore {
@@ -52,6 +55,14 @@ class SettingsMessageSearchBackfillStore implements MessageSearchBackfillStore {
     required String id,
   }) =>
       _settings.setSearchBackfillCursor(timestamp: timestamp, id: id);
+
+  @override
+  Future<int> getSearchBackfillFailureCount(String rowKey) =>
+      _settings.getSearchBackfillFailureCount(rowKey);
+
+  @override
+  Future<void> setSearchBackfillFailureCount(String rowKey, int count) =>
+      _settings.setSearchBackfillFailureCount(rowKey, count);
 }
 
 /// Backfills the FTS index for messages stored before search was enabled.
@@ -70,7 +81,14 @@ class MessageSearchBackfillService {
   final MessageSearchBackfillStore _settings;
 
   static const _batchSize = 200;
-  bool _running = false;
+
+  /// Attempts before an un-indexable row is skipped permanently so backfill
+  /// completion is never blocked forever.
+  static const _maxRowRetries = 5;
+
+  /// Shared across instances so overlapping startIfNeeded calls observe the
+  /// same guard.
+  static bool _running = false;
 
   Future<void> startIfNeeded() async {
     if (_running) return;
@@ -107,39 +125,73 @@ class MessageSearchBackfillService {
           await _settings.setSearchBackfillCursor(timestamp: 0, id: '');
           continue;
         }
+        phase = 'done';
+        await _settings.setSearchBackfillPhase(phase);
         await _settings.setSearchBackfillComplete(true);
         return;
       }
 
+      var lastProcessed = <String, dynamic>{};
       for (final row in batch) {
         final messageId = phase == 'self'
             ? row['id'] as String
             : MessageIdCodec.wireIdFromStorage(row['id'] as String);
-        if (await _searchDao.exists(messageId)) continue;
+        if (await _searchDao.exists(messageId)) {
+          lastProcessed = row;
+          continue;
+        }
 
-        try {
-          if (phase == 'self') {
-            await indexService.indexSelfRow(row);
-          } else {
-            await indexService.indexInboundRow(row, userId);
+        final ok = phase == 'self'
+            ? await indexService.indexSelfRow(row)
+            : await indexService.indexInboundRow(row, userId);
+        if (!ok) {
+          final rowKey = row['id'] as String;
+          final failures =
+              await _settings.getSearchBackfillFailureCount(rowKey) + 1;
+          await _settings.setSearchBackfillFailureCount(rowKey, failures);
+          if (failures < _maxRowRetries) {
+            Logging.error(
+              'Search backfill failed for $messageId '
+              '($failures/$_maxRowRetries attempts), retrying next run',
+              'MessageSearchBackfill',
+            );
+            if (lastProcessed.isNotEmpty) {
+              await _settings.setSearchBackfillCursor(
+                timestamp: lastProcessed['timestamp'] as int,
+                id: lastProcessed['id'] as String,
+              );
+            }
+            return;
           }
-        } catch (e) {
           Logging.error(
-            'Search backfill failed for $messageId: $e',
+            'Search backfill permanently skipping un-indexable row '
+            '$messageId after $failures attempts',
             'MessageSearchBackfill',
           );
         }
+        lastProcessed = row;
       }
 
-      final last = batch.last;
-      cursorTs = last['timestamp'] as int;
-      cursorId = last['id'] as String;
       await _settings.setSearchBackfillCursor(
-        timestamp: cursorTs,
-        id: cursorId,
+        timestamp: lastProcessed['timestamp'] as int,
+        id: lastProcessed['id'] as String,
       );
+      cursorTs = lastProcessed['timestamp'] as int;
+      cursorId = lastProcessed['id'] as String;
       await Future<void>.delayed(const Duration(milliseconds: 16));
     }
+  }
+
+  static const _messageColumns =
+      'id, type, timestamp, groupId, senderId, receiverId, message, '
+      'fileName, deletedAt, viewOnce, viewed';
+
+  static const _selfColumns =
+      'id, type, timestamp, message, fileName, deletedAt, viewOnce, viewed';
+
+  static String _typeInClause(List<String> types) {
+    final placeholders = List.filled(types.length, '?').join(', ');
+    return 'type IS NULL OR type IN ($placeholders)';
   }
 
   Future<List<Map<String, dynamic>>> _fetchMessagesBatch(
@@ -147,15 +199,17 @@ class MessageSearchBackfillService {
     String cursorId,
   ) async {
     final db = await MessagesDb.database;
-    return db.rawQuery(
+    final rows = await db.rawQuery(
       '''
-      SELECT *
+      SELECT $_messageColumns
       FROM messages
       WHERE deletedAt IS NULL
         AND (viewOnce IS NULL OR viewOnce = 0 OR viewed IS NULL OR viewed = 0)
         AND (
-          type IS NULL
-          OR type IN ('text', 'file', 'image', 'audio', ?, ?, ?, ?)
+          ${_typeInClause([
+        ...MessageSearchIndexService.searchableDirectTypes,
+        ...MessageSearchIndexService.searchableGroupTypes,
+      ])}
         )
         AND (
           timestamp > ?
@@ -165,16 +219,15 @@ class MessageSearchBackfillService {
       LIMIT ?
       ''',
       [
-        groupTextType,
-        groupImageType,
-        groupFileType,
-        groupAudioType,
+        ...MessageSearchIndexService.searchableDirectTypes,
+        ...MessageSearchIndexService.searchableGroupTypes,
         cursorTs,
         cursorTs,
         cursorId,
         _batchSize,
       ],
     );
+    return _resolveMessageBlobs(rows);
   }
 
   Future<List<Map<String, dynamic>>> _fetchSelfBatch(
@@ -182,13 +235,15 @@ class MessageSearchBackfillService {
     String cursorId,
   ) async {
     final db = await MessagesDb.database;
-    return db.rawQuery(
+    final rows = await db.rawQuery(
       '''
-      SELECT *
+      SELECT $_selfColumns
       FROM self_messages
       WHERE deletedAt IS NULL
         AND (viewOnce IS NULL OR viewOnce = 0 OR viewed IS NULL OR viewed = 0)
-        AND (type IS NULL OR type IN ('text', 'file', 'image', 'audio'))
+        AND (
+          ${_typeInClause(MessageSearchIndexService.searchableDirectTypes)}
+        )
         AND (
           timestamp > ?
           OR (timestamp = ? AND id > ?)
@@ -196,7 +251,28 @@ class MessageSearchBackfillService {
       ORDER BY timestamp ASC, id ASC
       LIMIT ?
       ''',
-      [cursorTs, cursorTs, cursorId, _batchSize],
+      [
+        ...MessageSearchIndexService.searchableDirectTypes,
+        cursorTs,
+        cursorTs,
+        cursorId,
+        _batchSize,
+      ],
     );
+    return _resolveMessageBlobs(rows);
+  }
+
+  /// Resolves `blob:` payload markers back into the original message payload
+  /// so decryption downstream receives the full ciphertext.
+  static Future<List<Map<String, dynamic>>> _resolveMessageBlobs(
+    List<Map<String, dynamic>> rows,
+  ) async {
+    for (final row in rows) {
+      final wire = row['message'] as String?;
+      if (wire != null && MessageBlobStore.isMarker(wire)) {
+        row['message'] = await MessageBlobStore.resolve(wire);
+      }
+    }
+    return rows;
   }
 }

--- a/lib/services/message_search_backfill_service.dart
+++ b/lib/services/message_search_backfill_service.dart
@@ -6,8 +6,6 @@ import 'package:prysm/services/message_search_index_service.dart';
 import 'package:prysm/services/settings_service.dart';
 import 'package:prysm/util/key_manager.dart';
 import 'package:prysm/util/logging.dart';
-import 'package:sqflite/sqflite.dart';
-
 abstract class MessageSearchBackfillStore {
   Future<bool> isSearchBackfillComplete();
   Future<void> setSearchBackfillComplete(bool value);

--- a/lib/services/message_search_index_service.dart
+++ b/lib/services/message_search_index_service.dart
@@ -152,7 +152,12 @@ class MessageSearchIndexService {
         body: plaintext,
       );
 
-  Future<void> removeMessage(String messageId) => _dao.remove(messageId);
+  Future<void> removeMessage(
+    String messageId, {
+    String? conversationId,
+    String? scope,
+  }) =>
+      _dao.remove(messageId, conversationId: conversationId, scope: scope);
 
   /// Indexes an inbound row; returns false when the row could not be indexed
   /// (decryption failure, missing group text, unreadable payload) so callers
@@ -177,23 +182,33 @@ class MessageSearchIndexService {
       if (type == groupTextType) {
         final text = await _decryptGroupText(row, groupId, senderId);
         if (text == null) return false;
-        await _dao.upsert(
-          messageId: wireId,
-          conversationId: groupId,
-          scope: 'group',
-          timestamp: timestamp,
-          body: text,
-        );
+        try {
+          await _dao.upsert(
+            messageId: wireId,
+            conversationId: groupId,
+            scope: 'group',
+            timestamp: timestamp,
+            body: text,
+          );
+        } catch (e) {
+          Logging.error('Search index group-text write failed: $e', 'MessageSearch');
+          return false;
+        }
       } else {
         final fileName = row['fileName'] as String?;
         if (fileName == null || fileName.trim().isEmpty) return true;
-        await indexOutboundFile(
-          messageId: wireId,
-          conversationId: groupId,
-          scope: 'group',
-          timestamp: timestamp,
-          fileName: fileName,
-        );
+        try {
+          await indexOutboundFile(
+            messageId: wireId,
+            conversationId: groupId,
+            scope: 'group',
+            timestamp: timestamp,
+            fileName: fileName,
+          );
+        } catch (e) {
+          Logging.error('Search index group-file write failed: $e', 'MessageSearch');
+          return false;
+        }
       }
       return true;
     }
@@ -225,13 +240,18 @@ class MessageSearchIndexService {
       if (fileName == null || fileName.trim().isEmpty) return true;
       final peerId =
           senderId == localUserId ? row['receiverId'] as String : senderId;
-      await indexOutboundFile(
-        messageId: wireId,
-        conversationId: peerId,
-        scope: 'direct',
-        timestamp: timestamp,
-        fileName: fileName,
-      );
+      try {
+        await indexOutboundFile(
+          messageId: wireId,
+          conversationId: peerId,
+          scope: 'direct',
+          timestamp: timestamp,
+          fileName: fileName,
+        );
+      } catch (e) {
+        Logging.error('Search index direct-file write failed: $e', 'MessageSearch');
+        return false;
+      }
       return true;
     }
   }
@@ -265,11 +285,16 @@ class MessageSearchIndexService {
     } else {
       final fileName = row['fileName'] as String?;
       if (fileName == null || fileName.trim().isEmpty) return true;
-      await indexSelfFile(
-        messageId: messageId,
-        timestamp: timestamp,
-        fileName: fileName,
-      );
+      try {
+        await indexSelfFile(
+          messageId: messageId,
+          timestamp: timestamp,
+          fileName: fileName,
+        );
+      } catch (e) {
+        Logging.error('Search index self-file write failed: $e', 'MessageSearch');
+        return false;
+      }
       return true;
     }
   }

--- a/lib/services/message_search_index_service.dart
+++ b/lib/services/message_search_index_service.dart
@@ -154,8 +154,8 @@ class MessageSearchIndexService {
 
   Future<void> removeMessage(
     String messageId, {
-    String? conversationId,
-    String? scope,
+    required String conversationId,
+    required String scope,
   }) =>
       _dao.remove(messageId, conversationId: conversationId, scope: scope);
 

--- a/lib/services/message_search_index_service.dart
+++ b/lib/services/message_search_index_service.dart
@@ -7,6 +7,7 @@ import 'package:prysm/services/group_service.dart';
 import 'package:prysm/services/message_view_mapper.dart';
 import 'package:prysm/util/key_manager.dart';
 import 'package:prysm/util/logging.dart';
+import 'package:prysm/util/message_blob_store.dart';
 import 'package:prysm/util/peer_identity_loader.dart';
 
 /// Keeps the FTS5 search index in sync with message lifecycle events.
@@ -168,7 +169,12 @@ class MessageSearchIndexService {
     String localUserId,
   ) async {
     if (row['deletedAt'] != null) return true;
-    if ((row['viewOnce'] ?? 0) == 1 && (row['viewed'] ?? 0) == 1) return true;
+    if ((row['viewOnce'] ?? 0) == 1) return true;
+    final wire = row['message'] as String?;
+    if (MessageBlobStore.isMarker(wire)) {
+      // Rows from sqflite are read-only; resolve into a fresh map.
+      row = {...row, 'message': await MessageBlobStore.resolve(wire)};
+    }
 
     final storageId = row['id'] as String;
     final wireId = MessageIdCodec.wireIdFromStorage(storageId);
@@ -260,7 +266,12 @@ class MessageSearchIndexService {
   /// indexed so callers like the backfill can retry it.
   Future<bool> indexSelfRow(Map<String, dynamic> row) async {
     if (row['deletedAt'] != null) return true;
-    if ((row['viewOnce'] ?? 0) == 1 && (row['viewed'] ?? 0) == 1) return true;
+    if ((row['viewOnce'] ?? 0) == 1) return true;
+    final wire = row['message'] as String?;
+    if (MessageBlobStore.isMarker(wire)) {
+      // Rows from sqflite are read-only; resolve into a fresh map.
+      row = {...row, 'message': await MessageBlobStore.resolve(wire)};
+    }
 
     final messageId = row['id'] as String;
     final type = row['type'] as String?;
@@ -328,6 +339,7 @@ class MessageSearchIndexService {
   }
 
   static String buildSnippet(String body, String query, {int maxLen = 80}) {
+    if (body.length <= maxLen) return body;
     final lowerBody = body.toLowerCase();
     final tokens = query
         .trim()

--- a/lib/services/message_search_index_service.dart
+++ b/lib/services/message_search_index_service.dart
@@ -1,0 +1,299 @@
+import 'package:prysm/constants/group_constants.dart';
+import 'package:prysm/crypto/group_crypto.dart';
+import 'package:prysm/database/message_id_codec.dart';
+import 'package:prysm/database/message_search_dao.dart';
+import 'package:prysm/models/conversation.dart';
+import 'package:prysm/services/group_service.dart';
+import 'package:prysm/services/message_view_mapper.dart';
+import 'package:prysm/util/key_manager.dart';
+import 'package:prysm/util/logging.dart';
+import 'package:prysm/util/peer_identity_loader.dart';
+
+/// Keeps the FTS5 search index in sync with message lifecycle events.
+class MessageSearchIndexService {
+  MessageSearchIndexService({
+    MessageSearchDao? dao,
+    required this.keyManager,
+    required this.userId,
+    GroupService? groupService,
+  })  : _dao = dao ?? const MessageSearchDao(),
+        _groupService = groupService;
+
+  final MessageSearchDao _dao;
+  final KeyManager keyManager;
+  final String userId;
+  final GroupService? _groupService;
+  late final MessageViewMapper _viewMapper =
+      MessageViewMapper(keyManager: keyManager);
+
+  GroupService get _groups =>
+      _groupService ?? GroupService(userId: userId, keyManager: keyManager);
+
+  static bool isSearchableDirectType(String? type) =>
+      type == null || isDirectMessageType(type);
+
+  static bool isSearchableGroupType(String type) => isGroupMessageType(type);
+
+  static bool isSearchableSelfType(String? type) =>
+      type == null || type == 'text' || type == 'file' || type == 'image' || type == 'audio';
+
+  Future<void> indexOutboundDirectText({
+    required String messageId,
+    required String peerId,
+    required int timestamp,
+    required String plaintext,
+  }) =>
+      _dao.upsert(
+        messageId: messageId,
+        conversationId: peerId,
+        scope: 'direct',
+        timestamp: timestamp,
+        body: plaintext,
+      );
+
+  Future<void> indexOutboundGroupText({
+    required String messageId,
+    required String groupId,
+    required int timestamp,
+    required String plaintext,
+  }) =>
+      _dao.upsert(
+        messageId: messageId,
+        conversationId: groupId,
+        scope: 'group',
+        timestamp: timestamp,
+        body: plaintext,
+      );
+
+  Future<void> indexOutboundFile({
+    required String messageId,
+    required String conversationId,
+    required String scope,
+    required int timestamp,
+    required String fileName,
+  }) =>
+      _dao.upsert(
+        messageId: messageId,
+        conversationId: conversationId,
+        scope: scope,
+        timestamp: timestamp,
+        body: fileName,
+      );
+
+  Future<void> indexSelfText({
+    required String messageId,
+    required int timestamp,
+    required String plaintext,
+  }) =>
+      _dao.upsert(
+        messageId: messageId,
+        conversationId: SelfConversation.conversationId,
+        scope: 'self',
+        timestamp: timestamp,
+        body: plaintext,
+      );
+
+  Future<void> indexSelfFile({
+    required String messageId,
+    required int timestamp,
+    required String fileName,
+  }) =>
+      indexOutboundFile(
+        messageId: messageId,
+        conversationId: SelfConversation.conversationId,
+        scope: 'self',
+        timestamp: timestamp,
+        fileName: fileName,
+      );
+
+  Future<void> reindexEditedMessage({
+    required String messageId,
+    required String conversationId,
+    required String scope,
+    required int timestamp,
+    required String plaintext,
+  }) =>
+      _dao.upsert(
+        messageId: messageId,
+        conversationId: conversationId,
+        scope: scope,
+        timestamp: timestamp,
+        body: plaintext,
+      );
+
+  Future<void> removeMessage(String messageId) => _dao.remove(messageId);
+
+  Future<void> indexInboundRow(
+    Map<String, dynamic> row,
+    String localUserId,
+  ) async {
+    if (row['deletedAt'] != null) return;
+    if ((row['viewOnce'] ?? 0) == 1 && (row['viewed'] ?? 0) == 1) return;
+
+    final storageId = row['id'] as String;
+    final wireId = MessageIdCodec.wireIdFromStorage(storageId);
+    final type = row['type'] as String?;
+    final timestamp = row['timestamp'] as int;
+    final groupId = row['groupId'] as String?;
+    final senderId = row['senderId'] as String;
+
+    if (groupId != null) {
+      if (type == null || !isSearchableGroupType(type)) return;
+      if (type == groupTextType) {
+        final text = await _decryptGroupText(row, groupId, senderId);
+        if (text == null) return;
+        await _dao.upsert(
+          messageId: wireId,
+          conversationId: groupId,
+          scope: 'group',
+          timestamp: timestamp,
+          body: text,
+        );
+      } else {
+        final fileName = row['fileName'] as String?;
+        if (fileName == null || fileName.trim().isEmpty) return;
+        await indexOutboundFile(
+          messageId: wireId,
+          conversationId: groupId,
+          scope: 'group',
+          timestamp: timestamp,
+          fileName: fileName,
+        );
+      }
+      return;
+    }
+
+    if (type != null && !isSearchableDirectType(type)) return;
+    if (type == 'text' || type == null) {
+      try {
+        final text = await _viewMapper.decryptDirectTextMessage(
+          row,
+          localUserId: localUserId,
+        );
+        final peerId = senderId == localUserId
+            ? row['receiverId'] as String
+            : senderId;
+        await _dao.upsert(
+          messageId: wireId,
+          conversationId: peerId,
+          scope: 'direct',
+          timestamp: timestamp,
+          body: text,
+        );
+      } catch (e) {
+        Logging.error('Search index inbound decrypt failed: $e', 'MessageSearch');
+      }
+    } else {
+      final fileName = row['fileName'] as String?;
+      if (fileName == null || fileName.trim().isEmpty) return;
+      final peerId =
+          senderId == localUserId ? row['receiverId'] as String : senderId;
+      await indexOutboundFile(
+        messageId: wireId,
+        conversationId: peerId,
+        scope: 'direct',
+        timestamp: timestamp,
+        fileName: fileName,
+      );
+    }
+  }
+
+  Future<void> indexSelfRow(Map<String, dynamic> row) async {
+    if (row['deletedAt'] != null) return;
+    if ((row['viewOnce'] ?? 0) == 1 && (row['viewed'] ?? 0) == 1) return;
+
+    final messageId = row['id'] as String;
+    final type = row['type'] as String?;
+    final timestamp = row['timestamp'] as int;
+    if (!isSearchableSelfType(type)) return;
+
+    if (type == 'text' || type == null) {
+      final wire = row['message'] as String?;
+      if (wire == null || wire.isEmpty) return;
+      try {
+        final text = await keyManager.decryptMessage(wire);
+        await indexSelfText(
+          messageId: messageId,
+          timestamp: timestamp,
+          plaintext: text,
+        );
+      } catch (e) {
+        Logging.error('Search index self decrypt failed: $e', 'MessageSearch');
+      }
+    } else {
+      final fileName = row['fileName'] as String?;
+      if (fileName == null || fileName.trim().isEmpty) return;
+      await indexSelfFile(
+        messageId: messageId,
+        timestamp: timestamp,
+        fileName: fileName,
+      );
+    }
+  }
+
+  Future<String?> _decryptGroupText(
+    Map<String, dynamic> row,
+    String groupId,
+    String senderId,
+  ) async {
+    final groupKey = await _groups.getDecryptedGroupKey(groupId);
+    if (groupKey == null) return null;
+    final wire = row['message'] as String?;
+    if (wire == null || wire.isEmpty) return null;
+    try {
+      if (GroupCryptoV2.isSenderKeyEnvelope(wire)) {
+        final senderKeys = await loadPeerIdentityFromDb(keyManager, senderId);
+        if (senderKeys == null) return null;
+        return GroupCryptoV2.decryptWithSenderKey(
+          epochKey: groupKey,
+          groupId: groupId,
+          wire: wire,
+          transportSenderId: senderId,
+          senderKeys: senderKeys,
+        );
+      }
+      return GroupCryptoV2.decryptText(groupKey, wire);
+    } catch (e) {
+      Logging.error('Search index group decrypt failed: $e', 'MessageSearch');
+      return null;
+    }
+  }
+
+  static String buildSnippet(String body, String query, {int maxLen = 80}) {
+    final lowerBody = body.toLowerCase();
+    final tokens = query
+        .trim()
+        .toLowerCase()
+        .split(RegExp(r'\s+'))
+        .where((t) => t.isNotEmpty)
+        .toList();
+    if (tokens.isEmpty) {
+      return body.length <= maxLen ? body : '${body.substring(0, maxLen)}…';
+    }
+
+    var matchStart = -1;
+    var matchLen = 0;
+    for (final token in tokens) {
+      final idx = lowerBody.indexOf(token);
+      if (idx >= 0) {
+        matchStart = idx;
+        matchLen = token.length;
+        break;
+      }
+    }
+    if (matchStart < 0) {
+      return body.length <= maxLen ? body : '${body.substring(0, maxLen)}…';
+    }
+
+    const pad = 24;
+    final start = (matchStart - pad).clamp(0, body.length);
+    final end = (matchStart + matchLen + pad).clamp(0, body.length);
+    var snippet = body.substring(start, end);
+    if (start > 0) snippet = '…$snippet';
+    if (end < body.length) snippet = '$snippet…';
+    if (snippet.length > maxLen) {
+      snippet = '${snippet.substring(0, maxLen)}…';
+    }
+    return snippet;
+  }
+}

--- a/lib/services/message_search_index_service.dart
+++ b/lib/services/message_search_index_service.dart
@@ -22,12 +22,43 @@ class MessageSearchIndexService {
   final MessageSearchDao _dao;
   final KeyManager keyManager;
   final String userId;
-  final GroupService? _groupService;
+  GroupService? _groupService;
   late final MessageViewMapper _viewMapper =
       MessageViewMapper(keyManager: keyManager);
 
   GroupService get _groups =>
-      _groupService ?? GroupService(userId: userId, keyManager: keyManager);
+      _groupService ??= GroupService(userId: userId, keyManager: keyManager);
+
+  /// Searchable direct-message types (mirrors `directMessageTypes`).
+  static const List<String> searchableDirectTypes = [
+    'text',
+    'file',
+    'image',
+    'audio',
+  ];
+
+  /// Searchable group-message types.
+  static const List<String> searchableGroupTypes = [
+    groupTextType,
+    groupImageType,
+    groupFileType,
+    groupAudioType,
+  ];
+
+  /// Runs an index action best-effort: failures are logged and swallowed so
+  /// message delivery, notification, and upload flows never depend on FTS.
+  static Future<void> indexBestEffort(
+    Future<void> Function() action,
+  ) async {
+    try {
+      await action();
+    } catch (e, stack) {
+      Logging.error(
+        'Message search indexing failed: $e\n$stack',
+        'MessageSearch',
+      );
+    }
+  }
 
   static bool isSearchableDirectType(String? type) =>
       type == null || isDirectMessageType(type);
@@ -35,7 +66,7 @@ class MessageSearchIndexService {
   static bool isSearchableGroupType(String type) => isGroupMessageType(type);
 
   static bool isSearchableSelfType(String? type) =>
-      type == null || type == 'text' || type == 'file' || type == 'image' || type == 'audio';
+      type == null || searchableDirectTypes.contains(type);
 
   Future<void> indexOutboundDirectText({
     required String messageId,
@@ -123,12 +154,16 @@ class MessageSearchIndexService {
 
   Future<void> removeMessage(String messageId) => _dao.remove(messageId);
 
-  Future<void> indexInboundRow(
+  /// Indexes an inbound row; returns false when the row could not be indexed
+  /// (decryption failure, missing group text, unreadable payload) so callers
+  /// like the backfill can retry it. Legitimate skips (deleted, viewed
+  /// view-once, non-searchable type) return true.
+  Future<bool> indexInboundRow(
     Map<String, dynamic> row,
     String localUserId,
   ) async {
-    if (row['deletedAt'] != null) return;
-    if ((row['viewOnce'] ?? 0) == 1 && (row['viewed'] ?? 0) == 1) return;
+    if (row['deletedAt'] != null) return true;
+    if ((row['viewOnce'] ?? 0) == 1 && (row['viewed'] ?? 0) == 1) return true;
 
     final storageId = row['id'] as String;
     final wireId = MessageIdCodec.wireIdFromStorage(storageId);
@@ -138,10 +173,10 @@ class MessageSearchIndexService {
     final senderId = row['senderId'] as String;
 
     if (groupId != null) {
-      if (type == null || !isSearchableGroupType(type)) return;
+      if (type == null || !isSearchableGroupType(type)) return true;
       if (type == groupTextType) {
         final text = await _decryptGroupText(row, groupId, senderId);
-        if (text == null) return;
+        if (text == null) return false;
         await _dao.upsert(
           messageId: wireId,
           conversationId: groupId,
@@ -151,7 +186,7 @@ class MessageSearchIndexService {
         );
       } else {
         final fileName = row['fileName'] as String?;
-        if (fileName == null || fileName.trim().isEmpty) return;
+        if (fileName == null || fileName.trim().isEmpty) return true;
         await indexOutboundFile(
           messageId: wireId,
           conversationId: groupId,
@@ -160,10 +195,10 @@ class MessageSearchIndexService {
           fileName: fileName,
         );
       }
-      return;
+      return true;
     }
 
-    if (type != null && !isSearchableDirectType(type)) return;
+    if (type != null && !isSearchableDirectType(type)) return true;
     if (type == 'text' || type == null) {
       try {
         final text = await _viewMapper.decryptDirectTextMessage(
@@ -180,12 +215,14 @@ class MessageSearchIndexService {
           timestamp: timestamp,
           body: text,
         );
+        return true;
       } catch (e) {
         Logging.error('Search index inbound decrypt failed: $e', 'MessageSearch');
+        return false;
       }
     } else {
       final fileName = row['fileName'] as String?;
-      if (fileName == null || fileName.trim().isEmpty) return;
+      if (fileName == null || fileName.trim().isEmpty) return true;
       final peerId =
           senderId == localUserId ? row['receiverId'] as String : senderId;
       await indexOutboundFile(
@@ -195,21 +232,24 @@ class MessageSearchIndexService {
         timestamp: timestamp,
         fileName: fileName,
       );
+      return true;
     }
   }
 
-  Future<void> indexSelfRow(Map<String, dynamic> row) async {
-    if (row['deletedAt'] != null) return;
-    if ((row['viewOnce'] ?? 0) == 1 && (row['viewed'] ?? 0) == 1) return;
+  /// Indexes a self-message row; returns false when the row could not be
+  /// indexed so callers like the backfill can retry it.
+  Future<bool> indexSelfRow(Map<String, dynamic> row) async {
+    if (row['deletedAt'] != null) return true;
+    if ((row['viewOnce'] ?? 0) == 1 && (row['viewed'] ?? 0) == 1) return true;
 
     final messageId = row['id'] as String;
     final type = row['type'] as String?;
     final timestamp = row['timestamp'] as int;
-    if (!isSearchableSelfType(type)) return;
+    if (!isSearchableSelfType(type)) return true;
 
     if (type == 'text' || type == null) {
       final wire = row['message'] as String?;
-      if (wire == null || wire.isEmpty) return;
+      if (wire == null || wire.isEmpty) return false;
       try {
         final text = await keyManager.decryptMessage(wire);
         await indexSelfText(
@@ -217,17 +257,20 @@ class MessageSearchIndexService {
           timestamp: timestamp,
           plaintext: text,
         );
+        return true;
       } catch (e) {
         Logging.error('Search index self decrypt failed: $e', 'MessageSearch');
+        return false;
       }
     } else {
       final fileName = row['fileName'] as String?;
-      if (fileName == null || fileName.trim().isEmpty) return;
+      if (fileName == null || fileName.trim().isEmpty) return true;
       await indexSelfFile(
         messageId: messageId,
         timestamp: timestamp,
         fileName: fileName,
       );
+      return true;
     }
   }
 
@@ -268,32 +311,66 @@ class MessageSearchIndexService {
         .where((t) => t.isNotEmpty)
         .toList();
     if (tokens.isEmpty) {
-      return body.length <= maxLen ? body : '${body.substring(0, maxLen)}…';
+      return body.length <= maxLen
+          ? body
+          : '${_safeSubstring(body, 0, maxLen)}…';
     }
 
     var matchStart = -1;
     var matchLen = 0;
     for (final token in tokens) {
       final idx = lowerBody.indexOf(token);
-      if (idx >= 0) {
+      if (idx >= 0 && (matchStart < 0 || idx < matchStart)) {
         matchStart = idx;
         matchLen = token.length;
-        break;
       }
     }
     if (matchStart < 0) {
-      return body.length <= maxLen ? body : '${body.substring(0, maxLen)}…';
+      return body.length <= maxLen
+          ? body
+          : '${_safeSubstring(body, 0, maxLen)}…';
     }
 
+    // matchStart indexes lowerBody; case mapping may change string lengths,
+    // so guard it before applying it to body.
+    final guardedMatch = matchStart.clamp(0, body.length);
     const pad = 24;
-    final start = (matchStart - pad).clamp(0, body.length);
-    final end = (matchStart + matchLen + pad).clamp(0, body.length);
+    var start = (guardedMatch - pad).clamp(0, body.length);
+    var end = (guardedMatch + matchLen + pad).clamp(0, body.length);
+    if (start < body.length && _isLowSurrogate(body.codeUnitAt(start))) {
+      start++;
+    }
+    if (end < body.length && _isSurrogate(body.codeUnitAt(end))) {
+      end--;
+    }
+    if (end < start) end = start;
     var snippet = body.substring(start, end);
     if (start > 0) snippet = '…$snippet';
     if (end < body.length) snippet = '$snippet…';
     if (snippet.length > maxLen) {
-      snippet = '${snippet.substring(0, maxLen)}…';
+      snippet = '${_safeSubstring(snippet, 0, maxLen)}…';
     }
     return snippet;
+  }
+
+  static bool _isHighSurrogate(int codeUnit) =>
+      codeUnit >= 0xD800 && codeUnit <= 0xDBFF;
+
+  static bool _isLowSurrogate(int codeUnit) =>
+      codeUnit >= 0xDC00 && codeUnit <= 0xDFFF;
+
+  static bool _isSurrogate(int codeUnit) =>
+      _isHighSurrogate(codeUnit) || _isLowSurrogate(codeUnit);
+
+  /// Substrings [start, end) without splitting a surrogate pair.
+  static String _safeSubstring(String value, int start, int end) {
+    if (start < value.length && _isLowSurrogate(value.codeUnitAt(start))) {
+      start++;
+    }
+    if (end > start && end < value.length && _isSurrogate(value.codeUnitAt(end))) {
+      end--;
+    }
+    if (end < start) end = start;
+    return value.substring(start, end);
   }
 }

--- a/lib/services/self_chat_service.dart
+++ b/lib/services/self_chat_service.dart
@@ -4,6 +4,7 @@ import 'package:prysm/constants/media_constants.dart';
 import 'package:prysm/crypto/wire.dart';
 import 'package:prysm/database/self_messages_db.dart';
 import 'package:prysm/util/key_manager.dart';
+import 'package:prysm/services/message_search_index_service.dart';
 import 'package:prysm/util/logging.dart';
 import 'package:prysm/util/message_modify_policy.dart';
 import 'package:uuid/uuid.dart';
@@ -33,6 +34,15 @@ class SelfChatService {
       'timestamp': timestamp,
       'replyTo': replyToId,
     });
+
+    await MessageSearchIndexService(
+      keyManager: keyManager,
+      userId: userId,
+    ).indexSelfText(
+      messageId: id,
+      timestamp: timestamp,
+      plaintext: text,
+    );
 
     return id;
   }
@@ -64,6 +74,15 @@ class SelfChatService {
       'replyTo': replyToId,
       'viewOnce': viewOnce ? 1 : 0,
     });
+
+    await MessageSearchIndexService(
+      keyManager: keyManager,
+      userId: userId,
+    ).indexSelfFile(
+      messageId: id,
+      timestamp: timestamp,
+      fileName: fileName,
+    );
 
     return id;
   }

--- a/lib/services/self_chat_service.dart
+++ b/lib/services/self_chat_service.dart
@@ -35,13 +35,15 @@ class SelfChatService {
       'replyTo': replyToId,
     });
 
-    await MessageSearchIndexService(
-      keyManager: keyManager,
-      userId: userId,
-    ).indexSelfText(
-      messageId: id,
-      timestamp: timestamp,
-      plaintext: text,
+    await MessageSearchIndexService.indexBestEffort(
+      () => MessageSearchIndexService(
+        keyManager: keyManager,
+        userId: userId,
+      ).indexSelfText(
+        messageId: id,
+        timestamp: timestamp,
+        plaintext: text,
+      ),
     );
 
     return id;
@@ -75,14 +77,20 @@ class SelfChatService {
       'viewOnce': viewOnce ? 1 : 0,
     });
 
-    await MessageSearchIndexService(
-      keyManager: keyManager,
-      userId: userId,
-    ).indexSelfFile(
-      messageId: id,
-      timestamp: timestamp,
-      fileName: fileName,
-    );
+    // ponytail: guard instead of a viewOnce param on indexOutboundFile — a
+    // view-once write is dead weight: viewing wipes the row and de-indexes.
+    if (!viewOnce) {
+      await MessageSearchIndexService.indexBestEffort(
+        () => MessageSearchIndexService(
+          keyManager: keyManager,
+          userId: userId,
+        ).indexSelfFile(
+          messageId: id,
+          timestamp: timestamp,
+          fileName: fileName,
+        ),
+      );
+    }
 
     return id;
   }

--- a/lib/services/settings_service.dart
+++ b/lib/services/settings_service.dart
@@ -367,6 +367,7 @@ class SettingsService {
   static const _searchBackfillCursorTsKey = 'search_backfill_cursor_ts';
   static const _searchBackfillCursorIdKey = 'search_backfill_cursor_id';
   static const _searchBackfillCompleteKey = 'search_backfill_complete';
+  static const _searchBackfillRetryPrefixKey = 'search_backfill_retry_';
 
   Future<bool> isSearchBackfillComplete() async =>
       _prefs?.getBool(_searchBackfillCompleteKey) ?? false;
@@ -393,4 +394,10 @@ class SettingsService {
     await _prefs?.setInt(_searchBackfillCursorTsKey, timestamp);
     await _prefs?.setString(_searchBackfillCursorIdKey, id);
   }
+
+  Future<int> getSearchBackfillFailureCount(String rowKey) async =>
+      _prefs?.getInt('$_searchBackfillRetryPrefixKey$rowKey') ?? 0;
+
+  Future<void> setSearchBackfillFailureCount(String rowKey, int count) async =>
+      await _prefs?.setInt('$_searchBackfillRetryPrefixKey$rowKey', count);
 }

--- a/lib/services/settings_service.dart
+++ b/lib/services/settings_service.dart
@@ -362,4 +362,35 @@ class SettingsService {
         return 'Unknown';
     }
   }
+
+  static const _searchBackfillPhaseKey = 'search_backfill_phase';
+  static const _searchBackfillCursorTsKey = 'search_backfill_cursor_ts';
+  static const _searchBackfillCursorIdKey = 'search_backfill_cursor_id';
+  static const _searchBackfillCompleteKey = 'search_backfill_complete';
+
+  Future<bool> isSearchBackfillComplete() async =>
+      _prefs?.getBool(_searchBackfillCompleteKey) ?? false;
+
+  Future<void> setSearchBackfillComplete(bool value) async =>
+      await _prefs?.setBool(_searchBackfillCompleteKey, value);
+
+  Future<String> getSearchBackfillPhase() async =>
+      _prefs?.getString(_searchBackfillPhaseKey) ?? 'messages';
+
+  Future<void> setSearchBackfillPhase(String phase) async =>
+      await _prefs?.setString(_searchBackfillPhaseKey, phase);
+
+  Future<int> getSearchBackfillCursorTimestamp() async =>
+      _prefs?.getInt(_searchBackfillCursorTsKey) ?? 0;
+
+  Future<String> getSearchBackfillCursorId() async =>
+      _prefs?.getString(_searchBackfillCursorIdKey) ?? '';
+
+  Future<void> setSearchBackfillCursor({
+    required int timestamp,
+    required String id,
+  }) async {
+    await _prefs?.setInt(_searchBackfillCursorTsKey, timestamp);
+    await _prefs?.setString(_searchBackfillCursorIdKey, id);
+  }
 }

--- a/lib/ui/chat/chat_search_bar.dart
+++ b/lib/ui/chat/chat_search_bar.dart
@@ -1,0 +1,129 @@
+import 'dart:async';
+
+import 'package:flutter/cupertino.dart';
+import 'package:flutter/widgets.dart';
+import 'package:prysm/database/messages.dart';
+import 'package:prysm/models/message_search_hit.dart';
+import 'package:prysm/theme/prysm_style_scope.dart';
+import 'package:prysm/ui/core/prysm_button.dart';
+import 'package:prysm/ui/core/prysm_icons.dart';
+import 'package:prysm/ui/prysm_search_field.dart';
+
+class ChatSearchBar extends StatefulWidget {
+  const ChatSearchBar({
+    required this.conversationId,
+    required this.onResultSelected,
+    required this.onClose,
+    this.onQueryChanged,
+    super.key,
+  });
+
+  final String conversationId;
+  final void Function(MessageSearchHit hit, int index) onResultSelected;
+  final VoidCallback onClose;
+  final ValueChanged<String>? onQueryChanged;
+
+  @override
+  State<ChatSearchBar> createState() => _ChatSearchBarState();
+}
+
+class _ChatSearchBarState extends State<ChatSearchBar> {
+  final _controller = TextEditingController();
+  Timer? _debounce;
+  List<MessageSearchHit> _results = const [];
+  int _currentIndex = 0;
+  String _query = '';
+
+  @override
+  void dispose() {
+    _debounce?.cancel();
+    _controller.dispose();
+    super.dispose();
+  }
+
+  void _onQueryChanged(String value) {
+    _debounce?.cancel();
+    final trimmed = value.trim();
+    setState(() => _query = trimmed);
+    widget.onQueryChanged?.call(trimmed);
+    if (trimmed.length < 2) {
+      setState(() {
+        _results = const [];
+        _currentIndex = 0;
+      });
+      return;
+    }
+    _debounce = Timer(const Duration(milliseconds: 300), () async {
+      final hits = await MessagesDb.searchMessagesInConversation(
+        widget.conversationId,
+        trimmed,
+      );
+      if (!mounted) return;
+      setState(() {
+        _results = hits;
+        _currentIndex = hits.isEmpty ? 0 : hits.length - 1;
+      });
+      if (hits.isNotEmpty) {
+        widget.onResultSelected(hits[_currentIndex], _currentIndex);
+      }
+    });
+  }
+
+  void _step(int delta) {
+    if (_results.isEmpty) return;
+    final next = (_currentIndex + delta).clamp(0, _results.length - 1);
+    setState(() => _currentIndex = next);
+    widget.onResultSelected(_results[next], next);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final tokens = context.prysmStyle.tokens;
+    final counter = _results.isEmpty
+        ? ''
+        : '${_currentIndex + 1}/${_results.length}';
+
+    return Container(
+      padding: const EdgeInsets.fromLTRB(12, 8, 12, 8),
+      decoration: BoxDecoration(
+        border: Border(
+          bottom: BorderSide(color: tokens.divider.withValues(alpha: 0.15)),
+        ),
+      ),
+      child: Row(
+        children: [
+          Expanded(
+            child: PrysmSearchField(
+              controller: _controller,
+              hintText: 'Search in chat...',
+              onChanged: _onQueryChanged,
+              onClear: () {
+                _controller.clear();
+                _onQueryChanged('');
+              },
+            ),
+          ),
+          if (_query.length >= 2) ...[
+            const SizedBox(width: 8),
+            Text(counter, style: TextStyle(color: tokens.textMuted, fontSize: 13)),
+            PrysmIconButton(
+              icon: CupertinoIcons.chevron_up,
+              tooltip: 'Previous match',
+              onPressed: _results.isEmpty ? null : () => _step(-1),
+            ),
+            PrysmIconButton(
+              icon: PrysmIcons.chevronDown,
+              tooltip: 'Next match',
+              onPressed: _results.isEmpty ? null : () => _step(1),
+            ),
+          ],
+          PrysmIconButton(
+            icon: PrysmIcons.close,
+            tooltip: 'Close search',
+            onPressed: widget.onClose,
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/ui/chat/chat_search_bar.dart
+++ b/lib/ui/chat/chat_search_bar.dart
@@ -53,11 +53,12 @@ class _ChatSearchBarState extends State<ChatSearchBar> {
       return;
     }
     _debounce = Timer(const Duration(milliseconds: 300), () async {
+      final submitted = trimmed;
       final hits = await MessagesDb.searchMessagesInConversation(
         widget.conversationId,
-        trimmed,
+        submitted,
       );
-      if (!mounted) return;
+      if (!mounted || submitted != _query) return;
       setState(() {
         _results = hits;
         _currentIndex = hits.isEmpty ? 0 : hits.length - 1;

--- a/lib/ui/chat/chat_search_bar.dart
+++ b/lib/ui/chat/chat_search_bar.dart
@@ -1,7 +1,6 @@
 import 'dart:async';
 
 import 'package:flutter/cupertino.dart';
-import 'package:flutter/widgets.dart';
 import 'package:prysm/database/messages.dart';
 import 'package:prysm/models/message_search_hit.dart';
 import 'package:prysm/theme/prysm_style_scope.dart';

--- a/lib/ui/prysm_search_field.dart
+++ b/lib/ui/prysm_search_field.dart
@@ -3,7 +3,6 @@ import 'package:prysm/theme/prysm_style_scope.dart';
 import 'package:prysm/theme/prysm_tokens.dart';
 import 'package:prysm/ui/core/prysm_icons.dart';
 import 'package:prysm/ui/core/prysm_pressable.dart';
-import 'package:prysm/ui/core/prysm_text_field.dart';
 
 class PrysmSearchField extends StatefulWidget {
   const PrysmSearchField({
@@ -24,15 +23,19 @@ class PrysmSearchField extends StatefulWidget {
 }
 
 class _PrysmSearchFieldState extends State<PrysmSearchField> {
+  late final FocusNode _focusNode;
+
   @override
   void initState() {
     super.initState();
+    _focusNode = FocusNode();
     widget.controller.addListener(_onTextChanged);
   }
 
   @override
   void dispose() {
     widget.controller.removeListener(_onTextChanged);
+    _focusNode.dispose();
     super.dispose();
   }
 
@@ -42,6 +45,9 @@ class _PrysmSearchFieldState extends State<PrysmSearchField> {
   Widget build(BuildContext context) {
     final style = context.prysmStyle;
     final tokens = style.tokens;
+    final showHint =
+        widget.hintText.isNotEmpty && widget.controller.text.isEmpty;
+
     return Container(
       height: 40,
       decoration: BoxDecoration(
@@ -54,10 +60,21 @@ class _PrysmSearchFieldState extends State<PrysmSearchField> {
           Icon(PrysmIcons.search, size: 20, color: tokens.textMuted),
           const SizedBox(width: PrysmTokens.spacing8),
           Expanded(
-            child: PrysmTextField(
-              controller: widget.controller,
-              hintText: widget.hintText,
-              onChanged: widget.onChanged,
+            child: Stack(
+              alignment: Alignment.centerLeft,
+              children: [
+                if (showHint)
+                  Text(widget.hintText, style: style.captionStyle),
+                EditableText(
+                  controller: widget.controller,
+                  focusNode: _focusNode,
+                  style: style.bodyStyle.copyWith(color: tokens.textPrimary),
+                  cursorColor: tokens.accent,
+                  backgroundCursorColor: tokens.textMuted,
+                  maxLines: 1,
+                  onChanged: widget.onChanged,
+                ),
+              ],
             ),
           ),
           if (widget.controller.text.isNotEmpty && widget.onClear != null)

--- a/test/chat_service_pending_delete_test.dart
+++ b/test/chat_service_pending_delete_test.dart
@@ -2,6 +2,7 @@ import 'dart:convert';
 
 import 'package:flutter_test/flutter_test.dart';
 import 'package:prysm/crypto/identity.dart';
+import 'package:prysm/database/message_schema_migrations.dart';
 import 'package:prysm/database/messages.dart';
 import 'package:prysm/services/chat_service.dart';
 import 'package:prysm/util/db_helper.dart';
@@ -83,6 +84,7 @@ Future<Database> _openMessagesDb() async {
       expiresAt INTEGER
     )
   ''');
+  await MessageSchemaMigrations.createMessageSearchFtsTable(db);
   return db;
 }
 

--- a/test/disappearing_messages_test.dart
+++ b/test/disappearing_messages_test.dart
@@ -38,6 +38,7 @@ Future<Database> _openMessagesDb() async {
   ''');
   await MessageSchemaMigrations.createReactionsTable(db);
   await MessageSchemaMigrations.createReadReceiptsTable(db);
+  await MessageSchemaMigrations.createMessageSearchFtsTable(db);
   return db;
 }
 

--- a/test/group_chat_service_test.dart
+++ b/test/group_chat_service_test.dart
@@ -15,6 +15,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:prysm/constants/group_constants.dart';
 import 'package:prysm/crypto/ratchet/session_store.dart';
 import 'package:prysm/crypto/identity.dart';
+import 'package:prysm/database/message_schema_migrations.dart';
 import 'package:prysm/database/messages.dart';
 import 'package:prysm/models/group.dart';
 import 'package:prysm/services/group_chat_service.dart';
@@ -111,6 +112,7 @@ Future<Database> _openMessagesDb() async {
       expiresAt INTEGER
     )
   ''');
+  await MessageSchemaMigrations.createMessageSearchFtsTable(db);
   return db;
 }
 

--- a/test/group_control_auth_test.dart
+++ b/test/group_control_auth_test.dart
@@ -8,6 +8,7 @@ import 'package:prysm/crypto/group_crypto.dart';
 import 'package:prysm/crypto/identity.dart';
 import 'package:prysm/crypto/ratchet/session_store.dart';
 import 'package:prysm/crypto/wire.dart';
+import 'package:prysm/database/message_schema_migrations.dart';
 import 'package:prysm/database/messages.dart';
 import 'package:prysm/services/group_service.dart';
 import 'package:prysm/util/db_helper.dart';
@@ -85,6 +86,7 @@ Future<Database> _openTestDb() async {
             groupId TEXT
           )
         ''');
+        await MessageSchemaMigrations.createMessageSearchFtsTable(db);
         await GroupSenderIndexStore.ensureTable(db);
         await RatchetSessionStore.ensureTable(db);
       },

--- a/test/message_actions_characterization_test.dart
+++ b/test/message_actions_characterization_test.dart
@@ -21,6 +21,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:prysm/crypto/identity.dart';
 import 'package:prysm/crypto/ratchet/session_store.dart';
 import 'package:prysm/database/message_reactions.dart';
+import 'package:prysm/database/message_schema_migrations.dart';
 import 'package:prysm/database/messages.dart';
 import 'package:prysm/services/group_service.dart';
 import 'package:prysm/services/message_modify_service.dart';
@@ -63,6 +64,7 @@ Future<Database> _openMessagesDb() async {
     )
   ''');
   await MessageReactionsDb.createTable(db);
+  await MessageSchemaMigrations.createMessageSearchFtsTable(db);
   return db;
 }
 

--- a/test/message_actions_service_test.dart
+++ b/test/message_actions_service_test.dart
@@ -10,6 +10,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:prysm/crypto/identity.dart';
 import 'package:prysm/crypto/ratchet/session_store.dart';
 import 'package:prysm/database/message_reactions.dart';
+import 'package:prysm/database/message_schema_migrations.dart';
 import 'package:prysm/database/messages.dart';
 import 'package:prysm/models/chat/prysm_message.dart';
 import 'package:prysm/services/group_service.dart';
@@ -51,6 +52,7 @@ Future<Database> _openMessagesDb() async {
     )
   ''');
   await MessageReactionsDb.createTable(db);
+  await MessageSchemaMigrations.createMessageSearchFtsTable(db);
   return db;
 }
 

--- a/test/message_schema_migrations_test.dart
+++ b/test/message_schema_migrations_test.dart
@@ -26,6 +26,10 @@ Future<bool> _tableExists(Database db, String name) async {
   return rows.isNotEmpty;
 }
 
+Future<bool> _virtualTableExists(Database db, String name) async {
+  return _tableExists(db, name);
+}
+
 void main() {
   late Directory docsDir;
 
@@ -74,6 +78,7 @@ void main() {
       expect(await _tableExists(db, 'message_read_receipts'), isTrue);
       expect(await _tableExists(db, 'self_messages'), isTrue);
       expect(await _tableExists(db, 'scheduled_messages'), isTrue);
+      expect(await _virtualTableExists(db, 'message_search_fts'), isTrue);
 
       await db.close();
     });
@@ -281,6 +286,39 @@ void main() {
       final sent = (await db.query('messages', where: 'id = ?', whereArgs: ['sent1'])).single;
       expect(sent['readAt'], 999);
 
+      await db.close();
+    });
+  });
+
+  group('v14 FTS search index', () {
+    test('onCreate includes message_search_fts virtual table', () async {
+      final db = await _openBareDb();
+      await MessageSchemaMigrations.onCreate(db, MessageSchemaMigrations.dbVersion);
+
+      expect(await _virtualTableExists(db, 'message_search_fts'), isTrue);
+
+      await db.execute('''
+        INSERT INTO message_search_fts(messageId, conversationId, scope, timestamp, body)
+        VALUES ('m1', 'peer1', 'direct', 100, 'hello world')
+      ''');
+      final hits = await db.rawQuery(
+        "SELECT messageId FROM message_search_fts WHERE message_search_fts MATCH 'hello'",
+      );
+      expect(hits, hasLength(1));
+      expect(hits.first['messageId'], 'm1');
+
+      await db.close();
+    });
+
+    test('upgrade from v13 adds message_search_fts', () async {
+      final db = await _openBareDb();
+      await MessageSchemaMigrations.onCreate(db, MessageSchemaMigrations.dbVersion);
+      await db.execute('DROP TABLE IF EXISTS message_search_fts');
+      expect(await _virtualTableExists(db, 'message_search_fts'), isFalse);
+
+      await MessageSchemaMigrations.onUpgrade(db, 13, 14);
+
+      expect(await _virtualTableExists(db, 'message_search_fts'), isTrue);
       await db.close();
     });
   });

--- a/test/message_search_backfill_test.dart
+++ b/test/message_search_backfill_test.dart
@@ -1,7 +1,9 @@
 import 'package:flutter_test/flutter_test.dart';
+import 'package:prysm/crypto/key_store.dart';
 import 'package:prysm/database/message_schema_migrations.dart';
 import 'package:prysm/database/message_search_dao.dart';
 import 'package:prysm/database/messages.dart';
+import 'package:prysm/models/unlock_type.dart';
 import 'package:prysm/services/message_search_backfill_service.dart';
 import 'package:prysm/util/key_manager.dart';
 import 'package:sqflite_common_ffi/sqflite_ffi.dart';
@@ -43,6 +45,15 @@ class _FakeStore implements MessageSearchBackfillStore {
     store['search_backfill_cursor_ts'] = timestamp;
     store['search_backfill_cursor_id'] = id;
   }
+
+  @override
+  Future<int> getSearchBackfillFailureCount(String rowKey) async =>
+      store['search_backfill_failures_$rowKey'] as int? ?? 0;
+
+  @override
+  Future<void> setSearchBackfillFailureCount(String rowKey, int count) async {
+    store['search_backfill_failures_$rowKey'] = count;
+  }
 }
 
 void main() {
@@ -53,6 +64,7 @@ void main() {
   });
 
   setUp(() async {
+    CryptoKeyStore.setUseInMemoryStorageOnly(true);
     final db = await databaseFactory.openDatabase(inMemoryDatabasePath);
     await MessageSchemaMigrations.onCreate(db, MessageSchemaMigrations.dbVersion);
     await db.insert('messages', {
@@ -72,7 +84,18 @@ void main() {
     MessagesDb.setDatabaseForTest(null);
   });
 
-  test('backfill skips rows that fail decrypt but marks complete', () async {
+  Future<KeyManager> unlockedKeyManager() async {
+    final keyManager = KeyManager();
+    final ok = await keyManager.unlockWithPassphrase(
+      'backfill-test-passphrase',
+      type: UnlockType.passphrase,
+    );
+    expect(ok, isTrue);
+    return keyManager;
+  }
+
+  test('backfill stops on decrypt failure, retains cursor, retries next run',
+      () async {
     final store = _FakeStore();
     final service = MessageSearchBackfillService(
       keyManager: KeyManager(),
@@ -82,6 +105,168 @@ void main() {
 
     await service.startIfNeeded();
 
+    expect(await store.isSearchBackfillComplete(), isFalse);
+    expect(await store.getSearchBackfillPhase(), 'messages');
+    expect(await store.getSearchBackfillCursorTimestamp(), 0);
+    expect(await store.getSearchBackfillCursorId(), '');
+    expect(await store.getSearchBackfillFailureCount('m1'), 1);
+    const dao = MessageSearchDao();
+    expect(await dao.searchGlobal('anything'), isEmpty);
+
+    // A second startIfNeeded retries the same row without completing.
+    await service.startIfNeeded();
+    expect(await store.getSearchBackfillFailureCount('m1'), 2);
+    expect(await store.isSearchBackfillComplete(), isFalse);
+  });
+
+  test('backfill indexes decryptable rows and marks complete', () async {
+    final keyManager = await unlockedKeyManager();
+    final encrypted = await keyManager.encryptForSelf('needle in haystack');
+    final db = await MessagesDb.database;
+    await db.delete('messages', where: 'id = ?', whereArgs: ['m1']);
+    await db.insert('messages', {
+      'id': 'm1',
+      'senderId': 'me',
+      'receiverId': 'peer',
+      'message': encrypted,
+      'type': 'text',
+      'timestamp': 100,
+      'status': 'sent',
+    });
+
+    final store = _FakeStore();
+    await MessageSearchBackfillService(
+      keyManager: keyManager,
+      userId: 'me',
+      store: store,
+    ).startIfNeeded();
+
+    expect(await store.isSearchBackfillComplete(), isTrue);
+    expect(await store.getSearchBackfillPhase(), 'done');
+    const dao = MessageSearchDao();
+    final hits = await dao.searchGlobal('needle');
+    expect(hits, hasLength(1));
+    expect(hits.first.messageId, 'm1');
+  });
+
+  test('messages-to-self transition resets the cursor to (0, \'\')', () async {
+    final db = await MessagesDb.database;
+    await db.delete('messages', where: 'id = ?', whereArgs: ['m1']);
+    await db.insert('self_messages', {
+      'id': 's1',
+      'message': 'encrypted',
+      'type': 'text',
+      'timestamp': 100,
+    });
+
+    final store = _FakeStore();
+    await MessageSearchBackfillService(
+      keyManager: KeyManager(),
+      userId: 'me',
+      store: store,
+    ).startIfNeeded();
+
+    expect(await store.getSearchBackfillPhase(), 'self');
+    expect(await store.getSearchBackfillCursorTimestamp(), 0);
+    expect(await store.getSearchBackfillCursorId(), '');
+    expect(await store.isSearchBackfillComplete(), isFalse);
+    expect(await store.getSearchBackfillFailureCount('s1'), 1);
+  });
+
+  test('resumption from a non-zero cursor skips earlier rows', () async {
+    final keyManager = await unlockedKeyManager();
+    final encrypted = await keyManager.encryptForSelf('needle in haystack');
+    final db = await MessagesDb.database;
+    await db.delete('messages', where: 'id = ?', whereArgs: ['m1']);
+    await db.insert('messages', {
+      'id': 'm1',
+      'senderId': 'me',
+      'receiverId': 'peer',
+      'message': encrypted,
+      'type': 'text',
+      'timestamp': 100,
+      'status': 'sent',
+    });
+    await db.insert('messages', {
+      'id': 'm2',
+      'senderId': 'me',
+      'receiverId': 'peer',
+      'message': encrypted,
+      'type': 'text',
+      'timestamp': 200,
+      'status': 'sent',
+    });
+
+    final store = _FakeStore();
+    await store.setSearchBackfillCursor(timestamp: 100, id: 'm1');
+    await MessageSearchBackfillService(
+      keyManager: keyManager,
+      userId: 'me',
+      store: store,
+    ).startIfNeeded();
+
+    expect(await store.isSearchBackfillComplete(), isTrue);
+    const dao = MessageSearchDao();
+    final hits = await dao.searchGlobal('needle');
+    // m1 sits at/behind the cursor and must not be re-indexed; only m2 is.
+    expect(hits.map((h) => h.messageId).toList(), ['m2']);
+  });
+
+  test('resumption skips already-indexed rows', () async {
+    final keyManager = await unlockedKeyManager();
+    final encrypted = await keyManager.encryptForSelf('needle in haystack');
+    final db = await MessagesDb.database;
+    await db.delete('messages', where: 'id = ?', whereArgs: ['m1']);
+    await db.insert('messages', {
+      'id': 'm1',
+      'senderId': 'me',
+      'receiverId': 'peer',
+      'message': encrypted,
+      'type': 'text',
+      'timestamp': 100,
+      'status': 'sent',
+    });
+
+    const dao = MessageSearchDao();
+    await dao.upsert(
+      messageId: 'm1',
+      conversationId: 'peer',
+      scope: 'direct',
+      timestamp: 100,
+      body: 'pre-indexed copy',
+    );
+
+    final store = _FakeStore();
+    await MessageSearchBackfillService(
+      keyManager: keyManager,
+      userId: 'me',
+      store: store,
+    ).startIfNeeded();
+
+    expect(await store.isSearchBackfillComplete(), isTrue);
+    final hits = await dao.searchGlobal('pre-indexed');
+    expect(hits, hasLength(1));
+    expect(hits.first.body, 'pre-indexed copy');
+  });
+
+  test('backfill permanently skips a row after max retries and completes',
+      () async {
+    final store = _FakeStore();
+    final service = MessageSearchBackfillService(
+      keyManager: KeyManager(),
+      userId: 'me',
+      store: store,
+    );
+
+    // Exhaust the retry budget for m1, then a fresh run skips it permanently.
+    for (var i = 0; i < 4; i++) {
+      await service.startIfNeeded();
+    }
+    expect(await store.getSearchBackfillFailureCount('m1'), 4);
+    expect(await store.isSearchBackfillComplete(), isFalse);
+
+    await service.startIfNeeded();
+    expect(await store.getSearchBackfillFailureCount('m1'), 5);
     expect(await store.isSearchBackfillComplete(), isTrue);
     const dao = MessageSearchDao();
     expect(await dao.searchGlobal('anything'), isEmpty);

--- a/test/message_search_backfill_test.dart
+++ b/test/message_search_backfill_test.dart
@@ -1,0 +1,89 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:prysm/database/message_schema_migrations.dart';
+import 'package:prysm/database/message_search_dao.dart';
+import 'package:prysm/database/messages.dart';
+import 'package:prysm/services/message_search_backfill_service.dart';
+import 'package:prysm/util/key_manager.dart';
+import 'package:sqflite_common_ffi/sqflite_ffi.dart';
+
+class _FakeStore implements MessageSearchBackfillStore {
+  final Map<String, Object> store = {};
+
+  @override
+  Future<bool> isSearchBackfillComplete() async =>
+      store['search_backfill_complete'] as bool? ?? false;
+
+  @override
+  Future<void> setSearchBackfillComplete(bool value) async {
+    store['search_backfill_complete'] = value;
+  }
+
+  @override
+  Future<String> getSearchBackfillPhase() async =>
+      store['search_backfill_phase'] as String? ?? 'messages';
+
+  @override
+  Future<void> setSearchBackfillPhase(String phase) async {
+    store['search_backfill_phase'] = phase;
+  }
+
+  @override
+  Future<int> getSearchBackfillCursorTimestamp() async =>
+      store['search_backfill_cursor_ts'] as int? ?? 0;
+
+  @override
+  Future<String> getSearchBackfillCursorId() async =>
+      store['search_backfill_cursor_id'] as String? ?? '';
+
+  @override
+  Future<void> setSearchBackfillCursor({
+    required int timestamp,
+    required String id,
+  }) async {
+    store['search_backfill_cursor_ts'] = timestamp;
+    store['search_backfill_cursor_id'] = id;
+  }
+}
+
+void main() {
+  setUpAll(() {
+    TestWidgetsFlutterBinding.ensureInitialized();
+    sqfliteFfiInit();
+    databaseFactory = databaseFactoryFfi;
+  });
+
+  setUp(() async {
+    final db = await databaseFactory.openDatabase(inMemoryDatabasePath);
+    await MessageSchemaMigrations.onCreate(db, MessageSchemaMigrations.dbVersion);
+    await db.insert('messages', {
+      'id': 'm1',
+      'senderId': 'me',
+      'receiverId': 'peer',
+      'message': 'encrypted',
+      'type': 'text',
+      'timestamp': 100,
+      'status': 'sent',
+    });
+    MessagesDb.setDatabaseForTest(db);
+  });
+
+  tearDown(() async {
+    await MessagesDb.close();
+    MessagesDb.setDatabaseForTest(null);
+  });
+
+  test('backfill skips rows that fail decrypt but marks complete', () async {
+    final store = _FakeStore();
+    final service = MessageSearchBackfillService(
+      keyManager: KeyManager(),
+      userId: 'me',
+      store: store,
+    );
+
+    await service.startIfNeeded();
+
+    expect(await store.isSearchBackfillComplete(), isTrue);
+    const dao = MessageSearchDao();
+    expect(await dao.searchGlobal('anything'), isEmpty);
+  });
+}

--- a/test/message_search_backfill_test.dart
+++ b/test/message_search_backfill_test.dart
@@ -1,4 +1,5 @@
 import 'package:flutter_test/flutter_test.dart';
+import 'package:prysm/constants/group_constants.dart';
 import 'package:prysm/crypto/key_store.dart';
 import 'package:prysm/database/message_schema_migrations.dart';
 import 'package:prysm/database/message_search_dao.dart';
@@ -7,6 +8,21 @@ import 'package:prysm/models/unlock_type.dart';
 import 'package:prysm/services/message_search_backfill_service.dart';
 import 'package:prysm/util/key_manager.dart';
 import 'package:sqflite_common_ffi/sqflite_ffi.dart';
+
+class _FailingSearchDao extends MessageSearchDao {
+  const _FailingSearchDao();
+
+  @override
+  Future<void> upsert({
+    required String messageId,
+    required String conversationId,
+    required String scope,
+    required int timestamp,
+    required String body,
+  }) async {
+    throw StateError('fts write failed');
+  }
+}
 
 class _FakeStore implements MessageSearchBackfillStore {
   final Map<String, Object> store = {};
@@ -268,6 +284,98 @@ void main() {
     await service.startIfNeeded();
     expect(await store.getSearchBackfillFailureCount('m1'), 5);
     expect(await store.isSearchBackfillComplete(), isTrue);
+    const dao = MessageSearchDao();
+    expect(await dao.searchGlobal('anything'), isEmpty);
+  });
+
+  test('identical wire ids in two groups are backfilled independently',
+      () async {
+    final db = await MessagesDb.database;
+    await db.delete('messages', where: 'id = ?', whereArgs: ['m1']);
+    await db.insert('messages', {
+      'id': 'groupA::shared',
+      'senderId': 'alice',
+      'receiverId': 'me',
+      'message': 'unused',
+      'type': groupFileType,
+      'groupId': 'groupA',
+      'fileName': 'alpha.txt',
+      'timestamp': 100,
+      'status': 'sent',
+    });
+    await db.insert('messages', {
+      'id': 'groupB::shared',
+      'senderId': 'alice',
+      'receiverId': 'me',
+      'message': 'unused',
+      'type': groupFileType,
+      'groupId': 'groupB',
+      'fileName': 'beta.txt',
+      'timestamp': 200,
+      'status': 'sent',
+    });
+
+    final store = _FakeStore();
+    await MessageSearchBackfillService(
+      keyManager: KeyManager(),
+      userId: 'me',
+      store: store,
+    ).startIfNeeded();
+
+    expect(await store.isSearchBackfillComplete(), isTrue);
+    const dao = MessageSearchDao();
+    final alpha = await dao.searchGlobal('alpha');
+    expect(alpha, hasLength(1));
+    expect(alpha.first.messageId, 'shared');
+    expect(alpha.first.conversationId, 'groupA');
+    final beta = await dao.searchGlobal('beta');
+    expect(beta, hasLength(1));
+    expect(beta.first.messageId, 'shared');
+    expect(beta.first.conversationId, 'groupB');
+
+    // Deleting one group's hit leaves the other group's hit intact.
+    await dao.remove('shared', conversationId: 'groupA', scope: 'group');
+    expect(await dao.searchGlobal('beta'), hasLength(1));
+  });
+
+  test('backfill retries when the FTS write fails, retaining the cursor',
+      () async {
+    final db = await MessagesDb.database;
+    await db.delete('messages', where: 'id = ?', whereArgs: ['m1']);
+    await db.insert('messages', {
+      'id': 'groupX::m1',
+      'senderId': 'alice',
+      'receiverId': 'me',
+      'message': 'unused',
+      'type': groupFileType,
+      'groupId': 'groupX',
+      'fileName': 'f.txt',
+      'timestamp': 100,
+      'status': 'sent',
+    });
+
+    final store = _FakeStore();
+    final service = MessageSearchBackfillService(
+      keyManager: KeyManager(),
+      userId: 'me',
+      store: store,
+      searchDao: const _FailingSearchDao(),
+    );
+
+    await service.startIfNeeded();
+
+    expect(await store.isSearchBackfillComplete(), isFalse);
+    expect(await store.getSearchBackfillPhase(), 'messages');
+    expect(await store.getSearchBackfillCursorTimestamp(), 0);
+    expect(await store.getSearchBackfillCursorId(), '');
+    expect(await store.getSearchBackfillFailureCount('groupX::m1'), 1);
+
+    // A second run retries the same row instead of advancing past it.
+    await service.startIfNeeded();
+    expect(await store.getSearchBackfillFailureCount('groupX::m1'), 2);
+    expect(await store.getSearchBackfillCursorTimestamp(), 0);
+    expect(await store.isSearchBackfillComplete(), isFalse);
+
     const dao = MessageSearchDao();
     expect(await dao.searchGlobal('anything'), isEmpty);
   });

--- a/test/message_search_call_sites_test.dart
+++ b/test/message_search_call_sites_test.dart
@@ -1,0 +1,76 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/rendering.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:prysm/crypto/identity.dart';
+import 'package:prysm/database/message_schema_migrations.dart';
+import 'package:prysm/database/messages.dart';
+import 'package:prysm/database/self_messages_db.dart';
+import 'package:prysm/screens/widgets/linked_message_text.dart';
+import 'package:prysm/services/self_chat_service.dart';
+import 'package:prysm/util/key_manager.dart';
+import 'package:sqflite_common_ffi/sqflite_ffi.dart';
+
+Future<void> _openUrl(String url) async {}
+
+void main() {
+  setUpAll(() {
+    sqfliteFfiInit();
+    databaseFactory = databaseFactoryFfi;
+  });
+
+  setUp(() async {
+    final db = await databaseFactory.openDatabase(inMemoryDatabasePath);
+    await MessageSchemaMigrations.onCreate(db, MessageSchemaMigrations.dbVersion);
+    MessagesDb.setDatabaseForTest(db);
+    SelfMessagesDb.setDatabaseForTest(db);
+  });
+
+  tearDown(() async {
+    await MessagesDb.close();
+    MessagesDb.setDatabaseForTest(null);
+    SelfMessagesDb.setDatabaseForTest(null);
+  });
+
+  testWidgets('LinkedMessageText scales with the ambient text scaler',
+      (tester) async {
+    Future<double> scaledFontSize(TextScaler scaler) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: MediaQuery(
+            data: MediaQueryData(textScaler: scaler),
+            child: const LinkedMessageText(
+              text: 'hello world',
+              textColor: Colors.black,
+              fontSize: 14,
+              onOpenUrl: _openUrl,
+            ),
+          ),
+        ),
+      );
+      final paragraph = tester.renderObject<RenderParagraph>(
+        find.descendant(
+          of: find.byType(LinkedMessageText),
+          matching: find.byType(RichText),
+        ),
+      );
+      return paragraph.textScaler.scale(14);
+    }
+
+    expect(await scaledFontSize(TextScaler.linear(2.0)), 28.0);
+    expect(await scaledFontSize(TextScaler.linear(1.0)), 14.0);
+  });
+
+  test('sendTextMessage stores the note even when the FTS table is missing',
+      () async {
+    final db = await MessagesDb.database;
+    await db.execute('DROP TABLE message_search_fts');
+
+    final keyManager =
+        KeyManager.fromIdentity(await IdentityKeyPair.generate());
+    final service = SelfChatService(userId: 'me.onion', keyManager: keyManager);
+
+    final id = await service.sendTextMessage('hello world');
+
+    expect(await SelfMessagesDb.getMessageById(id), hasLength(1));
+  });
+}

--- a/test/message_search_dao_test.dart
+++ b/test/message_search_dao_test.dart
@@ -55,7 +55,14 @@ void main() {
     expect(scoped.first.messageId, 'm2');
 
     await dao.remove('m1');
-    expect(await dao.exists('m1'), isFalse);
+    expect(
+      await dao.exists(
+        messageId: 'm1',
+        conversationId: 'peer1',
+        scope: 'direct',
+      ),
+      isFalse,
+    );
     expect(await dao.searchGlobal('hello'), isEmpty);
   });
 
@@ -102,7 +109,14 @@ void main() {
     );
 
     expect(await dao.searchGlobal('hello'), isEmpty);
-    expect(await dao.exists('m1'), isFalse);
+    expect(
+      await dao.exists(
+        messageId: 'm1',
+        conversationId: 'peer1',
+        scope: 'direct',
+      ),
+      isFalse,
+    );
   });
 
   test('same messageId in two groups stays independent', () async {
@@ -140,12 +154,34 @@ void main() {
 
     // Removing one group must not delete the other group's hit.
     await dao.remove('shared', conversationId: 'groupA', scope: 'group');
-    expect(await dao.exists('shared'), isTrue);
+    expect(
+      await dao.exists(
+        messageId: 'shared',
+        conversationId: 'groupA',
+        scope: 'group',
+      ),
+      isFalse,
+    );
+    expect(
+      await dao.exists(
+        messageId: 'shared',
+        conversationId: 'groupB',
+        scope: 'group',
+      ),
+      isTrue,
+    );
     final remaining = await dao.searchGlobal('beta');
     expect(remaining, hasLength(1));
     expect(remaining.first.conversationId, 'groupB');
 
     await dao.remove('shared', conversationId: 'groupB', scope: 'group');
-    expect(await dao.exists('shared'), isFalse);
+    expect(
+      await dao.exists(
+        messageId: 'shared',
+        conversationId: 'groupB',
+        scope: 'group',
+      ),
+      isFalse,
+    );
   });
 }

--- a/test/message_search_dao_test.dart
+++ b/test/message_search_dao_test.dart
@@ -80,4 +80,72 @@ void main() {
     expect(hits, hasLength(1));
     expect(hits.first.body, 'edited text');
   });
+
+  test('upsert with empty trimmed body removes the existing index row',
+      () async {
+    const dao = MessageSearchDao();
+    await dao.upsert(
+      messageId: 'm1',
+      conversationId: 'peer1',
+      scope: 'direct',
+      timestamp: 100,
+      body: 'hello world',
+    );
+    expect(await dao.searchGlobal('hello'), hasLength(1));
+
+    await dao.upsert(
+      messageId: 'm1',
+      conversationId: 'peer1',
+      scope: 'direct',
+      timestamp: 100,
+      body: '   ',
+    );
+
+    expect(await dao.searchGlobal('hello'), isEmpty);
+    expect(await dao.exists('m1'), isFalse);
+  });
+
+  test('same messageId in two groups stays independent', () async {
+    const dao = MessageSearchDao();
+    await dao.upsert(
+      messageId: 'shared',
+      conversationId: 'groupA',
+      scope: 'group',
+      timestamp: 100,
+      body: 'hello alpha',
+    );
+    await dao.upsert(
+      messageId: 'shared',
+      conversationId: 'groupB',
+      scope: 'group',
+      timestamp: 200,
+      body: 'hello beta',
+    );
+
+    // Upserting one group must not replace or delete the other group's hit.
+    await dao.upsert(
+      messageId: 'shared',
+      conversationId: 'groupA',
+      scope: 'group',
+      timestamp: 100,
+      body: 'edited alpha',
+    );
+
+    final editedHits = await dao.searchGlobal('edited');
+    expect(editedHits, hasLength(1));
+    expect(editedHits.first.conversationId, 'groupA');
+    final betaHits = await dao.searchGlobal('beta');
+    expect(betaHits, hasLength(1));
+    expect(betaHits.first.conversationId, 'groupB');
+
+    // Removing one group must not delete the other group's hit.
+    await dao.remove('shared', conversationId: 'groupA', scope: 'group');
+    expect(await dao.exists('shared'), isTrue);
+    final remaining = await dao.searchGlobal('beta');
+    expect(remaining, hasLength(1));
+    expect(remaining.first.conversationId, 'groupB');
+
+    await dao.remove('shared', conversationId: 'groupB', scope: 'group');
+    expect(await dao.exists('shared'), isFalse);
+  });
 }

--- a/test/message_search_dao_test.dart
+++ b/test/message_search_dao_test.dart
@@ -54,7 +54,7 @@ void main() {
     expect(scoped, hasLength(1));
     expect(scoped.first.messageId, 'm2');
 
-    await dao.remove('m1');
+    await dao.remove('m1', conversationId: 'peer1', scope: 'direct');
     expect(
       await dao.exists(
         messageId: 'm1',

--- a/test/message_search_dao_test.dart
+++ b/test/message_search_dao_test.dart
@@ -1,0 +1,83 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:prysm/database/message_schema_migrations.dart';
+import 'package:prysm/database/message_search_dao.dart';
+import 'package:prysm/database/messages.dart';
+import 'package:sqflite_common_ffi/sqflite_ffi.dart';
+
+void main() {
+  setUpAll(() {
+    sqfliteFfiInit();
+    databaseFactory = databaseFactoryFfi;
+  });
+
+  setUp(() async {
+    final db = await databaseFactory.openDatabase(inMemoryDatabasePath);
+    await MessageSchemaMigrations.onCreate(db, MessageSchemaMigrations.dbVersion);
+    MessagesDb.setDatabaseForTest(db);
+  });
+
+  tearDown(() async {
+    await MessagesDb.close();
+    MessagesDb.setDatabaseForTest(null);
+  });
+
+  test('escapeFtsQuery builds prefix OR query', () {
+    expect(
+      MessageSearchDao.escapeFtsQuery('hello world'),
+      '"hello"* OR "world"*',
+    );
+    expect(MessageSearchDao.escapeFtsQuery('  '), '');
+  });
+
+  test('upsert search remove and global search', () async {
+    const dao = MessageSearchDao();
+    await dao.upsert(
+      messageId: 'm1',
+      conversationId: 'peer1',
+      scope: 'direct',
+      timestamp: 100,
+      body: 'hello world',
+    );
+    await dao.upsert(
+      messageId: 'm2',
+      conversationId: 'peer2',
+      scope: 'direct',
+      timestamp: 200,
+      body: 'goodbye moon',
+    );
+
+    final hits = await dao.searchGlobal('hello');
+    expect(hits, hasLength(1));
+    expect(hits.first.messageId, 'm1');
+
+    final scoped = await dao.searchInConversation('peer2', 'moon');
+    expect(scoped, hasLength(1));
+    expect(scoped.first.messageId, 'm2');
+
+    await dao.remove('m1');
+    expect(await dao.exists('m1'), isFalse);
+    expect(await dao.searchGlobal('hello'), isEmpty);
+  });
+
+  test('upsert replaces existing row for same messageId', () async {
+    const dao = MessageSearchDao();
+    await dao.upsert(
+      messageId: 'm1',
+      conversationId: 'peer1',
+      scope: 'direct',
+      timestamp: 100,
+      body: 'first text',
+    );
+    await dao.upsert(
+      messageId: 'm1',
+      conversationId: 'peer1',
+      scope: 'direct',
+      timestamp: 100,
+      body: 'edited text',
+    );
+
+    final hits = await dao.searchGlobal('edited');
+    expect(hits, hasLength(1));
+    expect(hits.first.body, 'edited text');
+  });
+}

--- a/test/message_search_delete_test.dart
+++ b/test/message_search_delete_test.dart
@@ -1,0 +1,214 @@
+// FTS de-indexing on message delete: every delete path must remove its
+// search rows, scoped so a direct removal can never touch a group row that
+// happens to share the same (attacker-suppliable) wire id.
+import 'dart:io';
+
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:prysm/crypto/identity.dart';
+import 'package:prysm/database/message_schema_migrations.dart';
+import 'package:prysm/database/message_search_dao.dart';
+import 'package:prysm/database/messages.dart';
+import 'package:prysm/models/chat/prysm_message.dart';
+import 'package:prysm/services/message_actions_service.dart';
+import 'package:prysm/services/message_modify_service.dart';
+import 'package:prysm/util/key_manager.dart';
+import 'package:prysm/util/pending_message_db_helper.dart';
+import 'package:sqflite_common_ffi/sqflite_ffi.dart';
+
+const MessageSearchDao searchDao = MessageSearchDao();
+
+void main() {
+  setUpAll(() {
+    TestWidgetsFlutterBinding.ensureInitialized();
+    sqfliteFfiInit();
+    databaseFactory = databaseFactoryFfi;
+    // MessageContentWiper / MessageBlobStore touch the file system; the
+    // MessageActionsService end-to-end test needs a path provider.
+    final tempDir = Directory.systemTemp.createTempSync('prysm_search_delete_');
+    const channel = MethodChannel('plugins.flutter.io/path_provider');
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(channel, (call) async => tempDir.path);
+  });
+
+  late Database db;
+  late Database pendingDb;
+
+  setUp(() async {
+    db = await databaseFactory.openDatabase(inMemoryDatabasePath);
+    await MessageSchemaMigrations.onCreate(db, MessageSchemaMigrations.dbVersion);
+    MessagesDb.setDatabaseForTest(db);
+
+    pendingDb = await databaseFactory.openDatabase(inMemoryDatabasePath);
+    await pendingDb.execute('''
+      CREATE TABLE pending_messages(
+        id TEXT PRIMARY KEY,
+        senderId TEXT,
+        receiverId TEXT,
+        message TEXT,
+        type TEXT,
+        fileName TEXT,
+        fileSize INTEGER,
+        timestamp INTEGER,
+        status TEXT,
+        replyTo TEXT,
+        viewOnce INTEGER DEFAULT 0,
+        groupId TEXT,
+        targetMemberId TEXT
+      )
+    ''');
+    PendingMessageDbHelper.setDatabaseForTest(pendingDb);
+  });
+
+  tearDown(() async {
+    await MessagesDb.close();
+    MessagesDb.setDatabaseForTest(null);
+    await pendingDb.close();
+    PendingMessageDbHelper.setDatabaseForTest(null);
+  });
+
+  /// Mirrors MessageSearchIndexService.indexInboundRow: direct FTS rows are
+  /// keyed by the peer (the party that is not the local user).
+  Future<void> insertDirect(
+    String id,
+    String senderId,
+    String receiverId,
+    String localUserId,
+    int timestamp, {
+    required String ftsBody,
+  }) async {
+    await MessagesDb.insertMessage({
+      'id': id,
+      'senderId': senderId,
+      'receiverId': receiverId,
+      'message': 'cipher',
+      'type': 'text',
+      'status': 'sent',
+      'timestamp': timestamp,
+    });
+    await searchDao.upsert(
+      messageId: id,
+      conversationId: senderId == localUserId ? receiverId : senderId,
+      scope: 'direct',
+      timestamp: timestamp,
+      body: ftsBody,
+    );
+  }
+
+  Future<void> insertGroup(
+    String id,
+    String groupId,
+    int timestamp, {
+    required String ftsBody,
+  }) async {
+    await MessagesDb.insertMessage({
+      'id': id,
+      'senderId': 'peer',
+      'receiverId': 'me',
+      'message': 'cipher',
+      'type': 'text',
+      'status': 'sent',
+      'timestamp': timestamp,
+      'groupId': groupId,
+    });
+    await searchDao.upsert(
+      messageId: id,
+      conversationId: groupId,
+      scope: 'group',
+      timestamp: timestamp,
+      body: ftsBody,
+    );
+  }
+
+  test('deleteMessageById removes the FTS row for a direct message', () async {
+    await insertDirect('dm-1', 'peer', 'me', 'me', 1, ftsBody: 'alpha needle');
+    expect(await searchDao.searchGlobal('alpha'), hasLength(1));
+
+    await MessagesDb.deleteMessageById('dm-1');
+
+    expect(await searchDao.searchGlobal('alpha'), isEmpty);
+    expect(await MessagesDb.getMessageById('dm-1'), isEmpty);
+  });
+
+  test('deleteMessageById removes the FTS row for a group message', () async {
+    await insertGroup('gm-1', 'g1', 2, ftsBody: 'beta needle');
+    expect(await searchDao.searchGlobal('beta'), hasLength(1));
+
+    await MessagesDb.deleteMessageById('g1::gm-1');
+
+    expect(await searchDao.searchGlobal('beta'), isEmpty);
+  });
+
+  test('a direct delete keeps a group FTS row with the same wire id',
+      () async {
+    await insertDirect('shared', 'peer', 'me', 'me', 3,
+        ftsBody: 'zebra stripe');
+    await insertGroup('shared', 'g1', 4, ftsBody: 'giraffe spot');
+    expect(await searchDao.searchGlobal('zebra'), hasLength(1));
+    expect(await searchDao.searchGlobal('giraffe'), hasLength(1));
+
+    await MessagesDb.deleteMessageById('shared'); // direct storage id
+
+    expect(await searchDao.searchGlobal('zebra'), isEmpty);
+    final hits = await searchDao.searchGlobal('giraffe');
+    expect(hits, hasLength(1));
+    expect(hits.first.conversationId, 'g1');
+  });
+
+  test('deleteMessagesForGroup removes the group FTS rows', () async {
+    await insertGroup('g2-1', 'g2', 1, ftsBody: 'charlie old');
+    await insertGroup('g2-2', 'g2', 2, ftsBody: 'delta old');
+    expect(await searchDao.searchGlobal('charlie'), hasLength(1));
+
+    await MessagesDb.deleteMessagesForGroup('g2');
+
+    expect(await searchDao.searchGlobal('charlie'), isEmpty);
+    expect(await searchDao.searchGlobal('delta'), isEmpty);
+  });
+
+  test('deleteGroupMessagesBefore removes only the older FTS rows', () async {
+    await insertGroup('g3-1', 'g3', 100, ftsBody: 'echo old');
+    await insertGroup('g3-2', 'g3', 200, ftsBody: 'foxtrot new');
+
+    await MessagesDb.deleteGroupMessagesBefore('g3', 150);
+
+    expect(await searchDao.searchGlobal('echo'), isEmpty);
+    final hits = await searchDao.searchGlobal('foxtrot');
+    expect(hits, hasLength(1));
+    expect(hits.first.messageId, 'g3-2');
+  });
+
+  test('deleteMessagesBetween removes both directions of FTS rows', () async {
+    await insertDirect('dm-2', 'me', 'peer', 'me', 1,
+        ftsBody: 'hotel outbound');
+    await insertDirect('dm-3', 'peer', 'me', 'me', 2,
+        ftsBody: 'india inbound');
+
+    await MessagesDb.deleteMessagesBetween('me', 'peer');
+
+    expect(await searchDao.searchGlobal('hotel'), isEmpty);
+    expect(await searchDao.searchGlobal('india'), isEmpty);
+  });
+
+  test('MessageActionsService local-only delete de-indexes the message',
+      () async {
+    const wireId = 'wire-7';
+    await insertDirect(wireId, 'peer', 'me', 'me', 1,
+        ftsBody: 'juliet needle');
+    final actions = MessageActionsService(
+      modifyService: MessageModifyService.direct(
+        userId: 'me',
+        keyManager: KeyManager.fromIdentity(await IdentityKeyPair.generate()),
+        peerId: 'peer',
+      ),
+    );
+
+    final outcome = await actions.deleteMessage(
+      TextMessage(id: wireId, authorId: 'peer', text: 'x'),
+      localUserId: 'me',
+    );
+
+    expect(outcome, MessageDeleteOutcome.removedLocally);
+    expect(await searchDao.searchGlobal('juliet'), isEmpty);
+  });
+}

--- a/test/message_search_index_fixes_test.dart
+++ b/test/message_search_index_fixes_test.dart
@@ -1,0 +1,252 @@
+import 'dart:io';
+
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:prysm/crypto/key_store.dart';
+import 'package:prysm/database/message_schema_migrations.dart';
+import 'package:prysm/database/message_search_dao.dart';
+import 'package:prysm/database/messages.dart';
+import 'package:prysm/models/unlock_type.dart';
+import 'package:prysm/services/message_search_backfill_service.dart';
+import 'package:prysm/services/message_search_index_service.dart';
+import 'package:prysm/util/key_manager.dart';
+import 'package:prysm/util/message_blob_store.dart';
+import 'package:sqflite_common_ffi/sqflite_ffi.dart';
+
+class _FakeStore implements MessageSearchBackfillStore {
+  final Map<String, Object> store = {};
+
+  @override
+  Future<bool> isSearchBackfillComplete() async =>
+      store['search_backfill_complete'] as bool? ?? false;
+
+  @override
+  Future<void> setSearchBackfillComplete(bool value) async {
+    store['search_backfill_complete'] = value;
+  }
+
+  @override
+  Future<String> getSearchBackfillPhase() async =>
+      store['search_backfill_phase'] as String? ?? 'messages';
+
+  @override
+  Future<void> setSearchBackfillPhase(String phase) async {
+    store['search_backfill_phase'] = phase;
+  }
+
+  @override
+  Future<int> getSearchBackfillCursorTimestamp() async =>
+      store['search_backfill_cursor_ts'] as int? ?? 0;
+
+  @override
+  Future<String> getSearchBackfillCursorId() async =>
+      store['search_backfill_cursor_id'] as String? ?? '';
+
+  @override
+  Future<void> setSearchBackfillCursor({
+    required int timestamp,
+    required String id,
+  }) async {
+    store['search_backfill_cursor_ts'] = timestamp;
+    store['search_backfill_cursor_id'] = id;
+  }
+
+  @override
+  Future<int> getSearchBackfillFailureCount(String rowKey) async =>
+      store['search_backfill_failures_$rowKey'] as int? ?? 0;
+
+  @override
+  Future<void> setSearchBackfillFailureCount(String rowKey, int count) async {
+    store['search_backfill_failures_$rowKey'] = count;
+  }
+}
+
+void main() {
+  setUpAll(() {
+    TestWidgetsFlutterBinding.ensureInitialized();
+    sqfliteFfiInit();
+    databaseFactory = databaseFactoryFfi;
+  });
+
+  setUp(() async {
+    CryptoKeyStore.setUseInMemoryStorageOnly(true);
+    final docsDir = Directory.systemTemp.createTempSync('search_index_fixes');
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(
+      MethodChannel('plugins.flutter.io/path_provider'),
+      (call) async {
+        if (call.method == 'getApplicationDocumentsDirectory') {
+          return docsDir.path;
+        }
+        return null;
+      },
+    );
+    final db = await databaseFactory.openDatabase(inMemoryDatabasePath);
+    await MessageSchemaMigrations.onCreate(db, MessageSchemaMigrations.dbVersion);
+    MessagesDb.setDatabaseForTest(db);
+  });
+
+  tearDown(() async {
+    await MessagesDb.close();
+    MessagesDb.setDatabaseForTest(null);
+  });
+
+  Future<KeyManager> unlockedKeyManager() async {
+    final keyManager = KeyManager();
+    final ok = await keyManager.unlockWithPassphrase(
+      'search-index-fixes-passphrase',
+      type: UnlockType.passphrase,
+    );
+    expect(ok, isTrue);
+    return keyManager;
+  }
+
+  Future<Map<String, dynamic>> messageRow(String id) async {
+    final db = await MessagesDb.database;
+    return (await db.query('messages', where: 'id = ?', whereArgs: [id]))
+        .single;
+  }
+
+  test('unviewed view-once rows are not indexed; normal rows are', () async {
+    final db = await MessagesDb.database;
+    await db.insert('messages', {
+      'id': 'vo1',
+      'senderId': 'alice',
+      'receiverId': 'me',
+      'message': 'unused',
+      'type': 'file',
+      'fileName': 'vo.png',
+      'viewOnce': 1,
+      'viewed': 0,
+      'timestamp': 100,
+      'status': 'received',
+    });
+    await db.insert('messages', {
+      'id': 'n1',
+      'senderId': 'alice',
+      'receiverId': 'me',
+      'message': 'unused',
+      'type': 'file',
+      'fileName': 'normal.txt',
+      'timestamp': 200,
+      'status': 'received',
+    });
+
+    final service =
+        MessageSearchIndexService(keyManager: KeyManager(), userId: 'me');
+    expect(await service.indexInboundRow(await messageRow('vo1'), 'me'),
+        isTrue);
+    expect(await service.indexInboundRow(await messageRow('n1'), 'me'),
+        isTrue);
+
+    const dao = MessageSearchDao();
+    expect(await dao.searchGlobal('vo'), isEmpty);
+    final hits = await dao.searchGlobal('normal');
+    expect(hits, hasLength(1));
+    expect(hits.first.messageId, 'n1');
+  });
+
+  test('indexInboundRow resolves oversized blob markers before decrypting',
+      () async {
+    final keyManager = await unlockedKeyManager();
+    final encrypted = await keyManager.encryptForSelf('needle in the haystack');
+    final db = await MessagesDb.database;
+    // A marker row is what prepareForStorage leaves behind for any payload
+    // over MessageBlobStore.inlineThreshold.
+    await db.insert('messages', {
+      'id': 'big1',
+      'senderId': 'me',
+      'receiverId': 'peer',
+      'message': MessageBlobStore.marker('big1'),
+      'type': 'text',
+      'timestamp': 100,
+      'status': 'sent',
+    });
+    await MessageBlobStore.save('big1', encrypted);
+    await db.insert('messages', {
+      'id': 'small1',
+      'senderId': 'me',
+      'receiverId': 'peer',
+      'message': await keyManager.encryptForSelf('second note mentions pineapple'),
+      'type': 'text',
+      'timestamp': 200,
+      'status': 'sent',
+    });
+
+    final service = MessageSearchIndexService(
+      keyManager: keyManager,
+      userId: 'me',
+    );
+    expect(await service.indexInboundRow(await messageRow('big1'), 'me'),
+        isTrue);
+    expect(await service.indexInboundRow(await messageRow('small1'), 'me'),
+        isTrue);
+
+    const dao = MessageSearchDao();
+    final bigHits = await dao.searchGlobal('needle');
+    expect(bigHits, hasLength(1));
+    expect(bigHits.first.messageId, 'big1');
+    expect(bigHits.first.conversationId, 'peer');
+    expect((await dao.searchGlobal('pineapple')), hasLength(1));
+  });
+
+  test('backfill completes over an oversized blob-marker row and resets '
+      'its failure count', () async {
+    final keyManager = await unlockedKeyManager();
+    final encrypted = await keyManager.encryptForSelf('needle in the haystack');
+    final db = await MessagesDb.database;
+    await db.insert('messages', {
+      'id': 'big1',
+      'senderId': 'me',
+      'receiverId': 'peer',
+      'message': MessageBlobStore.marker('big1'),
+      'type': 'text',
+      'timestamp': 100,
+      'status': 'sent',
+    });
+    await MessageBlobStore.save('big1', encrypted);
+    await db.insert('messages', {
+      'id': 'small1',
+      'senderId': 'me',
+      'receiverId': 'peer',
+      'message': await keyManager.encryptForSelf('second note mentions pineapple'),
+      'type': 'text',
+      'timestamp': 200,
+      'status': 'sent',
+    });
+
+    final store = _FakeStore();
+    // Prior transient failures (e.g. before the group key existed) must not
+    // burn the row once it indexes successfully.
+    await store.setSearchBackfillFailureCount('big1', 3);
+
+    await MessageSearchBackfillService(
+      keyManager: keyManager,
+      userId: 'me',
+      store: store,
+    ).startIfNeeded();
+
+    expect(await store.isSearchBackfillComplete(), isTrue);
+    expect(await store.getSearchBackfillPhase(), 'done');
+    expect(await store.getSearchBackfillFailureCount('big1'), 0);
+    const dao = MessageSearchDao();
+    final hits = await dao.searchGlobal('needle');
+    expect(hits, hasLength(1));
+    expect(hits.first.messageId, 'big1');
+    expect((await dao.searchGlobal('pineapple')), hasLength(1));
+  });
+
+  test('buildSnippet returns short bodies verbatim', () {
+    // 37 chars, maxLen 80: the match window must not ellipsize a body that
+    // already fits.
+    const body = 'the pineapple upside down cake recipe';
+    expect(MessageSearchIndexService.buildSnippet(body, 'recipe'), body);
+
+    // Control: body exactly at maxLen is also returned unchanged.
+    const atLimit = 'the second note mentions pineapple';
+    expect(
+      MessageSearchIndexService.buildSnippet(atLimit, 'note', maxLen: 34),
+      atLimit,
+    );
+  });
+}

--- a/test/message_search_index_service_test.dart
+++ b/test/message_search_index_service_test.dart
@@ -1,4 +1,5 @@
 import 'package:flutter_test/flutter_test.dart';
+import 'package:prysm/constants/group_constants.dart';
 import 'package:prysm/services/message_search_index_service.dart';
 
 void main() {
@@ -10,9 +11,53 @@ void main() {
     expect(snippet.toLowerCase(), contains('fox'));
   });
 
+  test('buildSnippet returns whole short body for empty query', () {
+    expect(
+      MessageSearchIndexService.buildSnippet('short body', '   '),
+      'short body',
+    );
+  });
+
+  test('buildSnippet truncates long body without match with trailing ellipsis',
+      () {
+    final long = List.filled(20, 'abcdefghij').join();
+    expect(
+      MessageSearchIndexService.buildSnippet(long, 'zzz'),
+      '${long.substring(0, 80)}…',
+    );
+  });
+
+  test('buildSnippet truncates long body with empty query', () {
+    final long = List.filled(20, 'abcdefghij').join();
+    expect(
+      MessageSearchIndexService.buildSnippet(long, ''),
+      '${long.substring(0, 80)}…',
+    );
+  });
+
+  test('buildSnippet shows leading ellipsis for match near the end', () {
+    final body = '${'x' * 100}needle';
+    expect(
+      MessageSearchIndexService.buildSnippet(body, 'needle'),
+      '…${body.substring(76)}',
+    );
+  });
+
+  test('buildSnippet centers on the earliest matching token', () {
+    final body = '${'x' * 30}alpha${'y' * 30}beta${'z' * 30}';
+    expect(
+      MessageSearchIndexService.buildSnippet(body, 'beta alpha'),
+      '…${'x' * 24}alpha${'y' * 24}…',
+    );
+  });
+
   test('searchable type helpers', () {
     expect(MessageSearchIndexService.isSearchableDirectType('text'), isTrue);
     expect(MessageSearchIndexService.isSearchableDirectType('reaction'), isFalse);
     expect(MessageSearchIndexService.isSearchableSelfType('audio'), isTrue);
+    expect(MessageSearchIndexService.isSearchableGroupType(groupTextType), isTrue);
+    expect(MessageSearchIndexService.isSearchableGroupType(groupImageType), isTrue);
+    expect(MessageSearchIndexService.isSearchableGroupType('text'), isFalse);
+    expect(MessageSearchIndexService.isSearchableGroupType('reaction'), isFalse);
   });
 }

--- a/test/message_search_index_service_test.dart
+++ b/test/message_search_index_service_test.dart
@@ -1,5 +1,4 @@
 import 'package:flutter_test/flutter_test.dart';
-import 'package:prysm/database/message_search_dao.dart';
 import 'package:prysm/services/message_search_index_service.dart';
 
 void main() {

--- a/test/message_search_index_service_test.dart
+++ b/test/message_search_index_service_test.dart
@@ -1,0 +1,19 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:prysm/database/message_search_dao.dart';
+import 'package:prysm/services/message_search_index_service.dart';
+
+void main() {
+  test('buildSnippet includes match context', () {
+    final snippet = MessageSearchIndexService.buildSnippet(
+      'The quick brown fox jumps over the lazy dog',
+      'fox',
+    );
+    expect(snippet.toLowerCase(), contains('fox'));
+  });
+
+  test('searchable type helpers', () {
+    expect(MessageSearchIndexService.isSearchableDirectType('text'), isTrue);
+    expect(MessageSearchIndexService.isSearchableDirectType('reaction'), isFalse);
+    expect(MessageSearchIndexService.isSearchableSelfType('audio'), isTrue);
+  });
+}

--- a/test/messages_db_characterization_test.dart
+++ b/test/messages_db_characterization_test.dart
@@ -9,6 +9,7 @@ import 'dart:io';
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:prysm/crypto/ratchet/session_store.dart';
+import 'package:prysm/database/message_schema_migrations.dart';
 import 'package:prysm/database/messages.dart';
 import 'package:prysm/util/db_helper.dart';
 import 'package:sqflite_common_ffi/sqflite_ffi.dart';
@@ -37,6 +38,7 @@ Future<Database> _openMessagesDb() async {
       expiresAt INTEGER
     )
   ''');
+  await MessageSchemaMigrations.createMessageSearchFtsTable(db);
   return db;
 }
 

--- a/test/pending_queue_reconciler_test.dart
+++ b/test/pending_queue_reconciler_test.dart
@@ -2,6 +2,7 @@ import 'dart:io';
 
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:prysm/database/message_schema_migrations.dart';
 import 'package:prysm/database/messages.dart';
 import 'package:prysm/services/pending_queue_reconciler.dart';
 import 'package:prysm/util/pending_message_db_helper.dart';
@@ -54,6 +55,7 @@ Future<Database> _openMessagesDb() async {
       expiresAt INTEGER
     )
   ''');
+  await MessageSchemaMigrations.createMessageSearchFtsTable(db);
   return db;
 }
 

--- a/test/security/group_message_anti_replay_test.dart
+++ b/test/security/group_message_anti_replay_test.dart
@@ -15,6 +15,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:prysm/constants/group_constants.dart';
 import 'package:prysm/crypto/crypto.dart';
 import 'package:prysm/database/conversation_preferences_db.dart';
+import 'package:prysm/database/message_schema_migrations.dart';
 import 'package:prysm/database/messages.dart';
 import 'package:prysm/server/inbound_message_router.dart';
 import 'package:prysm/services/settings_service.dart';
@@ -58,6 +59,7 @@ Future<void> _createMessagesTable(Database db) async {
       expiresAt INTEGER
     )
   ''');
+  await MessageSchemaMigrations.createMessageSearchFtsTable(db);
 }
 
 Future<Database> _openMessagesDb() async {

--- a/test/self_messages_db_test.dart
+++ b/test/self_messages_db_test.dart
@@ -1,4 +1,6 @@
 import 'package:flutter_test/flutter_test.dart';
+import 'package:prysm/database/message_schema_migrations.dart';
+import 'package:prysm/database/messages_database.dart';
 import 'package:prysm/database/self_messages_db.dart';
 import 'package:sqflite_common_ffi/sqflite_ffi.dart';
 
@@ -15,14 +17,17 @@ void main() {
         version: 1,
         onCreate: (db, version) async {
           await SelfMessagesDb.createTable(db);
+          await MessageSchemaMigrations.createMessageSearchFtsTable(db);
         },
       ),
     );
     SelfMessagesDb.setDatabaseForTest(db);
+    MessagesDatabase.setDatabaseForTest(db);
   });
 
   tearDown(() async {
     SelfMessagesDb.setDatabaseForTest(null);
+    MessagesDatabase.setDatabaseForTest(null);
   });
 
   test('insert and batch query returns newest first', () async {


### PR DESCRIPTION
- Added MessageSearchDao for managing FTS5-backed local message search.
- Introduced MessageSearchBackfillService to index historical messages for search.
- Updated MessageCrudDao to integrate search functionality, including message removal.
- Enhanced MessagesDb with global and conversation-specific search methods.
- Implemented UI components for search in chat screens, including ChatSearchBar.
- Updated database schema to support message search indexing.
- Added MessageSearchHit model for search results representation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added global message search with snippets, grouped conversations, loading states, and navigation to matching messages.
  * Added in-conversation search with match counts, previous/next controls, highlighted matches, and direct navigation.
  * Search covers text and file names across direct, group, and self chats.
  * Added automatic indexing for new and edited messages, plus background indexing of existing messages.

* **Bug Fixes**
  * Deleted and view-once messages are removed from search results.
  * Blocked conversations no longer show message previews or unread badges.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->