### PR TITLE
perf(ratchet): read the peer scheme from cache on the send path

### DIFF
--- a/lib/crypto/constants.dart
+++ b/lib/crypto/constants.dart
@@ -60,9 +60,11 @@ class CryptoConstants {
     return ratchetSchemeRank(a) >= ratchetSchemeRank(b) ? a : b;
   }
 
-  /// Validates a profile or wire ratchet scheme string.
-  static String? parseRatchetScheme(String? raw) {
-    if (raw == null) return null;
+  /// Validates a profile or wire ratchet scheme string. Peer-controlled
+  /// profile JSON may carry a non-string value (a number or object); those
+  /// are ignored (null), never thrown on.
+  static String? parseRatchetScheme(Object? raw) {
+    if (raw is! String) return null;
     final trimmed = raw.trim();
     switch (trimmed) {
       case schemeRatchet1:

--- a/lib/crypto/ratchet/ratchet_service.dart
+++ b/lib/crypto/ratchet/ratchet_service.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:convert';
 
 import 'package:cryptography/cryptography.dart';
@@ -9,7 +10,9 @@ import 'package:prysm/crypto/ratchet/prekey_bundle.dart';
 import 'package:prysm/crypto/ratchet/ratchet_session.dart';
 import 'package:prysm/crypto/ratchet/session_store.dart';
 import 'package:prysm/crypto/wire.dart';
+import 'package:prysm/transport/transport_preference.dart';
 import 'package:prysm/transport/transport_provider.dart';
+import 'package:prysm/util/db_helper.dart';
 
 /// High-level 1:1 ratchet encrypt/decrypt with SQLite session persistence.
 class RatchetService {
@@ -20,6 +23,10 @@ class RatchetService {
 
   RatchetSessionStore? _sessionStore;
   final Map<String, Mutex> _peerLocks = {};
+
+  /// Peers with a background scheme warm currently in flight, so a peer
+  /// whose profile never answers cannot pile up one fetch per message.
+  final Set<String> _inFlightSchemeWarms = {};
 
   /// Test override for peer profile ratchet-scheme lookup.
   Future<String?> Function(String peerId)? _peerRatchetSchemeFetcher;
@@ -49,13 +56,24 @@ class RatchetService {
 
   static final X25519 _x25519 = X25519();
 
+  /// Bounds the scheme profile fetch: a single attempt, a short timeout and
+  /// no TorDelivery retry/NEWNYM (maxAttempts 1 never reaches the
+  /// circuit-refresh branch of withTorRetry), so a cold first send cannot
+  /// pay 3 x 20s or tear down healthy circuits.
+  static const Duration _schemeFetchTimeout = Duration(seconds: 3);
+
   Future<String?> _peerRatchetSchemeFromProfile(String peerId) async {
     final fetcher = _peerRatchetSchemeFetcher;
     if (fetcher != null) {
       return CryptoConstants.parseRatchetScheme(await fetcher(peerId));
     }
     try {
-      final body = await TransportProvider.getProfileOrFallback(peerId);
+      final body = await TransportProvider.getProfileOrFallback(
+        peerId,
+        timeout: _schemeFetchTimeout,
+        maxAttempts: 1,
+        preference: TransportPreference.httpOnly,
+      );
       final data = jsonDecode(body) as Map<String, dynamic>;
       return CryptoConstants.parseRatchetScheme(
         data['ratchetScheme'] as String?,
@@ -65,13 +83,85 @@ class RatchetService {
     }
   }
 
+  /// The peer ratchet scheme persisted on the `users` row, warmed by the
+  /// profile fetches the app already performs (ContactAddService,
+  /// PeerIdentityResolver, the chat screen refresh and the inbound
+  /// sender-profile refresh). Null when unknown.
+  Future<String?> _cachedPeerRatchetScheme(String peerId) async {
+    try {
+      final user = await DBHelper.getUserById(peerId);
+      return CryptoConstants.parseRatchetScheme(
+        user?['ratchetScheme'] as String?,
+      );
+    } catch (_) {
+      return null;
+    }
+  }
+
+  /// Persists [scheme] for [peerId]. A missing `users` row (or a
+  /// pre-migration schema without the column) leaves the cache cold and is
+  /// not an error: the next cold bootstrap simply re-warms.
+  Future<void> _persistPeerRatchetScheme(String peerId, String scheme) async {
+    try {
+      await DBHelper.updateUserFields(peerId, {'ratchetScheme': scheme});
+    } catch (_) {
+      // Deliberately silent: a cold cache only costs another bounded
+      // background fetch.
+    }
+  }
+
+  /// Bounded background scheme refresh for a cold cache. Never throws.
+  /// At most one background fetch per peer runs at a time: a second warm
+  /// for the same peer while one is in flight is dropped (the in-flight
+  /// one will persist the scheme if the profile ever answers).
+  Future<void> _warmPeerRatchetScheme(String peerId) async {
+    if (!_inFlightSchemeWarms.add(peerId)) return;
+    try {
+      final scheme = await _peerRatchetSchemeFromProfile(peerId);
+      if (scheme != null) {
+        await _persistPeerRatchetScheme(peerId, scheme);
+      }
+    } catch (_) {
+      // Nothing to recover: the cache simply stays cold.
+    } finally {
+      _inFlightSchemeWarms.remove(peerId);
+    }
+  }
+
+  /// Resolves the peer's ratchet scheme for a NEW session. The persisted
+  /// cache is consulted first; only a cold cache awaits the already-bounded
+  /// profile fetch (single attempt, ~3s, no NEWNYM), so a reachable peer
+  /// negotiates v3 instead of silently downgrading to the v2 initializer.
+  /// On fetch failure or timeout the send falls back to v2 and re-warms in
+  /// the background, keeping the first send bounded (never the old 3 x 20s
+  /// + NEWNYM behaviour).
   Future<String?> _resolvePeerRatchetScheme(
     String peerId,
     RatchetSession? session,
   ) async {
-    final cached = session?.peerWireScheme;
-    final profile = await _peerRatchetSchemeFromProfile(peerId);
-    return CryptoConstants.maxRatchetScheme(cached, profile);
+    final cached =
+        session?.peerWireScheme ?? await _cachedPeerRatchetScheme(peerId);
+    if (cached != null) {
+      return cached;
+    }
+    String? fromProfile;
+    try {
+      // The bound is enforced here, not only passed to the fetch: the device
+      // log is full of Tor futures that never complete ("TimeoutException
+      // after 0:00:30: Future not completed"), and a send must stay bounded
+      // even if the transport fails to honour its own timeout.
+      fromProfile = await _peerRatchetSchemeFromProfile(
+        peerId,
+      ).timeout(_schemeFetchTimeout);
+    } catch (_) {
+      // Fetch failed or timed out: fall through to the v2 fallback below.
+    }
+    if (fromProfile != null) {
+      await _persistPeerRatchetScheme(peerId, fromProfile);
+      return fromProfile;
+    }
+    unawaited(_warmPeerRatchetScheme(peerId));
+    return null;
   }
 
   Future<String> encryptText({

--- a/lib/crypto/ratchet/ratchet_service.dart
+++ b/lib/crypto/ratchet/ratchet_service.dart
@@ -24,9 +24,13 @@ class RatchetService {
   RatchetSessionStore? _sessionStore;
   final Map<String, Mutex> _peerLocks = {};
 
-  /// Peers with a background scheme warm currently in flight, so a peer
-  /// whose profile never answers cannot pile up one fetch per message.
-  final Set<String> _inFlightSchemeWarms = {};
+  /// The one in-flight profile fetch per peer. Both the foreground
+  /// resolve path and the background warm share this future, so a peer
+  /// whose profile never answers cannot pile up one fetch per message
+  /// (or per cold bootstrap). The entry is removed when the fetch
+  /// settles; while it hangs, every cold caller waits on the same
+  /// request instead of starting a new one.
+  final Map<String, Future<String?>> _inFlightSchemeFetches = {};
 
   /// Test override for peer profile ratchet-scheme lookup.
   Future<String?> Function(String peerId)? _peerRatchetSchemeFetcher;
@@ -75,9 +79,7 @@ class RatchetService {
         preference: TransportPreference.httpOnly,
       );
       final data = jsonDecode(body) as Map<String, dynamic>;
-      return CryptoConstants.parseRatchetScheme(
-        data['ratchetScheme'] as String?,
-      );
+      return CryptoConstants.parseRatchetScheme(data['ratchetScheme']);
     } catch (_) {
       return null;
     }
@@ -90,9 +92,7 @@ class RatchetService {
   Future<String?> _cachedPeerRatchetScheme(String peerId) async {
     try {
       final user = await DBHelper.getUserById(peerId);
-      return CryptoConstants.parseRatchetScheme(
-        user?['ratchetScheme'] as String?,
-      );
+      return CryptoConstants.parseRatchetScheme(user?['ratchetScheme']);
     } catch (_) {
       return null;
     }
@@ -110,22 +110,36 @@ class RatchetService {
     }
   }
 
-  /// Bounded background scheme refresh for a cold cache. Never throws.
-  /// At most one background fetch per peer runs at a time: a second warm
-  /// for the same peer while one is in flight is dropped (the in-flight
-  /// one will persist the scheme if the profile ever answers).
-  Future<void> _warmPeerRatchetScheme(String peerId) async {
-    if (!_inFlightSchemeWarms.add(peerId)) return;
-    try {
-      final scheme = await _peerRatchetSchemeFromProfile(peerId);
-      if (scheme != null) {
-        await _persistPeerRatchetScheme(peerId, scheme);
+  /// Returns the one shared in-flight profile fetch for [peerId], starting
+  /// it if none is running. Never throws: fetch and persistence failures
+  /// surface as a null scheme. The scheme is persisted off this shared
+  /// future, so the result is stored even when the foreground caller has
+  /// already timed out and moved on. The entry is cleared when the future
+  /// settles, letting the next cold bootstrap start a fresh fetch.
+  Future<String?> _sharedSchemeFetch(String peerId) {
+    final inFlight = _inFlightSchemeFetches[peerId];
+    if (inFlight != null) return inFlight;
+    final future = _peerRatchetSchemeFromProfile(peerId).then((scheme) async {
+      if (scheme == null) return null;
+      await _persistPeerRatchetScheme(peerId, scheme);
+      return scheme;
+    });
+    _inFlightSchemeFetches[peerId] = future;
+    unawaited(future.whenComplete(() {
+      // Only clear our own entry: a newer fetch for the same peer must not
+      // be evicted by the settling of this one.
+      if (identical(_inFlightSchemeFetches[peerId], future)) {
+        _inFlightSchemeFetches.remove(peerId);
       }
-    } catch (_) {
-      // Nothing to recover: the cache simply stays cold.
-    } finally {
-      _inFlightSchemeWarms.remove(peerId);
-    }
+    }));
+    return future;
+  }
+
+  /// Bounded background scheme refresh for a cold cache. Never throws.
+  /// A second warm for the same peer while a fetch is in flight reuses
+  /// the shared fetch instead of starting a new one.
+  Future<void> _warmPeerRatchetScheme(String peerId) async {
+    unawaited(_sharedSchemeFetch(peerId));
   }
 
   /// Resolves the peer's ratchet scheme for a NEW session. The persisted
@@ -149,15 +163,19 @@ class RatchetService {
       // The bound is enforced here, not only passed to the fetch: the device
       // log is full of Tor futures that never complete ("TimeoutException
       // after 0:00:30: Future not completed"), and a send must stay bounded
-      // even if the transport fails to honour its own timeout.
-      fromProfile = await _peerRatchetSchemeFromProfile(
+      // even if the transport fails to honour its own timeout. The timeout
+      // stops THIS caller waiting; the shared fetch keeps running so a
+      // background warm (or the next cold bootstrap) reuses it instead of
+      // starting a duplicate fetch.
+      fromProfile = await _sharedSchemeFetch(
         peerId,
       ).timeout(_schemeFetchTimeout);
     } catch (_) {
       // Fetch failed or timed out: fall through to the v2 fallback below.
     }
     if (fromProfile != null) {
-      await _persistPeerRatchetScheme(peerId, fromProfile);
+      // Persistence hangs off the shared fetch (see _sharedSchemeFetch), so
+      // the cache is already warm by the time the future completed here.
       return fromProfile;
     }
     unawaited(_warmPeerRatchetScheme(peerId));

--- a/lib/screens/chat.dart
+++ b/lib/screens/chat.dart
@@ -81,6 +81,7 @@ import 'package:prysm/services/typing_state_tracker.dart';
 import 'package:prysm/util/typing_indicator_notifier.dart';
 import 'package:prysm/util/battery_saver_policy.dart';
 import 'package:prysm/util/db_helper.dart';
+import 'package:prysm/crypto/constants.dart';
 import 'package:prysm/crypto/wire.dart';
 import 'package:prysm/util/tor_service.dart';
 import 'package:prysm/util/key_manager.dart';
@@ -609,6 +610,14 @@ class _ChatScreenState extends State<ChatScreen> {
       }
       if (data['avatar'] != null && (data['avatar'] as String).isNotEmpty) {
         updates['avatarBase64'] = data['avatar'];
+      }
+      // The peer's advertised ratchet scheme warms the send-path cache so
+      // the first message to this peer never needs a profile fetch.
+      final ratchetScheme = CryptoConstants.parseRatchetScheme(
+        data['ratchetScheme'] as String?,
+      );
+      if (ratchetScheme != null) {
+        updates['ratchetScheme'] = ratchetScheme;
       }
       if (updates.isNotEmpty) {
         await DBHelper.updateUserFields(widget.peerId, updates);

--- a/lib/screens/chat.dart
+++ b/lib/screens/chat.dart
@@ -614,7 +614,7 @@ class _ChatScreenState extends State<ChatScreen> {
       // The peer's advertised ratchet scheme warms the send-path cache so
       // the first message to this peer never needs a profile fetch.
       final ratchetScheme = CryptoConstants.parseRatchetScheme(
-        data['ratchetScheme'] as String?,
+        data['ratchetScheme'],
       );
       if (ratchetScheme != null) {
         updates['ratchetScheme'] = ratchetScheme;

--- a/lib/server/PrysmServer.dart
+++ b/lib/server/PrysmServer.dart
@@ -394,6 +394,14 @@ class PrysmServer {
         if (data['avatar'] != null && (data['avatar'] as String).isNotEmpty) {
           updates['avatarBase64'] = data['avatar'];
         }
+        // The sender's advertised ratchet scheme warms the send-path cache
+        // so the reply's first message never needs a profile fetch.
+        final ratchetScheme = PeerIdentityResolver.ratchetSchemeFromProfile(
+          data,
+        );
+        if (ratchetScheme != null) {
+          updates['ratchetScheme'] = ratchetScheme;
+        }
         if (updates.isNotEmpty) {
           await DBHelper.updateUserFields(senderId, updates);
         }

--- a/lib/services/contact_add_service.dart
+++ b/lib/services/contact_add_service.dart
@@ -180,7 +180,7 @@ class ContactAddService {
       // The peer's advertised ratchet scheme warms the send-path cache so
       // the first message to this peer never needs a profile fetch.
       final ratchetScheme = CryptoConstants.parseRatchetScheme(
-        profileData['ratchetScheme'] as String?,
+        profileData['ratchetScheme'],
       );
       if (ratchetScheme != null) {
         updates['ratchetScheme'] = ratchetScheme;

--- a/lib/services/contact_add_service.dart
+++ b/lib/services/contact_add_service.dart
@@ -147,6 +147,9 @@ class ContactAddService {
       'customName': newUser.customName,
       'identityJson': identityJson,
       'publicKeyPem': identityJson,
+      // INSERT OR REPLACE destroys every column not carried over: keep a
+      // scheme already recorded by an earlier profile fetch.
+      'ratchetScheme': existing?['ratchetScheme'] as String?,
     });
 
     unawaited(_enrichFromProfile(onionId));
@@ -173,6 +176,14 @@ class ContactAddService {
       final avatar = profileData['avatar'] as String?;
       if (avatar != null && avatar.isNotEmpty) {
         updates['avatarBase64'] = avatar;
+      }
+      // The peer's advertised ratchet scheme warms the send-path cache so
+      // the first message to this peer never needs a profile fetch.
+      final ratchetScheme = CryptoConstants.parseRatchetScheme(
+        profileData['ratchetScheme'] as String?,
+      );
+      if (ratchetScheme != null) {
+        updates['ratchetScheme'] = ratchetScheme;
       }
       if (updates.isEmpty) {
         return;

--- a/lib/services/peer_identity_resolver.dart
+++ b/lib/services/peer_identity_resolver.dart
@@ -76,11 +76,13 @@ class PeerIdentityResolver {
     if (TorRuntimeGate.blocked) return null;
     try {
       String? identityJson;
+      String? ratchetScheme;
       late IdentityPublicKeys identity;
       PrekeyBundle? prekeyBundle;
       try {
         final profileBody = await _fetchProfile(peerId);
         final data = jsonDecode(profileBody) as Map<String, dynamic>;
+        ratchetScheme = ratchetSchemeFromProfile(data);
         identityJson = IdentityKeyPair.storedPeerIdentityRaw(
           (data['identityJson'] as String?)?.trim(),
           (data['publicKeyPem'] as String?)?.trim(),
@@ -99,7 +101,7 @@ class PeerIdentityResolver {
         identity = keyManager.importPeerIdentity(identityJson);
         onIdentityResolved?.call(identity);
       }
-      await _persist(identityJson);
+      await _persist(identityJson, ratchetScheme: ratchetScheme);
       return ResolvedPeerIdentity(identity, prekeyBundle);
     } catch (e) {
       Logging.error('Failed to fetch peer identity: $e', 'PeerIdentityResolver');
@@ -107,7 +109,7 @@ class PeerIdentityResolver {
     }
   }
 
-  Future<void> _persist(String identityJson) async {
+  Future<void> _persist(String identityJson, {String? ratchetScheme}) async {
     try {
       final existing = await DBHelper.getUserById(peerId);
       await DBHelper.insertOrUpdateUser({
@@ -118,6 +120,9 @@ class PeerIdentityResolver {
         'customName': existing?['customName'],
         'identityJson': identityJson,
         'publicKeyPem': identityJson,
+        // Warms the send-path ratchet-scheme cache; preserves a previously
+        // recorded scheme when this profile advertised none.
+        'ratchetScheme': ratchetScheme ?? existing?['ratchetScheme'] as String?,
       });
     } catch (e) {
       Logging.error('Failed to persist peer public key: $e', 'PeerIdentityResolver');

--- a/lib/services/peer_identity_resolver.dart
+++ b/lib/services/peer_identity_resolver.dart
@@ -42,8 +42,9 @@ class PeerIdentityResolver {
         _fetchPublic = fetchPublic ?? TransportProvider.getPublicOrFallback;
 
   /// Parsed ratchet wire scheme from a profile JSON object, if advertised.
+  /// Non-string values (peer-controlled JSON) are ignored, not thrown on.
   static String? ratchetSchemeFromProfile(Map<String, dynamic> data) =>
-      CryptoConstants.parseRatchetScheme(data['ratchetScheme'] as String?);
+      CryptoConstants.parseRatchetScheme(data['ratchetScheme']);
 
   /// The identity JSON cached in the local user store for [peerId], if any.
   Future<String?> getCachedIdentityJson() async {

--- a/lib/util/db_helper.dart
+++ b/lib/util/db_helper.dart
@@ -62,7 +62,7 @@ class DBHelper {
     await DatabaseCipher.prepare(path);
     final db = await openDatabase(
       path,
-      version: 14,
+      version: 15,
       onCreate: _createDB,
       onUpgrade: _onUpgrade,
       // PRAGMA key must be the first statement on the connection.
@@ -86,7 +86,8 @@ class DBHelper {
         avatarBase64 TEXT,
         customName TEXT,
         publicKeyPem TEXT,
-        identityJson TEXT
+        identityJson TEXT,
+        ratchetScheme TEXT
       )
     ''');
     await db.execute('CREATE INDEX idx_users_name ON users(name)');
@@ -224,6 +225,21 @@ class DBHelper {
       // the step on a database that already has the other crypto tables
       // only adds the missing one.
       await _createCryptoTables(db);
+    }
+    if (oldVersion < 15) {
+      // users.ratchetScheme (the persisted per-peer ratchet-scheme cache
+      // that keeps the first-message send path off the network). Column
+      // additions on users follow the v2/v3/v6 pattern, with one extra
+      // guard those steps do not need: this step runs for every database
+      // older than 15, including ones predating the users table, and
+      // PRAGMA table_info returns an empty list (not an error) for a table
+      // that does not exist. Empty therefore means "no users table" — skip,
+      // because onCreate already ships the column.
+      final cols = await db.rawQuery('PRAGMA table_info(users)');
+      final colNames = cols.map((c) => c['name'] as String).toSet();
+      if (cols.isNotEmpty && !colNames.contains('ratchetScheme')) {
+        await db.execute('ALTER TABLE users ADD COLUMN ratchetScheme TEXT');
+      }
     }
   }
 

--- a/test/chat_service_characterization_test.dart
+++ b/test/chat_service_characterization_test.dart
@@ -53,7 +53,8 @@ Future<Database> _openDbHelperDb() async {
       avatarBase64 TEXT,
       customName TEXT,
       publicKeyPem TEXT,
-      identityJson TEXT
+      identityJson TEXT,
+      ratchetScheme TEXT
     )
   ''');
   // ChatService.encryptForPeer routes through KeyManager into the shared

--- a/test/contact_add_service_characterization_test.dart
+++ b/test/contact_add_service_characterization_test.dart
@@ -37,7 +37,8 @@ Future<Database> _openTestDb() async {
       avatarBase64 TEXT,
       customName TEXT,
       publicKeyPem TEXT,
-      identityJson TEXT
+      identityJson TEXT,
+      ratchetScheme TEXT
     )
   ''');
   await db.execute('''

--- a/test/contact_add_service_characterization_test.dart
+++ b/test/contact_add_service_characterization_test.dart
@@ -360,6 +360,43 @@ void main() {
     });
 
     test(
+        'a non-string ratchetScheme in the profile is ignored without '
+        'breaking name/avatar enrichment', () async {
+      final service = ContactAddService.forTesting(
+        fetchPublic: (_) async => peerIdentityJson,
+        fetchProfile: (_) async => jsonEncode({
+          'identityJson': peerIdentityJson,
+          'username': 'Alice B.',
+          'avatar': 'YWJj',
+          // Peer-controlled JSON must not be trusted to carry a string: a
+          // numeric scheme used to throw a TypeError that aborted the whole
+          // enrichment, silently dropping name and avatar too.
+          'ratchetScheme': 42,
+        }),
+      );
+
+      final added = await service.addContact(
+        onionId: onionId,
+        displayName: 'Alice',
+      );
+      expect(added, isTrue);
+
+      Map<String, dynamic>? row;
+      for (var i = 0; i < 20; i++) {
+        row = await DBHelper.getUserById(onionId);
+        if (row != null && row['avatarBase64'] == 'YWJj') break;
+        await Future.delayed(const Duration(milliseconds: 5));
+      }
+
+      // The rest of the profile is still applied...
+      expect(row?['name'], 'Alice B.');
+      expect(row?['customName'], 'Alice');
+      expect(row?['avatarBase64'], 'YWJj');
+      // ...and the non-string scheme is ignored, not stored.
+      expect(row?['ratchetScheme'], isNull);
+    });
+
+    test(
         'background profile enrichment failure does not throw or affect '
         'the already-added contact', () async {
       final service = ContactAddService.forTesting(

--- a/test/crypto/ratchet_bootstrap_test.dart
+++ b/test/crypto/ratchet_bootstrap_test.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:convert';
 import 'dart:typed_data';
 
@@ -51,12 +52,14 @@ void main() {
     CryptoKeyStore.setUseInMemoryStorageOnly(false);
   });
 
+  late Database db;
+
   setUp(() async {
     CryptoKeyStore.resetInMemoryStorageForTest();
     RatchetService.instance.setPeerRatchetSchemeFetcherForTest(
       (_) async => CryptoConstants.schemeRatchet3,
     );
-    final db = await databaseFactory.openDatabase(
+    db = await databaseFactory.openDatabase(
       inMemoryDatabasePath,
       options: OpenDatabaseOptions(
         version: 1,
@@ -83,8 +86,13 @@ void main() {
     await RatchetSessionStore(db).deleteAll();
   });
 
-  tearDown(() {
+  tearDown(() async {
     RatchetService.instance.setPeerRatchetSchemeFetcherForTest(null);
+    // Close the database: sqflite_common_ffi caches inMemoryDatabasePath
+    // (singleInstance is the default), so without a close the next setUp's
+    // openDatabase returns THIS database and earlier tests' users rows
+    // (including ratchetScheme) leak into the next test's "cold" cache.
+    await db.close();
     DBHelper.setDatabaseForTest(null);
   });
 
@@ -213,9 +221,7 @@ void main() {
 
     final bobBundle = await PrekeyBundle.generate(bob, persist: true);
 
-    // Cold cache: the users row exists but no scheme was recorded yet. The
-    // row is replaced outright so a scheme seeded by an earlier test in this
-    // process cannot leak in (the in-memory DB is shared across tests).
+    // Cold cache: the users row exists but no scheme was recorded yet.
     await DBHelper.insertOrUpdateUser({'id': bobOnion});
     RatchetService.instance.setPeerRatchetSchemeFetcherForTest(
       (_) async {
@@ -1027,5 +1033,52 @@ void main() {
     );
     // 96 bytes DH1||DH2||DH3 + 32-byte DH4 term.
     expect(sharedResp.material.length, 128);
+  });
+
+  test(
+      'repeated cold bootstraps to a hanging profile share one in-flight '
+      'fetch', () async {
+    final alice = await IdentityKeyPair.generate();
+    final bob = await IdentityKeyPair.generate();
+    final bobPub = await _publicKeys(bob);
+    const bobOnion = 'bob.peer.onion';
+
+    final bobBundle = await PrekeyBundle.generate(bob, persist: true);
+
+    // Cold cache: the users row exists but no scheme was ever recorded.
+    await DBHelper.insertOrUpdateUser({'id': bobOnion});
+
+    // A profile that never answers: the fetcher hangs on an uncompleted
+    // Completer, so only genuinely started fetches are counted.
+    final hang = Completer<String?>();
+    var fetchCount = 0;
+    RatchetService.instance.setPeerRatchetSchemeFetcherForTest((_) {
+      fetchCount++;
+      return hang.future;
+    });
+
+    final store = RatchetSessionStore(await DBHelper.database);
+    for (var i = 0; i < 3; i++) {
+      // Drop the persisted session so every send re-enters the cold
+      // bootstrap path (the only path that resolves the peer scheme).
+      await store.delete(bobOnion);
+      await RatchetService.instance.encryptText(
+        peerId: bobOnion,
+        plaintext: 'msg-$i',
+        local: alice,
+        peer: bobPub,
+        peerBundle: bobBundle,
+      );
+    }
+
+    // Every cold bootstrap must share the single in-flight fetch: the count
+    // must not grow with each send (pre-fix, each send started a fresh
+    // untracked foreground fetch on top of a background warm).
+    expect(fetchCount, 1);
+
+    // Let the shared fetch settle so the service's in-flight entry clears
+    // and no later test in this file inherits a hanging entry for the peer.
+    hang.complete(null);
+    await Future<void>.delayed(Duration.zero);
   });
 }

--- a/test/crypto/ratchet_bootstrap_test.dart
+++ b/test/crypto/ratchet_bootstrap_test.dart
@@ -62,6 +62,20 @@ void main() {
         version: 1,
         onCreate: (db, _) async {
           await RatchetSessionStore.ensureTable(db);
+          // Mirrors DBHelper._createDB so the send path can consult the
+          // persisted per-peer ratchet-scheme cache (users.ratchetScheme).
+          await db.execute('''
+            CREATE TABLE users (
+              id TEXT PRIMARY KEY,
+              name TEXT,
+              avatarUrl TEXT,
+              avatarBase64 TEXT,
+              customName TEXT,
+              publicKeyPem TEXT,
+              identityJson TEXT,
+              ratchetScheme TEXT
+            )
+          ''');
         },
       ),
     );
@@ -163,6 +177,13 @@ void main() {
 
     final bobBundle = await PrekeyBundle.generate(bob, persist: true);
 
+    // The peer's profile fetch has already recorded its scheme (the normal
+    // pre-first-message path): v3 must be negotiated from the cache.
+    await DBHelper.ensureUserExist(bobOnion);
+    await DBHelper.updateUserFields(bobOnion, {
+      'ratchetScheme': CryptoConstants.schemeRatchet3,
+    });
+
     final wire = await RatchetService.instance.encryptText(
       peerId: bobOnion,
       plaintext: 'ratchet hello',
@@ -182,6 +203,175 @@ void main() {
       peer: alicePub,
     );
     expect(plain, 'ratchet hello');
+  });
+
+  test('cold cache awaits the bounded scheme fetch and negotiates v3', () async {
+    final alice = await IdentityKeyPair.generate();
+    final bob = await IdentityKeyPair.generate();
+    final bobPub = await _publicKeys(bob);
+    const bobOnion = 'bob.peer.onion';
+
+    final bobBundle = await PrekeyBundle.generate(bob, persist: true);
+
+    // Cold cache: the users row exists but no scheme was recorded yet. The
+    // row is replaced outright so a scheme seeded by an earlier test in this
+    // process cannot leak in (the in-memory DB is shared across tests).
+    await DBHelper.insertOrUpdateUser({'id': bobOnion});
+    RatchetService.instance.setPeerRatchetSchemeFetcherForTest(
+      (_) async {
+        await Future.delayed(const Duration(milliseconds: 300));
+        return CryptoConstants.schemeRatchet3;
+      },
+    );
+
+    final wire = await RatchetService.instance.encryptText(
+      peerId: bobOnion,
+      plaintext: 'hello',
+      local: alice,
+      peer: bobPub,
+      peerBundle: bobBundle,
+    );
+
+    // The cold send awaited the bounded fetch instead of returning null
+    // immediately: v3 is negotiated, not a silent downgrade to v2.
+    final envelope = jsonDecode(wire) as Map<String, dynamic>;
+    expect(envelope['scheme'], CryptoConstants.schemeRatchet3);
+    final session = await RatchetSessionStore(await DBHelper.database)
+        .load(bobOnion);
+    expect(session!.version, 3);
+
+    // The awaited fetch also warmed the persisted cache for later sends.
+    final user = await DBHelper.getUserById(bobOnion);
+    expect(user?['ratchetScheme'], CryptoConstants.schemeRatchet3);
+  });
+
+  test('cold cache with a dead profile falls back to v2 within the bounded fetch',
+      () async {
+    final alice = await IdentityKeyPair.generate();
+    final bob = await IdentityKeyPair.generate();
+    final bobPub = await _publicKeys(bob);
+    const bobOnion = 'bob.peer.onion';
+
+    final bobBundle = await PrekeyBundle.generate(bob, persist: true);
+
+    await DBHelper.insertOrUpdateUser({'id': bobOnion});
+    var completedCalls = 0;
+    RatchetService.instance.setPeerRatchetSchemeFetcherForTest((_) async {
+      await Future.delayed(const Duration(milliseconds: 400));
+      completedCalls++;
+      return null;
+    });
+
+    final stopwatch = Stopwatch()..start();
+    final wire = await RatchetService.instance.encryptText(
+      peerId: bobOnion,
+      plaintext: 'hello',
+      local: alice,
+      peer: bobPub,
+      peerBundle: bobBundle,
+    );
+    stopwatch.stop();
+
+    // The cold send awaited the bounded fetch: the fetch completed before
+    // the send returned (pre-fix it was still in flight in the background).
+    expect(completedCalls, greaterThanOrEqualTo(1));
+    // Bounded by the short timeout: nowhere near the old 3 x 20s.
+    expect(stopwatch.elapsed, lessThan(const Duration(seconds: 5)));
+    // No scheme known: the v2 initializer is used and ratchet-1 emitted.
+    final envelope = jsonDecode(wire) as Map<String, dynamic>;
+    expect(envelope['scheme'], isNot(CryptoConstants.schemeRatchet3));
+    final session = await RatchetSessionStore(await DBHelper.database)
+        .load(bobOnion);
+    expect(session!.version, 2);
+  });
+
+  test(
+      'repeated cold sends to a dead-profile peer keep background fetches bounded',
+      () async {
+    final alice = await IdentityKeyPair.generate();
+    final bob = await IdentityKeyPair.generate();
+    final bobPub = await _publicKeys(bob);
+    const bobOnion = 'bob.peer.onion';
+
+    final bobBundle = await PrekeyBundle.generate(bob, persist: true);
+
+    // The users row exists but no scheme was ever recorded: every send sees
+    // a cold cache and the profile never answers.
+    await DBHelper.insertOrUpdateUser({'id': bobOnion});
+
+    var concurrent = 0;
+    var maxConcurrent = 0;
+    RatchetService.instance.setPeerRatchetSchemeFetcherForTest((_) async {
+      concurrent++;
+      if (concurrent > maxConcurrent) maxConcurrent = concurrent;
+      await Future.delayed(const Duration(milliseconds: 300));
+      concurrent--;
+      return null;
+    });
+
+    // Drop the persisted session between sends so every send re-enters the
+    // cold bootstrap path (the only path that resolves the peer scheme).
+    final store = RatchetSessionStore(await DBHelper.database);
+    for (var i = 0; i < 4; i++) {
+      await store.delete(bobOnion);
+      await RatchetService.instance.encryptText(
+        peerId: bobOnion,
+        plaintext: 'msg-$i',
+        local: alice,
+        peer: bobPub,
+        peerBundle: bobBundle,
+      );
+    }
+
+    // At most the awaited fetch plus one background warm are ever in flight
+    // for a peer: repeated bootstraps must not pile up one background fetch
+    // per message.
+    expect(maxConcurrent, lessThanOrEqualTo(2));
+  });
+
+  test('cached peer scheme bootstraps a v3 session without a fetch', () async {
+    final alice = await IdentityKeyPair.generate();
+    final bob = await IdentityKeyPair.generate();
+    final alicePub = await _publicKeys(alice);
+    final bobPub = await _publicKeys(bob);
+    const aliceOnion = 'alice.peer.onion';
+    const bobOnion = 'bob.peer.onion';
+
+    final bobBundle = await PrekeyBundle.generate(bob, persist: true);
+
+    // Warm cache: a profile fetch has already recorded the peer's scheme.
+    // Any fetch now would be a regression, so the seam is armed to fail
+    // loudly if the send path consults it.
+    await DBHelper.ensureUserExist(bobOnion);
+    await DBHelper.updateUserFields(bobOnion, {
+      'ratchetScheme': CryptoConstants.schemeRatchet3,
+    });
+    RatchetService.instance.setPeerRatchetSchemeFetcherForTest(
+      (_) async => throw StateError('scheme fetch must not run on cache hit'),
+    );
+
+    final wire = await RatchetService.instance.encryptText(
+      peerId: bobOnion,
+      plaintext: 'hello v3',
+      local: alice,
+      peer: bobPub,
+      peerBundle: bobBundle,
+    );
+
+    final envelope = jsonDecode(wire) as Map<String, dynamic>;
+    expect(envelope['scheme'], CryptoConstants.schemeRatchet3);
+
+    final plain = await RatchetService.instance.decryptText(
+      peerId: aliceOnion,
+      wire: wire,
+      local: bob,
+      peer: alicePub,
+    );
+    expect(plain, 'hello v3');
+
+    final session = await RatchetSessionStore(await DBHelper.database)
+        .load(bobOnion);
+    expect(session!.version, 3);
   });
 
   test('second ratchet message without handshake', () async {

--- a/test/crypto/ratchet_interop_test.dart
+++ b/test/crypto/ratchet_interop_test.dart
@@ -39,6 +39,20 @@ void main() {
         version: 1,
         onCreate: (db, _) async {
           await RatchetSessionStore.ensureTable(db);
+          // Mirrors DBHelper._createDB so the send path can consult the
+          // persisted per-peer ratchet-scheme cache (users.ratchetScheme).
+          await db.execute('''
+            CREATE TABLE users (
+              id TEXT PRIMARY KEY,
+              name TEXT,
+              avatarUrl TEXT,
+              avatarBase64 TEXT,
+              customName TEXT,
+              publicKeyPem TEXT,
+              identityJson TEXT,
+              ratchetScheme TEXT
+            )
+          ''');
         },
       ),
     );
@@ -97,9 +111,13 @@ void main() {
 
       final bobBundle = await PrekeyBundle.generate(bob, persist: true);
 
-      RatchetService.instance.setPeerRatchetSchemeFetcherForTest(
-        (_) async => CryptoConstants.schemeRatchet3,
-      );
+      // The profile fetch has already recorded ratchet-3 on the users row
+      // (ContactAddService / PeerIdentityResolver / chat refresh all do
+      // this); the send path must negotiate v3 from that cache.
+      await DBHelper.ensureUserExist(bobOnion);
+      await DBHelper.updateUserFields(bobOnion, {
+        'ratchetScheme': CryptoConstants.schemeRatchet3,
+      });
 
       final wire = await RatchetService.instance.encryptText(
         peerId: bobOnion,

--- a/test/crypto/ratchet_interop_test.dart
+++ b/test/crypto/ratchet_interop_test.dart
@@ -31,9 +31,11 @@ void main() {
     CryptoKeyStore.setUseInMemoryStorageOnly(false);
   });
 
+  late Database db;
+
   setUp(() async {
     CryptoKeyStore.resetInMemoryStorageForTest();
-    final db = await databaseFactory.openDatabase(
+    db = await databaseFactory.openDatabase(
       inMemoryDatabasePath,
       options: OpenDatabaseOptions(
         version: 1,
@@ -61,8 +63,13 @@ void main() {
     RatchetService.instance.setPeerRatchetSchemeFetcherForTest(null);
   });
 
-  tearDown(() {
+  tearDown(() async {
     RatchetService.instance.setPeerRatchetSchemeFetcherForTest(null);
+    // Close the database: sqflite_common_ffi caches inMemoryDatabasePath
+    // (singleInstance is the default), so without a close the next setUp's
+    // openDatabase returns THIS database and earlier tests' users rows
+    // (including ratchetScheme) leak into the next test's "cold" cache.
+    await db.close();
     DBHelper.setDatabaseForTest(null);
   });
 

--- a/test/peer_identity_resolver_test.dart
+++ b/test/peer_identity_resolver_test.dart
@@ -20,7 +20,8 @@ Future<Database> _openDbHelperDb() async {
       avatarBase64 TEXT,
       customName TEXT,
       publicKeyPem TEXT,
-      identityJson TEXT
+      identityJson TEXT,
+      ratchetScheme TEXT
     )
   ''');
   return db;

--- a/test/peer_identity_resolver_test.dart
+++ b/test/peer_identity_resolver_test.dart
@@ -157,5 +157,39 @@ void main() {
                 await peerKeyPair.toPublicJson()));
       },
     );
+
+    test(
+      'a non-string ratchetScheme in the profile is ignored without '
+      'breaking identity resolution',
+      () async {
+        TorRuntimeGate.resetForTest(lifecycle: TorLifecycleState.ready);
+
+        final peerKeyPair = await IdentityKeyPair.generate();
+        final peerIdentityJson = jsonEncode(await peerKeyPair.toPublicJson());
+
+        final injectedResolver = PeerIdentityResolver(
+          peerId: peerId,
+          keyManager: keyManager,
+          fetchProfile: (_) async => jsonEncode({
+            'identityJson': peerIdentityJson,
+            // Peer-controlled JSON must not be trusted to carry a string: a
+            // numeric scheme used to throw a TypeError that aborted the
+            // whole fetch, so the identity below was never applied.
+            'ratchetScheme': 42,
+          }),
+          fetchPublic: (_) async =>
+              throw StateError('fallback must not be needed'),
+        );
+
+        final resolved = await injectedResolver.fetchOverTor();
+
+        // The identity is still resolved and persisted...
+        expect(resolved, isNotNull);
+        final row = await DBHelper.getUserById(peerId);
+        expect(row?['identityJson'], peerIdentityJson);
+        // ...and the non-string scheme is ignored, not stored.
+        expect(row?['ratchetScheme'], isNull);
+      },
+    );
   });
 }

--- a/test/security/chat_db_v10_v11_upgrade_test.dart
+++ b/test/security/chat_db_v10_v11_upgrade_test.dart
@@ -13,7 +13,7 @@
 // Like test/security/database_cipher_test.dart, this builds a real on-disk
 // database in a fresh temp directory and drives DBHelper's actual open path:
 // plaintext v10/v11 fixture -> DatabaseCipher.prepare (in-place encryption)
-// -> openDatabase(version: 14, onUpgrade) -> real GroupSenderIndexStore
+// -> openDatabase(version: 15, onUpgrade) -> real GroupSenderIndexStore
 // calls.
 import 'dart:io';
 
@@ -263,14 +263,14 @@ void main() {
       expect(File(path).existsSync(), isTrue);
 
       // The real open path: DatabaseCipher.prepare encrypts the plaintext
-      // fixture in place, then openDatabase(version: 14, onUpgrade) runs the
+      // fixture in place, then openDatabase(version: 15, onUpgrade) runs the
       // oldVersion < 11 and oldVersion < 13 steps that create
       // group_inbound_seen and group_inbound_floor. The handle is closed by
       // DBHelper.closeForWipe() in tearDown.
       final db = await DBHelper.database;
 
       final uv = await db.rawQuery('PRAGMA user_version');
-      expect(uv.first.values.single, 14);
+      expect(uv.first.values.single, 15);
 
       final inbound = await db.rawQuery(
         "SELECT name FROM sqlite_master WHERE type = 'table' "
@@ -366,7 +366,7 @@ void main() {
       final db = await DBHelper.database;
 
       final uv = await db.rawQuery('PRAGMA user_version');
-      expect(uv.first.values.single, 14);
+      expect(uv.first.values.single, 15);
 
       final cols = await db.rawQuery('PRAGMA table_info(group_inbound_seen)');
       final colNames = cols.map((c) => c['name']).toSet();

--- a/test/security/chat_db_v10_v11_upgrade_test.dart
+++ b/test/security/chat_db_v10_v11_upgrade_test.dart
@@ -271,6 +271,14 @@ void main() {
 
       final uv = await db.rawQuery('PRAGMA user_version');
       expect(uv.first.values.single, 15);
+      // The v15 step must add the users.ratchetScheme cache column, not
+      // just bump the version: a step that skipped the ALTER would pass a
+      // version-only assertion.
+      final usersCols = await db.rawQuery('PRAGMA table_info(users)');
+      expect(
+        usersCols.map((c) => c['name']),
+        contains('ratchetScheme'),
+      );
 
       final inbound = await db.rawQuery(
         "SELECT name FROM sqlite_master WHERE type = 'table' "
@@ -367,6 +375,14 @@ void main() {
 
       final uv = await db.rawQuery('PRAGMA user_version');
       expect(uv.first.values.single, 15);
+      // The v15 step must add the users.ratchetScheme cache column, not
+      // just bump the version: a step that skipped the ALTER would pass a
+      // version-only assertion.
+      final usersCols = await db.rawQuery('PRAGMA table_info(users)');
+      expect(
+        usersCols.map((c) => c['name']),
+        contains('ratchetScheme'),
+      );
 
       final cols = await db.rawQuery('PRAGMA table_info(group_inbound_seen)');
       final colNames = cols.map((c) => c['name']).toSet();

--- a/test/security/chat_db_v13_v14_upgrade_test.dart
+++ b/test/security/chat_db_v13_v14_upgrade_test.dart
@@ -4,12 +4,13 @@
 // for invites from senders whose identity is not local yet). Before the
 // v14 bump the table was only created from onCreate and from the
 // oldVersion < 7 step, so an install at version 13 would throw "no such
-// table: group_pending_invites" on the first hold.
+// table: group_pending_invites" on the first hold. The v15 bump (the
+// users.ratchetScheme send-path cache) rides the same upgrade path.
 //
 // Like test/security/database_cipher_test.dart, this builds a real on-disk
 // database in a fresh temp directory and drives DBHelper's actual open path:
 // plaintext v13 fixture -> DatabaseCipher.prepare (in-place encryption)
-// -> openDatabase(version: 14, onUpgrade) -> real GroupPendingInviteStore
+// -> openDatabase(version: 15, onUpgrade) -> real GroupPendingInviteStore
 // calls.
 import 'dart:io';
 
@@ -171,25 +172,32 @@ void main() {
     }
   }
 
-  test('v13 -> v14 adds group_pending_invites and keeps existing rows',
-      () async {
+  test('v13 -> v15 adds group_pending_invites and ratchetScheme, keeping '
+      'existing rows', () async {
     final path = '${tempDir.path}/prysm/chat_app.db';
     await buildV13Fixture(path);
     expect(File(path).existsSync(), isTrue);
 
     // The real open path: DatabaseCipher.prepare encrypts the plaintext
-    // fixture in place, then openDatabase(version: 14, onUpgrade) runs the
-    // oldVersion < 14 step that creates group_pending_invites. The handle
-    // is closed by DBHelper.closeForWipe() in tearDown.
+    // fixture in place, then openDatabase(version: 15, onUpgrade) runs the
+    // oldVersion < 14 step that creates group_pending_invites and the
+    // oldVersion < 15 step that adds users.ratchetScheme. The handle is
+    // closed by DBHelper.closeForWipe() in tearDown.
     final db = await DBHelper.database;
 
-    expect(Sqflite.firstIntValue(await db.rawQuery('PRAGMA user_version')), 14);
+    expect(Sqflite.firstIntValue(await db.rawQuery('PRAGMA user_version')), 15);
     expect(
       await db.rawQuery(
         "SELECT name FROM sqlite_master WHERE type='table' AND name=?",
         ['group_pending_invites'],
       ),
       hasLength(1),
+    );
+    // The v15 step adds the ratchet-scheme cache column to users.
+    final usersCols = await db.rawQuery('PRAGMA table_info(users)');
+    expect(
+      usersCols.map((c) => c['name']),
+      contains('ratchetScheme'),
     );
     // The upgrade is not allowed to lose what was already there.
     expect(await db.query('users'), hasLength(1));

--- a/test/security/chat_db_v13_v14_upgrade_test.dart
+++ b/test/security/chat_db_v13_v14_upgrade_test.dart
@@ -199,8 +199,15 @@ void main() {
       usersCols.map((c) => c['name']),
       contains('ratchetScheme'),
     );
-    // The upgrade is not allowed to lose what was already there.
-    expect(await db.query('users'), hasLength(1));
+    // The upgrade is not allowed to lose what was already there. hasLength
+    // alone would pass a migration that deleted local-user and inserted a
+    // different row: assert the preserved identity, and that the fresh
+    // column stays null for pre-existing rows.
+    final users = await db.query('users');
+    expect(users, hasLength(1));
+    expect(users.single['id'], 'local-user');
+    expect(users.single['name'], 'Local');
+    expect(users.single['ratchetScheme'], isNull);
     expect(
       (await db.query('group_sender_index')).single['nextIndex'],
       7,


### PR DESCRIPTION
## Problem

`RatchetService.encryptBytes` runs inside the per-peer ratchet lock. When no session exists yet
(the first message to a peer) it awaited `TransportProvider.getProfileOrFallback` — `timeout: 20s`,
`maxAttempts: 3`, each failed attempt able to force a global `SIGNAL NEWNYM` — purely to read an
optional `ratchetScheme` hint. On any error the result is discarded, so the cost was mandatory and
the value was not.

Measured latency passthrough, first send vs stubbed fetch delay:

| fetch delay | 0 ms | 250 ms | 1000 ms | 3000 ms |
|---|---|---|---|---|
| send latency | 17 ms | 255 ms | 1006 ms | 3005 ms |

Introduced in v0.6.4; the code is absent from v0.6.3.

## Change

- Persist the peer's scheme on the `users` row (`chat_app.db` v14 -> v15), warmed by the profile
  fetches the app already performs (contact add, peer identity resolution, chat profile refresh,
  inbound sender refresh).
- The send path reads that cache. A cold cache makes a **single** bounded attempt (3s, no circuit
  refresh) and falls back to the v2 initializer, re-warming in the background.
- The bound is enforced on the await itself, not only passed to the transport, because the device
  log shows Tor futures that never complete.

Ratchet v3 is a real forward-secrecy improvement over v2, so the cold path still attempts the
fetch rather than downgrading silently. The downgrade fallback itself predates this change.

## Verification

- `flutter analyze` clean; full suite green on this branch.
- Warm cache **12 ms**, still negotiates v3. Cold cache against a profile that never answers
  **3031 ms**, bounded (previously 3 x 20s plus a forced circuit reset).
- Migration exercised on a real SQLCipher database in the running Linux app: `user_version = 15`,
  `users.ratchetScheme` present.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for discovering and caching peers’ ratchet schemes.
  * Improved session setup with cached negotiation, bounded profile refreshes, and fallback compatibility.
  * Preserved advertised ratchet schemes during contact and profile updates.

* **Bug Fixes**
  * Prevented repeated or unbounded profile requests when scheme discovery fails.
  * Retained existing cached schemes when updated profiles omit this information.

* **Improvements**
  * Added a database upgrade to store cached ratchet scheme information.
  * Expanded coverage for negotiation, fallback, caching, and database migration scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->