### PR TITLE
fix(search): remove the index row on every delete path, and three more review findings

### DIFF
--- a/lib/database/conversation_queries_dao.dart
+++ b/lib/database/conversation_queries_dao.dart
@@ -1,11 +1,15 @@
 import 'package:prysm/database/message_query_filters.dart';
+import 'package:prysm/database/message_search_dao.dart';
 import 'package:prysm/database/messages_database.dart';
 import 'package:sqflite/sqflite.dart';
 
 /// Direct/group conversation message queries (batched + paginated reads) and
 /// their bulk deletes.
 class ConversationQueriesDao {
-  const ConversationQueriesDao();
+  const ConversationQueriesDao({MessageSearchDao? searchDao})
+      : _searchDao = searchDao ?? const MessageSearchDao();
+
+  final MessageSearchDao _searchDao;
 
   Future<Database> get _database => MessagesDatabase.database;
 
@@ -109,6 +113,8 @@ class ConversationQueriesDao {
             "groupId IS NULL AND ${MessageQueryFilters.directChatTypeFilter} AND ((senderId = ? AND receiverId = ?) OR (senderId = ? AND receiverId = ?) OR (senderId = ? AND receiverId = ? AND status = 'system') OR (senderId = ? AND receiverId = ? AND status = 'system'))",
         whereArgs: [userId, receiverId, receiverId, userId, userId, receiverId, receiverId, userId],
       );
+      await _searchDao.removeForConversationUnprotected(userId, 'direct');
+      await _searchDao.removeForConversationUnprotected(receiverId, 'direct');
     });
   }
 
@@ -155,6 +161,7 @@ class ConversationQueriesDao {
     await _protect(() async {
       final db = await _database;
       await db.delete('messages', where: 'groupId = ?', whereArgs: [groupId]);
+      await _searchDao.removeForConversationUnprotected(groupId, 'group');
     });
   }
 
@@ -168,6 +175,11 @@ class ConversationQueriesDao {
         'messages',
         where: 'groupId = ? AND timestamp < ?',
         whereArgs: [groupId, beforeTimestamp],
+      );
+      await _searchDao.removeForConversationUnprotected(
+        groupId,
+        'group',
+        beforeTimestamp: beforeTimestamp,
       );
     });
   }

--- a/lib/database/message_crud_dao.dart
+++ b/lib/database/message_crud_dao.dart
@@ -46,6 +46,50 @@ class MessageCrudDao {
     return normalized;
   }
 
+  /// Removes a message's FTS row, scoped to its conversation. The caller must
+  /// already hold [MessagesDatabase.mutex]. Pass [row] when the `messages` row
+  /// is about to be (or has already been) deleted; otherwise it is read here.
+  ///
+  /// A direct row's conversationId is the peer, which is one of the two
+  /// participants — both are tried, so the delete is never widened to a bare
+  /// `messageId` match. That matters because the wire id is chosen by the
+  /// sender: an unscoped delete lets a peer wipe search rows of unrelated
+  /// conversations by reusing an id it has seen.
+  Future<void> _removeSearchRow(
+    Database db, {
+    required String storageId,
+    required String wireId,
+    Map<String, Object?>? row,
+  }) async {
+    if (row == null) {
+      final rows = await db.query(
+        'messages',
+        columns: const ['groupId', 'senderId', 'receiverId'],
+        where: 'id = ?',
+        whereArgs: [storageId],
+        limit: 1,
+      );
+      if (rows.isEmpty) return;
+      row = rows.first;
+    }
+    final groupId = row['groupId'] as String?;
+    if (groupId != null) {
+      await _searchDao.removeUnprotected(
+        wireId,
+        conversationId: groupId,
+        scope: 'group',
+      );
+      return;
+    }
+    for (final side in const ['senderId', 'receiverId']) {
+      await _searchDao.removeUnprotected(
+        wireId,
+        conversationId: row[side] as String,
+        scope: 'direct',
+      );
+    }
+  }
+
   /// Mark a view-once message as viewed and wipe its content
   Future<void> markViewOnceViewed(
     String messageId, {
@@ -60,11 +104,7 @@ class MessageCrudDao {
         where: 'id = ? AND viewOnce = 1',
         whereArgs: [storageId],
       );
-      await _searchDao.removeUnprotected(
-        messageId,
-        conversationId: groupId,
-        scope: groupId != null ? 'group' : null,
-      );
+      await _removeSearchRow(db, storageId: storageId, wireId: messageId);
     });
   }
 
@@ -266,11 +306,7 @@ class MessageCrudDao {
         whereArgs: [storageId],
       );
       await MessageBlobStore.delete(storageId);
-      await _searchDao.removeUnprotected(
-        wireId,
-        conversationId: groupId,
-        scope: groupId != null ? 'group' : null,
-      );
+      await _removeSearchRow(db, storageId: storageId, wireId: wireId);
     });
   }
 
@@ -296,6 +332,13 @@ class MessageCrudDao {
   Future<void> deleteMessageById(String id) async {
     await _protect(() async {
       final db = await _database;
+      final rows = await db.query(
+        'messages',
+        columns: const ['groupId', 'senderId', 'receiverId'],
+        where: 'id = ?',
+        whereArgs: [id],
+        limit: 1,
+      );
       await db.transaction((txn) async {
         await txn.update(
           'messages',
@@ -305,6 +348,18 @@ class MessageCrudDao {
         );
         await txn.delete('messages', where: 'id = ?', whereArgs: [id]);
       });
+      if (rows.isEmpty) return;
+      // De-index AFTER the row is gone: a broken search index must not be able
+      // to block a delete. Strip the row's own groupId prefix rather than
+      // re-parsing via the codec — the wire id is sender-chosen and may itself
+      // contain '::'.
+      final groupId = rows.first['groupId'] as String?;
+      await _removeSearchRow(
+        db,
+        storageId: id,
+        wireId: groupId == null ? id : id.substring(groupId.length + 2),
+        row: rows.first,
+      );
     });
   }
 
@@ -321,11 +376,6 @@ class MessageCrudDao {
     );
     await deleteMessageById(storageId);
     await MessageBlobStore.delete(storageId);
-    await _searchDao.remove(
-      wireId,
-      conversationId: groupId,
-      scope: groupId != null ? 'group' : null,
-    );
   }
 
   Future<void> updateMessageStatus(

--- a/lib/database/message_search_dao.dart
+++ b/lib/database/message_search_dao.dart
@@ -59,8 +59,8 @@ class MessageSearchDao {
 
   Future<void> remove(
     String messageId, {
-    String? conversationId,
-    String? scope,
+    required String conversationId,
+    required String scope,
   }) =>
       _protect(
         () => removeUnprotected(
@@ -74,8 +74,8 @@ class MessageSearchDao {
   /// [MessagesDatabase.mutex] (via [_protect]) before invoking this.
   Future<void> removeUnprotected(
     String messageId, {
-    String? conversationId,
-    String? scope,
+    required String conversationId,
+    required String scope,
   }) async {
     final db = await _database;
     await _deleteRow(
@@ -89,20 +89,32 @@ class MessageSearchDao {
   Future<void> _deleteRow(
     Database db,
     String messageId, {
-    String? conversationId,
-    String? scope,
+    required String conversationId,
+    required String scope,
   }) {
-    if (conversationId != null && scope != null) {
-      return db.delete(
-        'message_search_fts',
-        where: 'messageId = ? AND conversationId = ? AND scope = ?',
-        whereArgs: [messageId, conversationId, scope],
-      );
-    }
     return db.delete(
       'message_search_fts',
-      where: 'messageId = ?',
-      whereArgs: [messageId],
+      where: 'messageId = ? AND conversationId = ? AND scope = ?',
+      whereArgs: [messageId, conversationId, scope],
+    );
+  }
+
+  /// Lock-free conversation-scoped search-row deletion: the caller must
+  /// already hold [MessagesDatabase.mutex] (via [_protect]) before invoking.
+  Future<void> removeForConversationUnprotected(
+    String conversationId,
+    String scope, {
+    int? beforeTimestamp,
+  }) async {
+    final db = await _database;
+    await db.delete(
+      'message_search_fts',
+      where: beforeTimestamp != null
+          ? 'conversationId = ? AND scope = ? AND timestamp < ?'
+          : 'conversationId = ? AND scope = ?',
+      whereArgs: beforeTimestamp != null
+          ? [conversationId, scope, beforeTimestamp]
+          : [conversationId, scope],
     );
   }
 

--- a/lib/screens/widgets/linked_message_text.dart
+++ b/lib/screens/widgets/linked_message_text.dart
@@ -81,7 +81,7 @@ class LinkedMessageText extends StatelessWidget {
 
     appendHighlightedSegment(lastEnd, text.length);
 
-    return RichText(text: TextSpan(children: spans));
+    return Text.rich(TextSpan(children: spans));
   }
 
   /// Builds spans for [segment], highlighting query token matches when a

--- a/lib/services/chat_service.dart
+++ b/lib/services/chat_service.dart
@@ -335,18 +335,22 @@ class ChatService {
       'expiresAt': ?expiresAt,
     }, notifyListeners: false);
 
-    await MessageSearchIndexService.indexBestEffort(
-      () => MessageSearchIndexService(
-        keyManager: keyManager,
-        userId: userId,
-      ).indexOutboundFile(
-        messageId: id,
-        conversationId: peerId,
-        scope: 'direct',
-        timestamp: timestamp,
-        fileName: fileName,
-      ),
-    );
+    // ponytail: guard instead of a viewOnce param on indexOutboundFile — the
+    // sender of a view-once file can never open it, so its name stays indexed.
+    if (!viewOnce) {
+      await MessageSearchIndexService.indexBestEffort(
+        () => MessageSearchIndexService(
+          keyManager: keyManager,
+          userId: userId,
+        ).indexOutboundFile(
+          messageId: id,
+          conversationId: peerId,
+          scope: 'direct',
+          timestamp: timestamp,
+          fileName: fileName,
+        ),
+      );
+    }
 
     if (expiresAt != null) {
       DisappearingActivityNotifier.instance.notify();

--- a/lib/services/group_chat_service.dart
+++ b/lib/services/group_chat_service.dart
@@ -279,19 +279,21 @@ class GroupChatService {
       'expiresAt': ?expiresAt,
     });
 
-    await MessageSearchIndexService.indexBestEffort(
-      () => MessageSearchIndexService(
-        keyManager: keyManager,
-        userId: userId,
-        groupService: groupService,
-      ).indexOutboundFile(
-        messageId: id,
-        conversationId: groupId,
-        scope: 'group',
-        timestamp: timestamp,
-        fileName: fileName,
-      ),
-    );
+    if (!viewOnce) {
+      await MessageSearchIndexService.indexBestEffort(
+        () => MessageSearchIndexService(
+          keyManager: keyManager,
+          userId: userId,
+          groupService: groupService,
+        ).indexOutboundFile(
+          messageId: id,
+          conversationId: groupId,
+          scope: 'group',
+          timestamp: timestamp,
+          fileName: fileName,
+        ),
+      );
+    }
 
     if (expiresAt != null) {
       DisappearingActivityNotifier.instance.notify();

--- a/lib/services/message_modify_service.dart
+++ b/lib/services/message_modify_service.dart
@@ -150,15 +150,17 @@ class MessageModifyService {
     final timestamp = rows.isNotEmpty
         ? rows.first['timestamp'] as int
         : modifiedAt;
-    await MessageSearchIndexService(
-      keyManager: keyManager,
-      userId: userId,
-    ).reindexEditedMessage(
-      messageId: targetMessageId,
-      conversationId: peerId!,
-      scope: 'direct',
-      timestamp: timestamp,
-      plaintext: newText,
+    await MessageSearchIndexService.indexBestEffort(
+      () => MessageSearchIndexService(
+        keyManager: keyManager,
+        userId: userId,
+      ).reindexEditedMessage(
+        messageId: targetMessageId,
+        conversationId: peerId!,
+        scope: 'direct',
+        timestamp: timestamp,
+        plaintext: newText,
+      ),
     );
 
     _notifyEdit(targetMessageId, newText, modifiedAt);
@@ -205,16 +207,18 @@ class MessageModifyService {
     final timestamp = rows.isNotEmpty
         ? rows.first['timestamp'] as int
         : modifiedAt;
-    await MessageSearchIndexService(
-      keyManager: keyManager,
-      userId: userId,
-      groupService: gs,
-    ).reindexEditedMessage(
-      messageId: targetMessageId,
-      conversationId: groupId!,
-      scope: 'group',
-      timestamp: timestamp,
-      plaintext: newText,
+    await MessageSearchIndexService.indexBestEffort(
+      () => MessageSearchIndexService(
+        keyManager: keyManager,
+        userId: userId,
+        groupService: gs,
+      ).reindexEditedMessage(
+        messageId: targetMessageId,
+        conversationId: groupId!,
+        scope: 'group',
+        timestamp: timestamp,
+        plaintext: newText,
+      ),
     );
 
     _notifyEdit(targetMessageId, newText, modifiedAt);
@@ -428,16 +432,19 @@ class MessageModifyService {
         groupService: groupService,
       );
       if (newText != null) {
-        await MessageSearchIndexService(
-          keyManager: keyManager,
-          userId: localUserId,
-          groupService: groupService,
-        ).reindexEditedMessage(
-          messageId: payload.targetMessageId,
-          conversationId: groupId ?? senderId,
-          scope: groupId != null ? 'group' : 'direct',
-          timestamp: row['timestamp'] as int,
-          plaintext: newText,
+        final indexedText = newText;
+        await MessageSearchIndexService.indexBestEffort(
+          () => MessageSearchIndexService(
+            keyManager: keyManager,
+            userId: localUserId,
+            groupService: groupService,
+          ).reindexEditedMessage(
+            messageId: payload.targetMessageId,
+            conversationId: groupId ?? senderId,
+            scope: groupId != null ? 'group' : 'direct',
+            timestamp: row['timestamp'] as int,
+            plaintext: indexedText,
+          ),
         );
       }
     }

--- a/lib/services/message_search_backfill_service.dart
+++ b/lib/services/message_search_backfill_service.dart
@@ -6,7 +6,6 @@ import 'package:prysm/services/message_search_index_service.dart';
 import 'package:prysm/services/settings_service.dart';
 import 'package:prysm/util/key_manager.dart';
 import 'package:prysm/util/logging.dart';
-import 'package:prysm/util/message_blob_store.dart';
 
 abstract class MessageSearchBackfillStore {
   Future<bool> isSearchBackfillComplete();
@@ -169,6 +168,9 @@ class MessageSearchBackfillService {
               '$messageId after $failures attempts',
               'MessageSearchBackfill',
             );
+          } else {
+            await _settings
+                .setSearchBackfillFailureCount(row['id'] as String, 0);
           }
           lastProcessed = row;
           continue;
@@ -215,6 +217,8 @@ class MessageSearchBackfillService {
             '$messageId after $failures attempts',
             'MessageSearchBackfill',
           );
+        } else {
+          await _settings.setSearchBackfillFailureCount(row['id'] as String, 0);
         }
         lastProcessed = row;
       }
@@ -251,7 +255,7 @@ class MessageSearchBackfillService {
       SELECT $_messageColumns
       FROM messages
       WHERE deletedAt IS NULL
-        AND (viewOnce IS NULL OR viewOnce = 0 OR viewed IS NULL OR viewed = 0)
+        AND (viewOnce IS NULL OR viewOnce = 0)
         AND (
           ${_typeInClause([
         ...MessageSearchIndexService.searchableDirectTypes,
@@ -274,7 +278,7 @@ class MessageSearchBackfillService {
         _batchSize,
       ],
     );
-    return _resolveMessageBlobs(rows);
+    return rows;
   }
 
   Future<List<Map<String, dynamic>>> _fetchSelfBatch(
@@ -287,7 +291,7 @@ class MessageSearchBackfillService {
       SELECT $_selfColumns
       FROM self_messages
       WHERE deletedAt IS NULL
-        AND (viewOnce IS NULL OR viewOnce = 0 OR viewed IS NULL OR viewed = 0)
+        AND (viewOnce IS NULL OR viewOnce = 0)
         AND (
           ${_typeInClause(MessageSearchIndexService.searchableDirectTypes)}
         )
@@ -306,20 +310,6 @@ class MessageSearchBackfillService {
         _batchSize,
       ],
     );
-    return _resolveMessageBlobs(rows);
-  }
-
-  /// Resolves `blob:` payload markers back into the original message payload
-  /// so decryption downstream receives the full ciphertext.
-  static Future<List<Map<String, dynamic>>> _resolveMessageBlobs(
-    List<Map<String, dynamic>> rows,
-  ) async {
-    for (final row in rows) {
-      final wire = row['message'] as String?;
-      if (wire != null && MessageBlobStore.isMarker(wire)) {
-        row['message'] = await MessageBlobStore.resolve(wire);
-      }
-    }
     return rows;
   }
 }

--- a/lib/services/message_search_index_service.dart
+++ b/lib/services/message_search_index_service.dart
@@ -154,8 +154,8 @@ class MessageSearchIndexService {
 
   Future<void> removeMessage(
     String messageId, {
-    String? conversationId,
-    String? scope,
+    required String conversationId,
+    required String scope,
   }) =>
       _dao.remove(messageId, conversationId: conversationId, scope: scope);
 

--- a/lib/services/message_search_index_service.dart
+++ b/lib/services/message_search_index_service.dart
@@ -7,6 +7,7 @@ import 'package:prysm/services/group_service.dart';
 import 'package:prysm/services/message_view_mapper.dart';
 import 'package:prysm/util/key_manager.dart';
 import 'package:prysm/util/logging.dart';
+import 'package:prysm/util/message_blob_store.dart';
 import 'package:prysm/util/peer_identity_loader.dart';
 
 /// Keeps the FTS5 search index in sync with message lifecycle events.
@@ -168,7 +169,12 @@ class MessageSearchIndexService {
     String localUserId,
   ) async {
     if (row['deletedAt'] != null) return true;
-    if ((row['viewOnce'] ?? 0) == 1 && (row['viewed'] ?? 0) == 1) return true;
+    if ((row['viewOnce'] ?? 0) == 1) return true;
+    final wire = row['message'] as String?;
+    if (MessageBlobStore.isMarker(wire)) {
+      // Rows from sqflite are read-only; resolve into a fresh map.
+      row = {...row, 'message': await MessageBlobStore.resolve(wire)};
+    }
 
     final storageId = row['id'] as String;
     final wireId = MessageIdCodec.wireIdFromStorage(storageId);
@@ -260,7 +266,12 @@ class MessageSearchIndexService {
   /// indexed so callers like the backfill can retry it.
   Future<bool> indexSelfRow(Map<String, dynamic> row) async {
     if (row['deletedAt'] != null) return true;
-    if ((row['viewOnce'] ?? 0) == 1 && (row['viewed'] ?? 0) == 1) return true;
+    if ((row['viewOnce'] ?? 0) == 1) return true;
+    final wire = row['message'] as String?;
+    if (MessageBlobStore.isMarker(wire)) {
+      // Rows from sqflite are read-only; resolve into a fresh map.
+      row = {...row, 'message': await MessageBlobStore.resolve(wire)};
+    }
 
     final messageId = row['id'] as String;
     final type = row['type'] as String?;
@@ -328,6 +339,7 @@ class MessageSearchIndexService {
   }
 
   static String buildSnippet(String body, String query, {int maxLen = 80}) {
+    if (body.length <= maxLen) return body;
     final lowerBody = body.toLowerCase();
     final tokens = query
         .trim()

--- a/lib/services/self_chat_service.dart
+++ b/lib/services/self_chat_service.dart
@@ -35,13 +35,15 @@ class SelfChatService {
       'replyTo': replyToId,
     });
 
-    await MessageSearchIndexService(
-      keyManager: keyManager,
-      userId: userId,
-    ).indexSelfText(
-      messageId: id,
-      timestamp: timestamp,
-      plaintext: text,
+    await MessageSearchIndexService.indexBestEffort(
+      () => MessageSearchIndexService(
+        keyManager: keyManager,
+        userId: userId,
+      ).indexSelfText(
+        messageId: id,
+        timestamp: timestamp,
+        plaintext: text,
+      ),
     );
 
     return id;
@@ -75,14 +77,20 @@ class SelfChatService {
       'viewOnce': viewOnce ? 1 : 0,
     });
 
-    await MessageSearchIndexService(
-      keyManager: keyManager,
-      userId: userId,
-    ).indexSelfFile(
-      messageId: id,
-      timestamp: timestamp,
-      fileName: fileName,
-    );
+    // ponytail: guard instead of a viewOnce param on indexOutboundFile — a
+    // view-once write is dead weight: viewing wipes the row and de-indexes.
+    if (!viewOnce) {
+      await MessageSearchIndexService.indexBestEffort(
+        () => MessageSearchIndexService(
+          keyManager: keyManager,
+          userId: userId,
+        ).indexSelfFile(
+          messageId: id,
+          timestamp: timestamp,
+          fileName: fileName,
+        ),
+      );
+    }
 
     return id;
   }

--- a/test/chat_service_pending_delete_test.dart
+++ b/test/chat_service_pending_delete_test.dart
@@ -2,6 +2,7 @@ import 'dart:convert';
 
 import 'package:flutter_test/flutter_test.dart';
 import 'package:prysm/crypto/identity.dart';
+import 'package:prysm/database/message_schema_migrations.dart';
 import 'package:prysm/database/messages.dart';
 import 'package:prysm/services/chat_service.dart';
 import 'package:prysm/util/db_helper.dart';
@@ -83,6 +84,7 @@ Future<Database> _openMessagesDb() async {
       expiresAt INTEGER
     )
   ''');
+  await MessageSchemaMigrations.createMessageSearchFtsTable(db);
   return db;
 }
 

--- a/test/disappearing_messages_test.dart
+++ b/test/disappearing_messages_test.dart
@@ -38,6 +38,7 @@ Future<Database> _openMessagesDb() async {
   ''');
   await MessageSchemaMigrations.createReactionsTable(db);
   await MessageSchemaMigrations.createReadReceiptsTable(db);
+  await MessageSchemaMigrations.createMessageSearchFtsTable(db);
   return db;
 }
 

--- a/test/group_control_auth_test.dart
+++ b/test/group_control_auth_test.dart
@@ -8,6 +8,7 @@ import 'package:prysm/crypto/group_crypto.dart';
 import 'package:prysm/crypto/identity.dart';
 import 'package:prysm/crypto/ratchet/session_store.dart';
 import 'package:prysm/crypto/wire.dart';
+import 'package:prysm/database/message_schema_migrations.dart';
 import 'package:prysm/database/messages.dart';
 import 'package:prysm/services/group_service.dart';
 import 'package:prysm/util/db_helper.dart';
@@ -85,6 +86,7 @@ Future<Database> _openTestDb() async {
             groupId TEXT
           )
         ''');
+        await MessageSchemaMigrations.createMessageSearchFtsTable(db);
         await GroupSenderIndexStore.ensureTable(db);
         await RatchetSessionStore.ensureTable(db);
       },

--- a/test/message_search_call_sites_test.dart
+++ b/test/message_search_call_sites_test.dart
@@ -1,0 +1,76 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/rendering.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:prysm/crypto/identity.dart';
+import 'package:prysm/database/message_schema_migrations.dart';
+import 'package:prysm/database/messages.dart';
+import 'package:prysm/database/self_messages_db.dart';
+import 'package:prysm/screens/widgets/linked_message_text.dart';
+import 'package:prysm/services/self_chat_service.dart';
+import 'package:prysm/util/key_manager.dart';
+import 'package:sqflite_common_ffi/sqflite_ffi.dart';
+
+Future<void> _openUrl(String url) async {}
+
+void main() {
+  setUpAll(() {
+    sqfliteFfiInit();
+    databaseFactory = databaseFactoryFfi;
+  });
+
+  setUp(() async {
+    final db = await databaseFactory.openDatabase(inMemoryDatabasePath);
+    await MessageSchemaMigrations.onCreate(db, MessageSchemaMigrations.dbVersion);
+    MessagesDb.setDatabaseForTest(db);
+    SelfMessagesDb.setDatabaseForTest(db);
+  });
+
+  tearDown(() async {
+    await MessagesDb.close();
+    MessagesDb.setDatabaseForTest(null);
+    SelfMessagesDb.setDatabaseForTest(null);
+  });
+
+  testWidgets('LinkedMessageText scales with the ambient text scaler',
+      (tester) async {
+    Future<double> scaledFontSize(TextScaler scaler) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: MediaQuery(
+            data: MediaQueryData(textScaler: scaler),
+            child: const LinkedMessageText(
+              text: 'hello world',
+              textColor: Colors.black,
+              fontSize: 14,
+              onOpenUrl: _openUrl,
+            ),
+          ),
+        ),
+      );
+      final paragraph = tester.renderObject<RenderParagraph>(
+        find.descendant(
+          of: find.byType(LinkedMessageText),
+          matching: find.byType(RichText),
+        ),
+      );
+      return paragraph.textScaler.scale(14);
+    }
+
+    expect(await scaledFontSize(TextScaler.linear(2.0)), 28.0);
+    expect(await scaledFontSize(TextScaler.linear(1.0)), 14.0);
+  });
+
+  test('sendTextMessage stores the note even when the FTS table is missing',
+      () async {
+    final db = await MessagesDb.database;
+    await db.execute('DROP TABLE message_search_fts');
+
+    final keyManager =
+        KeyManager.fromIdentity(await IdentityKeyPair.generate());
+    final service = SelfChatService(userId: 'me.onion', keyManager: keyManager);
+
+    final id = await service.sendTextMessage('hello world');
+
+    expect(await SelfMessagesDb.getMessageById(id), hasLength(1));
+  });
+}

--- a/test/message_search_dao_test.dart
+++ b/test/message_search_dao_test.dart
@@ -54,7 +54,7 @@ void main() {
     expect(scoped, hasLength(1));
     expect(scoped.first.messageId, 'm2');
 
-    await dao.remove('m1');
+    await dao.remove('m1', conversationId: 'peer1', scope: 'direct');
     expect(
       await dao.exists(
         messageId: 'm1',

--- a/test/message_search_delete_test.dart
+++ b/test/message_search_delete_test.dart
@@ -1,0 +1,214 @@
+// FTS de-indexing on message delete: every delete path must remove its
+// search rows, scoped so a direct removal can never touch a group row that
+// happens to share the same (attacker-suppliable) wire id.
+import 'dart:io';
+
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:prysm/crypto/identity.dart';
+import 'package:prysm/database/message_schema_migrations.dart';
+import 'package:prysm/database/message_search_dao.dart';
+import 'package:prysm/database/messages.dart';
+import 'package:prysm/models/chat/prysm_message.dart';
+import 'package:prysm/services/message_actions_service.dart';
+import 'package:prysm/services/message_modify_service.dart';
+import 'package:prysm/util/key_manager.dart';
+import 'package:prysm/util/pending_message_db_helper.dart';
+import 'package:sqflite_common_ffi/sqflite_ffi.dart';
+
+const MessageSearchDao searchDao = MessageSearchDao();
+
+void main() {
+  setUpAll(() {
+    TestWidgetsFlutterBinding.ensureInitialized();
+    sqfliteFfiInit();
+    databaseFactory = databaseFactoryFfi;
+    // MessageContentWiper / MessageBlobStore touch the file system; the
+    // MessageActionsService end-to-end test needs a path provider.
+    final tempDir = Directory.systemTemp.createTempSync('prysm_search_delete_');
+    const channel = MethodChannel('plugins.flutter.io/path_provider');
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(channel, (call) async => tempDir.path);
+  });
+
+  late Database db;
+  late Database pendingDb;
+
+  setUp(() async {
+    db = await databaseFactory.openDatabase(inMemoryDatabasePath);
+    await MessageSchemaMigrations.onCreate(db, MessageSchemaMigrations.dbVersion);
+    MessagesDb.setDatabaseForTest(db);
+
+    pendingDb = await databaseFactory.openDatabase(inMemoryDatabasePath);
+    await pendingDb.execute('''
+      CREATE TABLE pending_messages(
+        id TEXT PRIMARY KEY,
+        senderId TEXT,
+        receiverId TEXT,
+        message TEXT,
+        type TEXT,
+        fileName TEXT,
+        fileSize INTEGER,
+        timestamp INTEGER,
+        status TEXT,
+        replyTo TEXT,
+        viewOnce INTEGER DEFAULT 0,
+        groupId TEXT,
+        targetMemberId TEXT
+      )
+    ''');
+    PendingMessageDbHelper.setDatabaseForTest(pendingDb);
+  });
+
+  tearDown(() async {
+    await MessagesDb.close();
+    MessagesDb.setDatabaseForTest(null);
+    await pendingDb.close();
+    PendingMessageDbHelper.setDatabaseForTest(null);
+  });
+
+  /// Mirrors MessageSearchIndexService.indexInboundRow: direct FTS rows are
+  /// keyed by the peer (the party that is not the local user).
+  Future<void> insertDirect(
+    String id,
+    String senderId,
+    String receiverId,
+    String localUserId,
+    int timestamp, {
+    required String ftsBody,
+  }) async {
+    await MessagesDb.insertMessage({
+      'id': id,
+      'senderId': senderId,
+      'receiverId': receiverId,
+      'message': 'cipher',
+      'type': 'text',
+      'status': 'sent',
+      'timestamp': timestamp,
+    });
+    await searchDao.upsert(
+      messageId: id,
+      conversationId: senderId == localUserId ? receiverId : senderId,
+      scope: 'direct',
+      timestamp: timestamp,
+      body: ftsBody,
+    );
+  }
+
+  Future<void> insertGroup(
+    String id,
+    String groupId,
+    int timestamp, {
+    required String ftsBody,
+  }) async {
+    await MessagesDb.insertMessage({
+      'id': id,
+      'senderId': 'peer',
+      'receiverId': 'me',
+      'message': 'cipher',
+      'type': 'text',
+      'status': 'sent',
+      'timestamp': timestamp,
+      'groupId': groupId,
+    });
+    await searchDao.upsert(
+      messageId: id,
+      conversationId: groupId,
+      scope: 'group',
+      timestamp: timestamp,
+      body: ftsBody,
+    );
+  }
+
+  test('deleteMessageById removes the FTS row for a direct message', () async {
+    await insertDirect('dm-1', 'peer', 'me', 'me', 1, ftsBody: 'alpha needle');
+    expect(await searchDao.searchGlobal('alpha'), hasLength(1));
+
+    await MessagesDb.deleteMessageById('dm-1');
+
+    expect(await searchDao.searchGlobal('alpha'), isEmpty);
+    expect(await MessagesDb.getMessageById('dm-1'), isEmpty);
+  });
+
+  test('deleteMessageById removes the FTS row for a group message', () async {
+    await insertGroup('gm-1', 'g1', 2, ftsBody: 'beta needle');
+    expect(await searchDao.searchGlobal('beta'), hasLength(1));
+
+    await MessagesDb.deleteMessageById('g1::gm-1');
+
+    expect(await searchDao.searchGlobal('beta'), isEmpty);
+  });
+
+  test('a direct delete keeps a group FTS row with the same wire id',
+      () async {
+    await insertDirect('shared', 'peer', 'me', 'me', 3,
+        ftsBody: 'zebra stripe');
+    await insertGroup('shared', 'g1', 4, ftsBody: 'giraffe spot');
+    expect(await searchDao.searchGlobal('zebra'), hasLength(1));
+    expect(await searchDao.searchGlobal('giraffe'), hasLength(1));
+
+    await MessagesDb.deleteMessageById('shared'); // direct storage id
+
+    expect(await searchDao.searchGlobal('zebra'), isEmpty);
+    final hits = await searchDao.searchGlobal('giraffe');
+    expect(hits, hasLength(1));
+    expect(hits.first.conversationId, 'g1');
+  });
+
+  test('deleteMessagesForGroup removes the group FTS rows', () async {
+    await insertGroup('g2-1', 'g2', 1, ftsBody: 'charlie old');
+    await insertGroup('g2-2', 'g2', 2, ftsBody: 'delta old');
+    expect(await searchDao.searchGlobal('charlie'), hasLength(1));
+
+    await MessagesDb.deleteMessagesForGroup('g2');
+
+    expect(await searchDao.searchGlobal('charlie'), isEmpty);
+    expect(await searchDao.searchGlobal('delta'), isEmpty);
+  });
+
+  test('deleteGroupMessagesBefore removes only the older FTS rows', () async {
+    await insertGroup('g3-1', 'g3', 100, ftsBody: 'echo old');
+    await insertGroup('g3-2', 'g3', 200, ftsBody: 'foxtrot new');
+
+    await MessagesDb.deleteGroupMessagesBefore('g3', 150);
+
+    expect(await searchDao.searchGlobal('echo'), isEmpty);
+    final hits = await searchDao.searchGlobal('foxtrot');
+    expect(hits, hasLength(1));
+    expect(hits.first.messageId, 'g3-2');
+  });
+
+  test('deleteMessagesBetween removes both directions of FTS rows', () async {
+    await insertDirect('dm-2', 'me', 'peer', 'me', 1,
+        ftsBody: 'hotel outbound');
+    await insertDirect('dm-3', 'peer', 'me', 'me', 2,
+        ftsBody: 'india inbound');
+
+    await MessagesDb.deleteMessagesBetween('me', 'peer');
+
+    expect(await searchDao.searchGlobal('hotel'), isEmpty);
+    expect(await searchDao.searchGlobal('india'), isEmpty);
+  });
+
+  test('MessageActionsService local-only delete de-indexes the message',
+      () async {
+    const wireId = 'wire-7';
+    await insertDirect(wireId, 'peer', 'me', 'me', 1,
+        ftsBody: 'juliet needle');
+    final actions = MessageActionsService(
+      modifyService: MessageModifyService.direct(
+        userId: 'me',
+        keyManager: KeyManager.fromIdentity(await IdentityKeyPair.generate()),
+        peerId: 'peer',
+      ),
+    );
+
+    final outcome = await actions.deleteMessage(
+      TextMessage(id: wireId, authorId: 'peer', text: 'x'),
+      localUserId: 'me',
+    );
+
+    expect(outcome, MessageDeleteOutcome.removedLocally);
+    expect(await searchDao.searchGlobal('juliet'), isEmpty);
+  });
+}

--- a/test/message_search_index_fixes_test.dart
+++ b/test/message_search_index_fixes_test.dart
@@ -1,0 +1,252 @@
+import 'dart:io';
+
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:prysm/crypto/key_store.dart';
+import 'package:prysm/database/message_schema_migrations.dart';
+import 'package:prysm/database/message_search_dao.dart';
+import 'package:prysm/database/messages.dart';
+import 'package:prysm/models/unlock_type.dart';
+import 'package:prysm/services/message_search_backfill_service.dart';
+import 'package:prysm/services/message_search_index_service.dart';
+import 'package:prysm/util/key_manager.dart';
+import 'package:prysm/util/message_blob_store.dart';
+import 'package:sqflite_common_ffi/sqflite_ffi.dart';
+
+class _FakeStore implements MessageSearchBackfillStore {
+  final Map<String, Object> store = {};
+
+  @override
+  Future<bool> isSearchBackfillComplete() async =>
+      store['search_backfill_complete'] as bool? ?? false;
+
+  @override
+  Future<void> setSearchBackfillComplete(bool value) async {
+    store['search_backfill_complete'] = value;
+  }
+
+  @override
+  Future<String> getSearchBackfillPhase() async =>
+      store['search_backfill_phase'] as String? ?? 'messages';
+
+  @override
+  Future<void> setSearchBackfillPhase(String phase) async {
+    store['search_backfill_phase'] = phase;
+  }
+
+  @override
+  Future<int> getSearchBackfillCursorTimestamp() async =>
+      store['search_backfill_cursor_ts'] as int? ?? 0;
+
+  @override
+  Future<String> getSearchBackfillCursorId() async =>
+      store['search_backfill_cursor_id'] as String? ?? '';
+
+  @override
+  Future<void> setSearchBackfillCursor({
+    required int timestamp,
+    required String id,
+  }) async {
+    store['search_backfill_cursor_ts'] = timestamp;
+    store['search_backfill_cursor_id'] = id;
+  }
+
+  @override
+  Future<int> getSearchBackfillFailureCount(String rowKey) async =>
+      store['search_backfill_failures_$rowKey'] as int? ?? 0;
+
+  @override
+  Future<void> setSearchBackfillFailureCount(String rowKey, int count) async {
+    store['search_backfill_failures_$rowKey'] = count;
+  }
+}
+
+void main() {
+  setUpAll(() {
+    TestWidgetsFlutterBinding.ensureInitialized();
+    sqfliteFfiInit();
+    databaseFactory = databaseFactoryFfi;
+  });
+
+  setUp(() async {
+    CryptoKeyStore.setUseInMemoryStorageOnly(true);
+    final docsDir = Directory.systemTemp.createTempSync('search_index_fixes');
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(
+      MethodChannel('plugins.flutter.io/path_provider'),
+      (call) async {
+        if (call.method == 'getApplicationDocumentsDirectory') {
+          return docsDir.path;
+        }
+        return null;
+      },
+    );
+    final db = await databaseFactory.openDatabase(inMemoryDatabasePath);
+    await MessageSchemaMigrations.onCreate(db, MessageSchemaMigrations.dbVersion);
+    MessagesDb.setDatabaseForTest(db);
+  });
+
+  tearDown(() async {
+    await MessagesDb.close();
+    MessagesDb.setDatabaseForTest(null);
+  });
+
+  Future<KeyManager> unlockedKeyManager() async {
+    final keyManager = KeyManager();
+    final ok = await keyManager.unlockWithPassphrase(
+      'search-index-fixes-passphrase',
+      type: UnlockType.passphrase,
+    );
+    expect(ok, isTrue);
+    return keyManager;
+  }
+
+  Future<Map<String, dynamic>> messageRow(String id) async {
+    final db = await MessagesDb.database;
+    return (await db.query('messages', where: 'id = ?', whereArgs: [id]))
+        .single;
+  }
+
+  test('unviewed view-once rows are not indexed; normal rows are', () async {
+    final db = await MessagesDb.database;
+    await db.insert('messages', {
+      'id': 'vo1',
+      'senderId': 'alice',
+      'receiverId': 'me',
+      'message': 'unused',
+      'type': 'file',
+      'fileName': 'vo.png',
+      'viewOnce': 1,
+      'viewed': 0,
+      'timestamp': 100,
+      'status': 'received',
+    });
+    await db.insert('messages', {
+      'id': 'n1',
+      'senderId': 'alice',
+      'receiverId': 'me',
+      'message': 'unused',
+      'type': 'file',
+      'fileName': 'normal.txt',
+      'timestamp': 200,
+      'status': 'received',
+    });
+
+    final service =
+        MessageSearchIndexService(keyManager: KeyManager(), userId: 'me');
+    expect(await service.indexInboundRow(await messageRow('vo1'), 'me'),
+        isTrue);
+    expect(await service.indexInboundRow(await messageRow('n1'), 'me'),
+        isTrue);
+
+    const dao = MessageSearchDao();
+    expect(await dao.searchGlobal('vo'), isEmpty);
+    final hits = await dao.searchGlobal('normal');
+    expect(hits, hasLength(1));
+    expect(hits.first.messageId, 'n1');
+  });
+
+  test('indexInboundRow resolves oversized blob markers before decrypting',
+      () async {
+    final keyManager = await unlockedKeyManager();
+    final encrypted = await keyManager.encryptForSelf('needle in the haystack');
+    final db = await MessagesDb.database;
+    // A marker row is what prepareForStorage leaves behind for any payload
+    // over MessageBlobStore.inlineThreshold.
+    await db.insert('messages', {
+      'id': 'big1',
+      'senderId': 'me',
+      'receiverId': 'peer',
+      'message': MessageBlobStore.marker('big1'),
+      'type': 'text',
+      'timestamp': 100,
+      'status': 'sent',
+    });
+    await MessageBlobStore.save('big1', encrypted);
+    await db.insert('messages', {
+      'id': 'small1',
+      'senderId': 'me',
+      'receiverId': 'peer',
+      'message': await keyManager.encryptForSelf('second note mentions pineapple'),
+      'type': 'text',
+      'timestamp': 200,
+      'status': 'sent',
+    });
+
+    final service = MessageSearchIndexService(
+      keyManager: keyManager,
+      userId: 'me',
+    );
+    expect(await service.indexInboundRow(await messageRow('big1'), 'me'),
+        isTrue);
+    expect(await service.indexInboundRow(await messageRow('small1'), 'me'),
+        isTrue);
+
+    const dao = MessageSearchDao();
+    final bigHits = await dao.searchGlobal('needle');
+    expect(bigHits, hasLength(1));
+    expect(bigHits.first.messageId, 'big1');
+    expect(bigHits.first.conversationId, 'peer');
+    expect((await dao.searchGlobal('pineapple')), hasLength(1));
+  });
+
+  test('backfill completes over an oversized blob-marker row and resets '
+      'its failure count', () async {
+    final keyManager = await unlockedKeyManager();
+    final encrypted = await keyManager.encryptForSelf('needle in the haystack');
+    final db = await MessagesDb.database;
+    await db.insert('messages', {
+      'id': 'big1',
+      'senderId': 'me',
+      'receiverId': 'peer',
+      'message': MessageBlobStore.marker('big1'),
+      'type': 'text',
+      'timestamp': 100,
+      'status': 'sent',
+    });
+    await MessageBlobStore.save('big1', encrypted);
+    await db.insert('messages', {
+      'id': 'small1',
+      'senderId': 'me',
+      'receiverId': 'peer',
+      'message': await keyManager.encryptForSelf('second note mentions pineapple'),
+      'type': 'text',
+      'timestamp': 200,
+      'status': 'sent',
+    });
+
+    final store = _FakeStore();
+    // Prior transient failures (e.g. before the group key existed) must not
+    // burn the row once it indexes successfully.
+    await store.setSearchBackfillFailureCount('big1', 3);
+
+    await MessageSearchBackfillService(
+      keyManager: keyManager,
+      userId: 'me',
+      store: store,
+    ).startIfNeeded();
+
+    expect(await store.isSearchBackfillComplete(), isTrue);
+    expect(await store.getSearchBackfillPhase(), 'done');
+    expect(await store.getSearchBackfillFailureCount('big1'), 0);
+    const dao = MessageSearchDao();
+    final hits = await dao.searchGlobal('needle');
+    expect(hits, hasLength(1));
+    expect(hits.first.messageId, 'big1');
+    expect((await dao.searchGlobal('pineapple')), hasLength(1));
+  });
+
+  test('buildSnippet returns short bodies verbatim', () {
+    // 37 chars, maxLen 80: the match window must not ellipsize a body that
+    // already fits.
+    const body = 'the pineapple upside down cake recipe';
+    expect(MessageSearchIndexService.buildSnippet(body, 'recipe'), body);
+
+    // Control: body exactly at maxLen is also returned unchanged.
+    const atLimit = 'the second note mentions pineapple';
+    expect(
+      MessageSearchIndexService.buildSnippet(atLimit, 'note', maxLen: 34),
+      atLimit,
+    );
+  });
+}

--- a/test/pending_queue_reconciler_test.dart
+++ b/test/pending_queue_reconciler_test.dart
@@ -2,6 +2,7 @@ import 'dart:io';
 
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:prysm/database/message_schema_migrations.dart';
 import 'package:prysm/database/messages.dart';
 import 'package:prysm/services/pending_queue_reconciler.dart';
 import 'package:prysm/util/pending_message_db_helper.dart';
@@ -54,6 +55,7 @@ Future<Database> _openMessagesDb() async {
       expiresAt INTEGER
     )
   ''');
+  await MessageSchemaMigrations.createMessageSearchFtsTable(db);
   return db;
 }
 


### PR DESCRIPTION
Fixes found while reviewing #138. Base is `feat/message-search`, so merging this into that
branch carries the fixes into #138 itself.

The feature works — I drove it on the real app. The problem is that it adds a **plaintext
searchable copy of every message body** and then fails to delete that copy on three of the
app's delete paths, so content the user erased stays readable in the sidebar search, across
restarts.

## The three commits, by topic

### `fix(search): remove the index row on every message delete path`

Five primitives delete rows from `messages`; only two de-indexed.

| Primitive | Reached from |
|---|---|
| `MessageCrudDao.deleteMessageById` | every delete of a **received** message (`_deleteLocalOnly`) and of a pending one |
| `ConversationQueriesDao.deleteMessagesForGroup` | leave group, admin deletes the group, admin removes me, membership prune |
| `ConversationQueriesDao.deleteGroupMessagesBefore` | rejoin history purge |
| `ConversationQueriesDao.deleteMessagesBetween` | "clear chat" on a direct conversation |

`deleteMessageById` now reads the row before deleting it and de-indexes afterwards; the three
bulk deletes go through a new `MessageSearchDao.removeForConversationUnprotected`.

Two details worth a reviewer's attention:

- **De-indexing happens after the row is gone, not before.** In the other order a broken
  search index blocks the delete — `disappearing_messages_test` caught exactly that.
- **The wire id is stripped using the row's own `groupId`, not `MessageIdCodec`.** The wire id
  is chosen by the sender (`inbound_message_router.dart:611`, validated only `is String` at
  `:859-867`) and may itself contain `::`, which would make the codec misparse a direct id and
  leave the leak open for exactly the messages crafted to exploit it.

The same commit removes the unscoped `WHERE messageId = ?` fallback in
`MessageSearchDao._deleteRow`: `conversationId` and `scope` are now `required`. Direct removals
used to fall into that fallback and delete rows for the same wire id in **other**
conversations. Since the wire id is attacker-supplied and group wire ids travel in cleartext to
every member (`group_chat_service.dart:584-601`), a peer could send a direct message reusing an
observed group id and wipe the victim's group search rows the moment they deleted it — or, for
a view-once, merely opened it.

### `fix(search): stop indexing view-once messages and unresolved blob payloads`

- The view-once gate was `viewOnce == 1 && viewed == 1`, so it only skipped the **already
  viewed** row. It now skips any view-once, on the live path, in the backfill queries, and at
  the three send sites. The sender's own copy is the worst case: it can never be opened
  (`chat.dart:2008`, `group_chat.dart:1408-1409`), so `markViewOnceViewed` never ran for it and
  its fileName stayed searchable forever.
- `_resolveMessageBlobs` mutated rows returned by `db.rawQuery`, which sqflite returns
  **read-only**. It threw `Unsupported operation: read-only` on any message over
  `MessageBlobStore.inlineThreshold`, killing the whole backfill run before it indexed
  anything — cursor stuck at 0, never complete, crashing again on every launch. Marker
  resolution moved into `indexInboundRow`/`indexSelfRow`, which also fixes the live path (the
  router handed the marker straight to the decrypt, which threw and was swallowed), and
  `_resolveMessageBlobs` is deleted: one place knows about markers now.
- The backfill's per-row failure counter is persisted in SharedPreferences and was never reset
  on success, so five failures spread over five launches — possibly five different transient
  causes — burned a row permanently. It resets on success now.
- `buildSnippet` truncated bodies that already fit: a 34-char body with `maxLen` 80 rendered as
  `…he second note mentions pineapple`.

### `fix(search): keep index writes off the delivery path and restore text scaling`

- Five index call sites added by this PR were not wrapped in `indexBestEffort`, contradicting
  the contract the service documents at `message_search_index_service.dart:48-50`. With the FTS
  table missing, all five throw **after** the row is already persisted: the self note is stored
  and the send handler dies, the edit is written and the tap handler throws, the inbound edit is
  applied and the router returns 500. Four of them reach the UI uncaught.
- `LinkedMessageText` returned `RichText`, which defaults to `TextScaler.noScaling`, where the
  pre-PR code returned `Text` for URL-free bodies. `Text.rich` restores the ambient scaler and
  also fixes the URL-bearing bodies, which were already unscaled before this PR.

## Evidence

```
flutter analyze   0 issues
flutter test      970 passed + 1 skipped   (522e38b alone: 957 + 1)
per commit        964 / 968 / 970, each green in isolation
```

**The 13 new tests all bite.** Run against `522e38b`, 13 of 13 fail and 0 pass; against this
branch, 13 of 13 pass. Every fix has a test that fails on the pre-fix code.

**Verified on the real running app**, containerised, against the real SQLCipher database, using
`tool/live/prysmlab`. The headline check, same body and same probes before and after:

```
before   PROBE_FTS_AFTER_DELETE=1 body=confidential axolotl dossier from a peer
         prysmlab count "…" -> 1          # still painted in the sidebar

after    PROBE_ROWS_BEFORE=1 PROBE_FTS_BEFORE=1
         PROBE_ROWS_AFTER=0  PROBE_FTS_AFTER_DELETE=0
         prysmlab count "…" -> 0
```

Also verified live: group delete `3 → 1` hits and the bounded variant leaving only the newer
row; the same wire id indexed direct + group, where the direct delete now leaves the group row
alone; an unviewed view-once not indexed with a control that is; a 524,346-character payload
stored as a `blob:` marker and indexed end-to-end **with real crypto**; short snippets rendered
verbatim; search still working after a restart; and six hostile search queries (`"`, `*`, `AND`,
`NEAR(`, `a"b*c(`, `""""`) with no crash and no FTS5 syntax error.

## Deliberately not in this PR

- **Inbound wire-id validation.** The right fix for the attacker-chosen id is a UUID-shape check
  in `validateMessage`, which would also close a pre-existing defect this PR does not touch: the
  REPLACE clobber in `insertInboundMessage`. It needs updates to ~8 test files that use non-UUID
  ids on purpose, and it carries a compatibility assumption that deserves its own PR.
- **A SQL trigger on `messages`.** Tempting, and empirically it works — but it duplicates
  `MessageIdCodec` in untyped SQL that fails silently if a scope string is ever renamed. After
  this PR there are no delete primitives left that skip de-indexing, so the trigger buys a
  hypothetical future call site at the cost of a real drift surface.
- **A migration to purge already-indexed view-once rows.** Not needed: the FTS table is new in
  this unreleased PR, so no shipped build has them.
- **An indexed side table.** Every `upsert` currently scans the whole FTS table (all columns are
  `UNINDEXED`): measured at 0.59 ms / 1.0 ms / 1.9 ms for 5k / 10k / 20k rows, linear. A
  `storageId`-keyed map plus an fts5 table addressed by rowid brings that to 0.16 ms and 0.28 ms,
  but it adds a second consistency surface — the same class of bug this PR fixes. Worth revisiting
  when the index grows by an order of magnitude.
- Remaining minor findings from the review are listed in the comment on #138.
