### PR TITLE
fix(tor): stop offline peers from degrading healthy ones

### DIFF
--- a/lib/services/wake_hint_service.dart
+++ b/lib/services/wake_hint_service.dart
@@ -105,6 +105,11 @@ class WakeHintService {
           .take(BatterySaverPolicy.wakeHintMaxPeers)
           .map((e) => e.key)
           .where((id) => id != userId)
+          // Don't wake peers the connection manager is already throttling:
+          // each hint to a dead peer burns a full HTTP timeout.
+          .where(
+            (id) => !TransportProvider.instance.wsManager.isPeerUnreachable(id),
+          )
           .toSet();
     } catch (_) {
       return;
@@ -152,6 +157,9 @@ class WakeHintService {
     _lastReceivedFromPeer[senderId] = DateTime.now();
 
     if (TransportProvider.isConfigured) {
+      // The sender proved reachability with an authenticated hint: lift any
+      // backoff/quarantine so the flush connect is not rate-limited.
+      TransportProvider.instance.wsManager.clearPeerFailureState(senderId);
       unawaited(
         TransportProvider.instance.wsManager
             .ensureConnected(senderId)

--- a/lib/services/wake_hint_service.dart
+++ b/lib/services/wake_hint_service.dart
@@ -102,14 +102,16 @@ class WakeHintService {
       final recent = timestamps.entries.toList()
         ..sort((a, b) => b.value.compareTo(a.value));
       peers = recent
-          .take(BatterySaverPolicy.wakeHintMaxPeers)
           .map((e) => e.key)
           .where((id) => id != userId)
           // Don't wake peers the connection manager is already throttling:
-          // each hint to a dead peer burns a full HTTP timeout.
+          // each hint to a dead peer burns a full HTTP timeout. The cap is
+          // applied after filtering so unreachable peers never consume a slot
+          // in the top-N window.
           .where(
             (id) => !TransportProvider.instance.wsManager.isPeerUnreachable(id),
           )
+          .take(BatterySaverPolicy.wakeHintMaxPeers)
           .toSet();
     } catch (_) {
       return;

--- a/lib/services/ws_connection_manager.dart
+++ b/lib/services/ws_connection_manager.dart
@@ -19,6 +19,13 @@ import 'package:prysm/util/tor_delivery.dart';
 import 'package:prysm/util/tor_runtime_gate.dart';
 import 'package:prysm/util/tor_service.dart';
 
+/// Thrown by [WsConnectionManager.ensureConnected] when the peer is already in
+/// reconnect backoff. The attempt never reached the wire, so it is not a fresh
+/// connect failure: callers must not record it or re-arm the backoff window.
+class PeerInBackoffError extends StateError {
+  PeerInBackoffError() : super('Peer reconnect backoff active');
+}
+
 /// Maintains one full-duplex WebSocket link per peer (dialer or acceptor).
 class WsConnectionManager {
   WsConnectionManager(this._torManager);
@@ -29,12 +36,27 @@ class WsConnectionManager {
   static const Duration _maxReconnectBackoff = Duration(minutes: 2);
   static const int _maxPingFailures = 3;
 
+  /// Consecutive real dial failures after which a peer is quarantined: its
+  /// retry cadence drops from the ~2 min backoff cap to
+  /// [hostUnreachableQuarantine] until it proves reachable again (inbound
+  /// contact, authenticated wake hint, or explicit user action).
+  ///
+  /// A failure counts when it falls in the dial path's own retry taxonomy
+  /// ([TorDelivery.isRetryableError]) — `hostUnreachable` SOCKS replies,
+  /// connect timeouts, and the other peer-reachability failures the device
+  /// log shows for dead peers. Local state errors (no local onion, Tor
+  /// stopped) never count.
+  static const int hostUnreachableQuarantineThreshold = 10;
+  static const Duration hostUnreachableQuarantine = Duration(minutes: 10);
+
   final TorManager _torManager;
   final Map<String, WsPeerLink> _links = {};
   final Map<String, Future<void>> _connectChains = {};
   final Map<String, Future<void>> _requestChains = {};
   final Map<String, int> _requestQueueDepthByPeer = {};
   final Map<String, int> _connectFailures = {};
+  final Map<String, int> _hostUnreachableStreak = {};
+  final Map<String, DateTime> _quarantineUntil = {};
   final Map<String, int> _pingFailures = {};
   final Map<String, DateTime> _lastSuccessByPeer = {};
   final Map<String, DateTime> _nextRetryAfter = {};
@@ -77,7 +99,12 @@ class WsConnectionManager {
     return link.onPushFrames;
   }
 
-  void pinPeer(String peerOnion) => _pinnedPeers.add(peerOnion);
+  void pinPeer(String peerOnion) {
+    // Opening a chat, calling, or transferring is an explicit user action:
+    // lift any backoff/quarantine so the fresh attempt is not rate-limited.
+    clearPeerFailureState(peerOnion);
+    _pinnedPeers.add(peerOnion);
+  }
 
   void unpinPeer(String peerOnion) => _pinnedPeers.remove(peerOnion);
 
@@ -190,8 +217,11 @@ class WsConnectionManager {
         await ensureConnected(peer);
         _connectFailures.remove(peer);
         _nextRetryAfter.remove(peer);
-      } catch (_) {
-        _recordConnectFailure(peer);
+      } catch (e) {
+        // A fast-fail because the peer is already in backoff never reached
+        // the wire: it must not count as a fresh failure or re-arm the window.
+        if (e is PeerInBackoffError) continue;
+        _recordConnectFailure(peer, e);
       }
     }
 
@@ -209,7 +239,7 @@ class WsConnectionManager {
     return DateTime.now().isBefore(retryAfter);
   }
 
-  void _recordConnectFailure(String peerOnion) {
+  void _recordConnectFailure(String peerOnion, Object error) {
     final failures = (_connectFailures[peerOnion] ?? 0) + 1;
     _connectFailures[peerOnion] = failures;
 
@@ -218,11 +248,83 @@ class WsConnectionManager {
       seconds: backoffSeconds.clamp(1, _maxReconnectBackoff.inSeconds),
     );
     _nextRetryAfter[peerOnion] = DateTime.now().add(backoff);
+
+    if (_isPeerUnreachableError(error)) {
+      final streak = (_hostUnreachableStreak[peerOnion] ?? 0) + 1;
+      _hostUnreachableStreak[peerOnion] = streak;
+      if (streak >= hostUnreachableQuarantineThreshold &&
+          !_isQuarantined(peerOnion)) {
+        // Overrides the regular backoff with the longer quarantine window.
+        _enterQuarantine(peerOnion);
+      }
+    } else {
+      // A local or protocol failure (no local onion, Tor stopped) breaks the
+      // peer-unreachable streak.
+      _hostUnreachableStreak.remove(peerOnion);
+    }
+  }
+
+  /// True when [error] indicates the peer did not answer a real dial attempt
+  /// — the peer-reachability class the dial path itself retries
+  /// ([TorDelivery.isRetryableError]). A local state error (e.g. no local
+  /// onion address) is not the peer's fault and never counts.
+  bool _isPeerUnreachableError(Object error) =>
+      TorDelivery.isRetryableError(error);
+
+  bool _isQuarantined(String peerOnion) {
+    final until = _quarantineUntil[peerOnion];
+    if (until == null) return false;
+    if (DateTime.now().isBefore(until)) return true;
+    _quarantineUntil.remove(peerOnion);
+    return false;
+  }
+
+  void _enterQuarantine(String peerOnion) {
+    final until = DateTime.now().add(hostUnreachableQuarantine);
+    _quarantineUntil[peerOnion] = until;
+    _nextRetryAfter[peerOnion] = until;
+    Logging.debug(
+      'Quarantining ${Logging.redactOnion(peerOnion)} after '
+      '$hostUnreachableQuarantineThreshold consecutive unreachable dial failures',
+      'WsConnectionManager',
+    );
+  }
+
+  /// Minimum remaining backoff window before a peer counts as genuinely,
+  /// repeatedly unreachable for wake-hint suppression. The backoff ladder
+  /// (1, 2, 4, 8, 16, 32 s, then the 120 s cap) only reaches this at the
+  /// seventh consecutive failure, so a single transient blip never silences
+  /// hints, while a peer in the capped dead-peer regime — and the 10-minute
+  /// quarantine, which is a 10-minute window — is left alone.
+  static const Duration _wakeHintUnreachableMinBackoff = Duration(seconds: 60);
+
+  /// True when [peerOnion] is in reconnect backoff with a window long enough
+  /// to indicate sustained, repeated unreachability — wake hints to such peers
+  /// only feed the failure storm. A single transient failure (short window)
+  /// must not suppress hints: the hint is the nudge that wakes a sleeping
+  /// peer.
+  bool isPeerUnreachable(String peerOnion) {
+    final retryAfter = _nextRetryAfter[peerOnion];
+    if (retryAfter == null) return false;
+    return retryAfter.difference(DateTime.now()) >=
+        _wakeHintUnreachableMinBackoff;
+  }
+
+  /// Resets throttling state for [peerOnion] because it proved reachable
+  /// (inbound contact, authenticated wake hint) or the user explicitly
+  /// engaged with it, so the next connect attempt is not rate-limited.
+  void clearPeerFailureState(String peerOnion) {
+    _connectFailures.remove(peerOnion);
+    _nextRetryAfter.remove(peerOnion);
+    _hostUnreachableStreak.remove(peerOnion);
+    _quarantineUntil.remove(peerOnion);
   }
 
   void prepareForTorReconnect() {
     _connectFailures.clear();
     _nextRetryAfter.clear();
+    _hostUnreachableStreak.clear();
+    _quarantineUntil.clear();
     _localOnion = null;
     for (final peer in _links.keys.toList()) {
       unawaited(_removeLink(peer));
@@ -266,8 +368,11 @@ class WsConnectionManager {
     if (_links[peerOnion]?.isConnected == true) {
       return Future<void>.value();
     }
-    if (connectBudget == null && _isInBackoff(peerOnion)) {
-      return Future.error(StateError('Peer reconnect backoff active'));
+    if (_isInBackoff(peerOnion)) {
+      // Respect backoff on every path: a user-initiated connect against a
+      // throttled peer fails fast so callers fall back to the HTTP path
+      // instead of blocking the UI for the interactive connect budget.
+      return Future.error(PeerInBackoffError());
     }
 
     final prev = _connectChains[peerOnion] ?? Future<void>.value();
@@ -449,6 +554,8 @@ class WsConnectionManager {
     PeerTransportRegistry.instance.markWebSocket(peerOnion);
     _connectFailures.remove(peerOnion);
     _nextRetryAfter.remove(peerOnion);
+    _hostUnreachableStreak.remove(peerOnion);
+    _quarantineUntil.remove(peerOnion);
     _pingFailures.remove(peerOnion);
     _lastSuccessByPeer[peerOnion] = DateTime.now();
 
@@ -654,6 +761,19 @@ class WsConnectionManager {
     bool outbound = false,
   }) {
     _registerLink(peerOnion, link, outbound: outbound);
+  }
+
+  @visibleForTesting
+  void recordConnectFailureForTest(String peerOnion, Object error) {
+    _recordConnectFailure(peerOnion, error);
+  }
+
+  @visibleForTesting
+  Duration? retryDelayForTest(String peerOnion) {
+    final retryAfter = _nextRetryAfter[peerOnion];
+    if (retryAfter == null) return null;
+    final remaining = retryAfter.difference(DateTime.now());
+    return remaining.isNegative ? Duration.zero : remaining;
   }
 
   void dispose() {

--- a/lib/services/ws_connection_manager.dart
+++ b/lib/services/ws_connection_manager.dart
@@ -28,7 +28,8 @@ class PeerInBackoffError extends StateError {
 
 /// Maintains one full-duplex WebSocket link per peer (dialer or acceptor).
 class WsConnectionManager {
-  WsConnectionManager(this._torManager);
+  WsConnectionManager(this._torManager, {DateTime Function()? now})
+      : _now = now ?? DateTime.now;
 
   static const Duration interactiveConnectBudget = Duration(seconds: 25);
 
@@ -50,6 +51,7 @@ class WsConnectionManager {
   static const Duration hostUnreachableQuarantine = Duration(minutes: 10);
 
   final TorManager _torManager;
+  final DateTime Function() _now;
   final Map<String, WsPeerLink> _links = {};
   final Map<String, Future<void>> _connectChains = {};
   final Map<String, Future<void>> _requestChains = {};
@@ -217,6 +219,9 @@ class WsConnectionManager {
         await ensureConnected(peer);
         _connectFailures.remove(peer);
         _nextRetryAfter.remove(peer);
+        // A successful connect proves the peer reachable: lift the quarantine
+        // alongside the retry bookkeeping.
+        _quarantineUntil.remove(peer);
       } catch (e) {
         // A fast-fail because the peer is already in backoff never reached
         // the wire: it must not count as a fresh failure or re-arm the window.
@@ -234,9 +239,12 @@ class WsConnectionManager {
   }
 
   bool _isInBackoff(String peerOnion) {
+    // The quarantine is authoritative: while it is active the peer is gated
+    // even if the retry bookkeeping was cleared (e.g. by [stop]).
+    if (_isQuarantined(peerOnion)) return true;
     final retryAfter = _nextRetryAfter[peerOnion];
     if (retryAfter == null) return false;
-    return DateTime.now().isBefore(retryAfter);
+    return _now().isBefore(retryAfter);
   }
 
   void _recordConnectFailure(String peerOnion, Object error) {
@@ -247,7 +255,7 @@ class WsConnectionManager {
     final backoff = Duration(
       seconds: backoffSeconds.clamp(1, _maxReconnectBackoff.inSeconds),
     );
-    _nextRetryAfter[peerOnion] = DateTime.now().add(backoff);
+    _nextRetryAfter[peerOnion] = _now().add(backoff);
 
     if (_isPeerUnreachableError(error)) {
       final streak = (_hostUnreachableStreak[peerOnion] ?? 0) + 1;
@@ -274,13 +282,13 @@ class WsConnectionManager {
   bool _isQuarantined(String peerOnion) {
     final until = _quarantineUntil[peerOnion];
     if (until == null) return false;
-    if (DateTime.now().isBefore(until)) return true;
+    if (_now().isBefore(until)) return true;
     _quarantineUntil.remove(peerOnion);
     return false;
   }
 
   void _enterQuarantine(String peerOnion) {
-    final until = DateTime.now().add(hostUnreachableQuarantine);
+    final until = _now().add(hostUnreachableQuarantine);
     _quarantineUntil[peerOnion] = until;
     _nextRetryAfter[peerOnion] = until;
     Logging.debug(
@@ -304,10 +312,13 @@ class WsConnectionManager {
   /// must not suppress hints: the hint is the nudge that wakes a sleeping
   /// peer.
   bool isPeerUnreachable(String peerOnion) {
+    // The quarantine gates hints for its whole window, including the final
+    // minute where the retry bookkeeping's remaining window has already
+    // fallen below [_wakeHintUnreachableMinBackoff].
+    if (_isQuarantined(peerOnion)) return true;
     final retryAfter = _nextRetryAfter[peerOnion];
     if (retryAfter == null) return false;
-    return retryAfter.difference(DateTime.now()) >=
-        _wakeHintUnreachableMinBackoff;
+    return retryAfter.difference(_now()) >= _wakeHintUnreachableMinBackoff;
   }
 
   /// Resets throttling state for [peerOnion] because it proved reachable
@@ -772,7 +783,7 @@ class WsConnectionManager {
   Duration? retryDelayForTest(String peerOnion) {
     final retryAfter = _nextRetryAfter[peerOnion];
     if (retryAfter == null) return null;
-    final remaining = retryAfter.difference(DateTime.now());
+    final remaining = retryAfter.difference(_now());
     return remaining.isNegative ? Duration.zero : remaining;
   }
 

--- a/lib/util/tor_delivery.dart
+++ b/lib/util/tor_delivery.dart
@@ -50,16 +50,13 @@ class TorDelivery {
   static bool isCircuitError(Object error) {
     if (error is HttpException) return true;
     final message = _errorText(error);
-    return message.contains('hostunreachable') ||
-        message.contains('networkunreachable') ||
-        message.contains('ttlexpired') ||
+    return message.contains('ttlexpired') ||
         message.contains('connection closed while receiving') ||
         message.contains('general socks server failure');
   }
 
   static Future<void> _maybeRefreshCircuit({
     required bool circuitError,
-    bool force = false,
   }) async {
     final manager = _torManager;
     if (manager == null) return;
@@ -67,8 +64,7 @@ class TorDelivery {
     final now = DateTime.now();
     final minInterval =
         circuitError ? _circuitNewnymMinInterval : _newnymMinInterval;
-    if (!force &&
-        _lastNewnymAt != null &&
+    if (_lastNewnymAt != null &&
         now.difference(_lastNewnymAt!) < minInterval) {
       return;
     }
@@ -115,7 +111,7 @@ class TorDelivery {
         }
         final circuit = isCircuitError(e);
         if (circuit) {
-          await _maybeRefreshCircuit(circuitError: true, force: i == 0);
+          await _maybeRefreshCircuit(circuitError: true);
         }
         final delay = _retryDelays[min(i, _retryDelays.length - 1)];
         await Future.delayed(delay);

--- a/test/tor_delivery_test.dart
+++ b/test/tor_delivery_test.dart
@@ -5,6 +5,23 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:prysm/util/tor_delivery.dart';
 import 'package:prysm/util/tor_service.dart';
 
+class _CountingTorManager extends TorManager {
+  _CountingTorManager()
+      : super(
+          torPath: '/bin/false',
+          dataDir: '/tmp/tor-delivery-counting',
+          controlPassword: 'test-password',
+        );
+
+  int refreshCount = 0;
+
+  @override
+  Future<bool> refreshCircuit() async {
+    refreshCount++;
+    return true;
+  }
+}
+
 void main() {
   setUp(TorDelivery.resetForTest);
 
@@ -29,7 +46,7 @@ void main() {
       expect(TorDelivery.isCircuitError(error), isTrue);
     });
 
-    test('treats hostUnreachable as retryable circuit error', () {
+    test('treats hostUnreachable as retryable but not a circuit error', () {
       expect(
         TorDelivery.isRetryableError(
           Exception(
@@ -44,7 +61,7 @@ void main() {
             'SocksClientConnectionCommandFailedException: hostUnreachable',
           ),
         ),
-        isTrue,
+        isFalse,
       );
     });
 
@@ -112,6 +129,62 @@ void main() {
         },
       );
       expect(attempts, 2);
+    });
+
+    test('repeated hostUnreachable failures never refresh the circuit', () async {
+      final manager = _CountingTorManager();
+      TorDelivery.configure(manager);
+
+      await expectLater(
+        TorDelivery.withTorRetry<void>(
+          attempt: () async => throw Exception(
+            'SocksClientConnectionCommandFailedException: hostUnreachable',
+          ),
+        ),
+        throwsA(isA<Exception>()),
+      );
+      expect(manager.refreshCount, 0);
+    });
+
+    test('genuine circuit error still refreshes the circuit', () async {
+      final manager = _CountingTorManager();
+      TorDelivery.configure(manager);
+
+      var attempts = 0;
+      await TorDelivery.withTorRetry<void>(
+        maxAttempts: 2,
+        attempt: () async {
+          attempts++;
+          if (attempts == 1) {
+            throw HttpException(
+              'Connection closed while receiving data',
+              uri: Uri.parse('http://peer.onion/profile'),
+            );
+          }
+        },
+      );
+      expect(attempts, 2);
+      expect(manager.refreshCount, 1);
+    });
+
+    test('circuit refresh still respects the NEWNYM rate limit', () async {
+      final manager = _CountingTorManager();
+      TorDelivery.configure(manager);
+      TorDelivery.setLastNewnymForTest(
+        DateTime.now().subtract(const Duration(seconds: 1)),
+      );
+
+      await expectLater(
+        TorDelivery.withTorRetry<void>(
+          maxAttempts: 2,
+          attempt: () async => throw HttpException(
+            'Connection closed while receiving data',
+            uri: Uri.parse('http://peer.onion/profile'),
+          ),
+        ),
+        throwsA(isA<HttpException>()),
+      );
+      expect(manager.refreshCount, 0);
     });
   });
 }

--- a/test/wake_hint_service_test.dart
+++ b/test/wake_hint_service_test.dart
@@ -270,6 +270,56 @@ void main() {
       ]);
     });
 
+    test(
+        'reachable peers ranked below throttled ones still get hints, capped',
+        () async {
+      await SettingsService().setShowOnlineStatus(true);
+
+      final wsManager = TransportProvider.instance.wsManager;
+      final base = DateTime.now().millisecondsSinceEpoch;
+      // 30 recent peers: the 5 most recent are in the sustained-failure
+      // regime, the 25 ranked below them are healthy. The hint cap must
+      // count only peers that will actually be hinted, so the throttled
+      // top-5 must not consume slots.
+      for (var i = 0; i < 30; i++) {
+        await db.insert('messages', {
+          'id': 'f1-peer-$i',
+          'senderId': 'peer$i.onion',
+          'receiverId': 'me.onion',
+          'message': 'hello',
+          'type': 'text',
+          'timestamp': base + i,
+          'status': 'received',
+        });
+      }
+      for (var i = 25; i < 30; i++) {
+        for (var f = 0; f < 7; f++) {
+          wsManager.recordConnectFailureForTest(
+            'peer$i.onion',
+            Exception(
+              'SocksClientConnectionCommandFailedException: hostUnreachable',
+            ),
+          );
+        }
+      }
+      for (var i = 25; i < 30; i++) {
+        expect(wsManager.isPeerUnreachable('peer$i.onion'), isTrue);
+      }
+
+      await WakeHintService.instance.broadcastRecentPeerHints();
+
+      final hinted = sentHints.map((h) => h['peerOnion']).toSet();
+      // The 20 most recent reachable peers (peer24..peer5) are all hinted and
+      // the cap is respected; none of the throttled top-5 are.
+      expect(hinted.length, BatterySaverPolicy.wakeHintMaxPeers);
+      for (var i = 24; i >= 5; i--) {
+        expect(hinted, contains('peer$i.onion'));
+      }
+      for (var i = 25; i < 30; i++) {
+        expect(hinted, isNot(contains('peer$i.onion')));
+      }
+    });
+
     test('incoming wake hint clears throttling state for that peer', () async {
       final wsManager = TransportProvider.instance.wsManager;
       for (var i = 0;

--- a/test/wake_hint_service_test.dart
+++ b/test/wake_hint_service_test.dart
@@ -4,8 +4,11 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:prysm/database/messages.dart';
 import 'package:prysm/services/settings_service.dart';
 import 'package:prysm/services/wake_hint_service.dart';
+import 'package:prysm/services/ws_connection_manager.dart';
 import 'package:prysm/transport/transport_provider.dart';
 import 'package:prysm/util/battery_saver_policy.dart';
+import 'package:prysm/util/tor_lifecycle_state.dart';
+import 'package:prysm/util/tor_runtime_gate.dart';
 import 'package:prysm/util/tor_service.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:sqflite_common_ffi/sqflite_ffi.dart';
@@ -203,6 +206,97 @@ void main() {
         {'peerOnion': 'peer.onion', 'senderId': 'me.onion'},
       ]);
     });
+
+    test('skips peers with sustained connect failures', () async {
+      await SettingsService().setShowOnlineStatus(true);
+
+      // A single blip must NOT suppress hints; only the sustained dead-peer
+      // regime (capped 120s backoff, i.e. ~7+ consecutive failures) does.
+      for (var i = 0; i < 7; i++) {
+        TransportProvider.instance.wsManager.recordConnectFailureForTest(
+          'peer.onion',
+          Exception(
+            'SocksClientConnectionCommandFailedException: hostUnreachable',
+          ),
+        );
+      }
+      expect(
+        TransportProvider.instance.wsManager.isPeerUnreachable('peer.onion'),
+        isTrue,
+      );
+
+      await WakeHintService.instance.broadcastRecentPeerHints();
+
+      expect(sentHints, isEmpty);
+    });
+
+    test('sends a wake hint after a single transient connect failure',
+        () async {
+      await SettingsService().setShowOnlineStatus(true);
+
+      // Drive ONE real dial failure through the production path — the
+      // maintenance heartbeat dial against a peer whose connection is reset —
+      // then verify the hint still goes out: a single blip must not silence
+      // the nudge that wakes a sleeping peer.
+      final socks = _ClosingSocksServer();
+      await socks.start();
+      addTearDown(socks.close);
+      final dataDir = Directory.systemTemp.createTempSync('ws-hint-onion');
+      Directory('${dataDir.path}/hidden_service').createSync(recursive: true);
+      File('${dataDir.path}/hidden_service/hostname')
+          .writeAsStringSync('me.onion');
+      final tor = TorManager(
+        torPath: '/bin/false',
+        dataDir: dataDir.path,
+        controlPassword: 'test-password',
+        socksPort: socks.port,
+      );
+      TorRuntimeGate.resetForTest();
+      TransportProvider.resetForTest();
+      TransportProvider.configure(tor);
+      final wsManager = TransportProvider.instance.wsManager;
+      wsManager.start();
+      await _waitFor(() => wsManager.retryDelayForTest('peer.onion') != null);
+      TorRuntimeGate.resetForTest(lifecycle: TorLifecycleState.stopped);
+
+      // One failure recorded: the peer is in a 1s backoff, far below the
+      // sustained-unreachable threshold.
+      expect(wsManager.isPeerUnreachable('peer.onion'), isFalse);
+
+      await WakeHintService.instance.broadcastRecentPeerHints();
+
+      expect(sentHints, [
+        {'peerOnion': 'peer.onion', 'senderId': 'me.onion'},
+      ]);
+    });
+
+    test('incoming wake hint clears throttling state for that peer', () async {
+      final wsManager = TransportProvider.instance.wsManager;
+      for (var i = 0;
+          i < WsConnectionManager.hostUnreachableQuarantineThreshold;
+          i++) {
+        wsManager.recordConnectFailureForTest(
+          'peer.onion',
+          Exception(
+            'SocksClientConnectionCommandFailedException: hostUnreachable',
+          ),
+        );
+      }
+      expect(wsManager.isPeerUnreachable('peer.onion'), isTrue);
+
+      // Re-configure with a pending-check seam so handleIncomingHint does not
+      // touch the real pending_messages database.
+      WakeHintService.instance.configure(
+        userId: 'me.onion',
+        onFlushPeer: (_) async => true,
+        hasOutboundPendingForSender: (_) async => false,
+      );
+
+      await WakeHintService.instance.handleIncomingHint('peer.onion');
+
+      expect(wsManager.isPeerUnreachable('peer.onion'), isFalse);
+      expect(wsManager.retryDelayForTest('peer.onion'), isNull);
+    });
   });
 
   test('wake hint policy constants are sensible', () {
@@ -210,4 +304,38 @@ void main() {
     expect(BatterySaverPolicy.wakeHintReceiveDebounce.inSeconds, 30);
     expect(BatterySaverPolicy.wakeHintSendCooldown.inMinutes, 5);
   });
+}
+
+/// Polls [predicate] until it returns true or [timeout] elapses.
+Future<void> _waitFor(
+  bool Function() predicate, {
+  Duration timeout = const Duration(seconds: 30),
+}) async {
+  final deadline = DateTime.now().add(timeout);
+  while (!predicate()) {
+    if (DateTime.now().isAfter(deadline)) {
+      fail('condition not met within $timeout');
+    }
+    await Future<void>.delayed(const Duration(milliseconds: 25));
+  }
+}
+
+/// Accepts and immediately destroys incoming TCP connections: the production
+/// dial path fails with a socket-level error (connection reset), which the
+/// connection manager records as a real dial failure — no SOCKS protocol
+/// needed.
+class _ClosingSocksServer {
+  ServerSocket? _server;
+  int port = 0;
+
+  Future<void> start() async {
+    _server = await ServerSocket.bind(InternetAddress.loopbackIPv4, 0);
+    port = _server!.port;
+    _server!.listen((client) => client.destroy());
+  }
+
+  Future<void> close() async {
+    await _server?.close();
+    _server = null;
+  }
 }

--- a/test/ws_connection_manager_test.dart
+++ b/test/ws_connection_manager_test.dart
@@ -1,13 +1,80 @@
 import 'dart:async';
+import 'dart:convert';
+import 'dart:io';
 
 import 'package:flutter_test/flutter_test.dart';
+import 'package:prysm/client/tor_socks_websocket.dart';
+import 'package:prysm/database/messages.dart';
 import 'package:prysm/services/ws_connection_manager.dart';
 import 'package:prysm/transport/ws_peer_link.dart';
 import 'package:prysm/util/tor_lifecycle_state.dart';
 import 'package:prysm/util/tor_runtime_gate.dart';
 import 'package:prysm/util/tor_service.dart';
+import 'package:sqflite_common_ffi/sqflite_ffi.dart';
+
+Future<Database> _openMessagesDb() async {
+  final db = await databaseFactory.openDatabase(inMemoryDatabasePath);
+  await db.execute('DROP TABLE IF EXISTS messages');
+  await db.execute('''
+    CREATE TABLE messages(
+      id TEXT PRIMARY KEY,
+      senderId TEXT NOT NULL,
+      receiverId TEXT NOT NULL,
+      message TEXT,
+      type TEXT,
+      fileName TEXT,
+      fileSize INTEGER,
+      timestamp INTEGER NOT NULL,
+      status TEXT DEFAULT 'sent',
+      replyTo TEXT,
+      readAt INTEGER,
+      viewOnce INTEGER DEFAULT 0,
+      viewed INTEGER DEFAULT 0,
+      groupId TEXT,
+      deletedAt INTEGER,
+      editedAt INTEGER
+    )
+  ''');
+  return db;
+}
+
+/// Polls [predicate] until it returns true or [timeout] elapses.
+Future<void> _waitFor(
+  bool Function() predicate, {
+  Duration timeout = const Duration(seconds: 30),
+}) async {
+  final deadline = DateTime.now().add(timeout);
+  while (!predicate()) {
+    if (DateTime.now().isAfter(deadline)) {
+      fail('condition not met within $timeout');
+    }
+    await Future<void>.delayed(const Duration(milliseconds: 25));
+  }
+}
+
+/// A [TorManager] whose local onion is already provisioned (hostname file) and
+/// whose SOCKS port points at a local fake server, so the production dial path
+/// runs without a Tor daemon.
+TorManager _torManagerWithOnion({
+  required String dataDir,
+  required int socksPort,
+}) {
+  Directory('$dataDir/hidden_service').createSync(recursive: true);
+  File('$dataDir/hidden_service/hostname').writeAsStringSync('me.onion');
+  return TorManager(
+    torPath: '/bin/false',
+    dataDir: dataDir,
+    controlPassword: 'test-password',
+    socksPort: socksPort,
+  );
+}
 
 void main() {
+  setUpAll(() {
+    sqfliteFfiInit();
+    databaseFactory = databaseFactoryFfi;
+  });
+
   setUp(() {
     TorRuntimeGate.resetForTest();
   });
@@ -77,6 +144,266 @@ void main() {
 
     expect(link.ops, ['first', 'second']);
     manager.dispose();
+  });
+
+  test('interactive connect fails fast while peer is in backoff', () async {
+    final manager = WsConnectionManager(
+      TorManager(torPath: '/bin/false', dataDir: '/tmp/ws-manager-backoff', controlPassword: 'test-password'),
+    );
+    manager.recordConnectFailureForTest(
+      'peer.onion',
+      Exception('SocksClientConnectionCommandFailedException: hostUnreachable'),
+    );
+    // A single failure puts the peer in backoff (fast-fail applies) but is not
+    // enough to count it as genuinely unreachable for wake-hint suppression.
+    expect(manager.retryDelayForTest('peer.onion'), isNotNull);
+    expect(manager.isPeerUnreachable('peer.onion'), isFalse);
+
+    await expectLater(
+      manager.ensureConnected(
+        'peer.onion',
+        connectBudget: WsConnectionManager.interactiveConnectBudget,
+      ),
+      throwsA(
+        isA<StateError>().having(
+          (e) => e.message,
+          'message',
+          contains('backoff'),
+        ),
+      ),
+    );
+
+    manager.dispose();
+  });
+
+  test('quarantine caps retry frequency after repeated hostUnreachable failures',
+      () async {
+    final manager = WsConnectionManager(
+      TorManager(torPath: '/bin/false', dataDir: '/tmp/ws-manager-quarantine', controlPassword: 'test-password'),
+    );
+    for (var i = 0; i < WsConnectionManager.hostUnreachableQuarantineThreshold;
+        i++) {
+      manager.recordConnectFailureForTest(
+        'peer.onion',
+        Exception('SocksClientConnectionCommandFailedException: hostUnreachable'),
+      );
+    }
+
+    // Quarantine pushes the next retry well past the 2-minute backoff cap.
+    final delay = manager.retryDelayForTest('peer.onion');
+    expect(delay, isNotNull);
+    expect(delay!, greaterThan(const Duration(minutes: 2)));
+
+    // An explicit user action clears the quarantine immediately.
+    manager.pinPeer('peer.onion');
+    expect(manager.retryDelayForTest('peer.onion'), isNull);
+    expect(manager.isPeerUnreachable('peer.onion'), isFalse);
+
+    manager.dispose();
+  });
+
+  test('a non-peer-reachability failure breaks the quarantine streak', () async {
+    final manager = WsConnectionManager(
+      TorManager(torPath: '/bin/false', dataDir: '/tmp/ws-manager-quarantine-mixed', controlPassword: 'test-password'),
+    );
+    final hostUnreachable =
+        Exception('SocksClientConnectionCommandFailedException: hostUnreachable');
+    for (var i = 0;
+        i < WsConnectionManager.hostUnreachableQuarantineThreshold - 1;
+        i++) {
+      manager.recordConnectFailureForTest('peer.onion', hostUnreachable);
+    }
+    // A local state error (no local onion) is not the peer's fault: unlike a
+    // retryable dial failure (which includes timeouts), it breaks the streak.
+    manager.recordConnectFailureForTest(
+      'peer.onion',
+      StateError('Local onion address not available'),
+    );
+
+    final delay = manager.retryDelayForTest('peer.onion');
+    expect(delay, isNotNull);
+    expect(delay!, lessThanOrEqualTo(const Duration(minutes: 2)));
+
+    manager.dispose();
+  });
+
+  test('registering an inbound link clears throttling state', () async {
+    final manager = WsConnectionManager(
+      TorManager(torPath: '/bin/false', dataDir: '/tmp/ws-manager-quarantine-inbound', controlPassword: 'test-password'),
+    );
+    for (var i = 0; i < WsConnectionManager.hostUnreachableQuarantineThreshold;
+        i++) {
+      manager.recordConnectFailureForTest(
+        'peer.onion',
+        Exception('SocksClientConnectionCommandFailedException: hostUnreachable'),
+      );
+    }
+    expect(manager.isPeerUnreachable('peer.onion'), isTrue);
+
+    manager.registerLinkForTest('peer.onion', _FakeWsPeerLink('peer.onion'));
+
+    expect(manager.isPeerUnreachable('peer.onion'), isFalse);
+    expect(manager.retryDelayForTest('peer.onion'), isNull);
+
+    manager.dispose();
+  });
+
+  test(
+    'quarantine engages on the production path after repeated real dial failures',
+    () async {
+      final socks = _FakeSocksServer(mode: _FakeSocksMode.close);
+      await socks.start();
+      addTearDown(socks.close);
+      final db = await _openMessagesDb();
+      MessagesDb.setDatabaseForTest(db);
+      addTearDown(() async {
+        await db.close();
+        MessagesDb.setDatabaseForTest(null);
+      });
+      await db.insert('messages', {
+        'id': 'm1',
+        'senderId': 'peer.onion',
+        'receiverId': 'me.onion',
+        'message': 'hello',
+        'type': 'text',
+        'timestamp': DateTime.now().millisecondsSinceEpoch,
+        'status': 'received',
+      });
+
+      final manager = WsConnectionManager(
+        _torManagerWithOnion(
+          dataDir: Directory.systemTemp.createTempSync('ws-manager-q').path,
+          socksPort: socks.port,
+        ),
+      );
+      addTearDown(manager.dispose);
+
+      // The real heartbeat loop dials the peer and records the failure each
+      // cycle. Drive it through the production start()/stop() entry points
+      // (stop() only clears the retry window; the failure counters and the
+      // unreachable streak survive it).
+      manager.start();
+      await _waitFor(() => manager.retryDelayForTest('peer.onion') != null);
+      for (var i = 1;
+          i < WsConnectionManager.hostUnreachableQuarantineThreshold;
+          i++) {
+        manager.stop();
+        manager.start();
+        await _waitFor(() => manager.retryDelayForTest('peer.onion') != null);
+      }
+
+      // The dials fail with a socket-level error (connection reset), not a
+      // `hostUnreachable` SOCKS reply — the shape the device log shows for
+      // dead peers. Ten of those on the production path must still engage the
+      // quarantine: the retry window jumps from the 2-minute cap to 10 minutes.
+      final delay = manager.retryDelayForTest('peer.onion');
+      expect(delay, isNotNull);
+      expect(delay!, greaterThan(const Duration(minutes: 2)));
+
+      // An explicit user action clears the quarantine immediately.
+      manager.pinPeer('peer.onion');
+      expect(manager.retryDelayForTest('peer.onion'), isNull);
+      expect(manager.isPeerUnreachable('peer.onion'), isFalse);
+    },
+    timeout: const Timeout(Duration(minutes: 3)),
+  );
+
+  test('a fast-fail while the peer is in backoff does not extend the window',
+      () async {
+    final socks = _FakeSocksServer(mode: _FakeSocksMode.hostUnreachable);
+    await socks.start();
+    addTearDown(socks.close);
+    final db = await _openMessagesDb();
+    MessagesDb.setDatabaseForTest(db);
+    addTearDown(() async {
+      await db.close();
+      MessagesDb.setDatabaseForTest(null);
+    });
+    await db.insert('messages', {
+      'id': 'm1',
+      'senderId': 'peer.onion',
+      'receiverId': 'me.onion',
+      'message': 'hello',
+      'type': 'text',
+      'timestamp': DateTime.now().millisecondsSinceEpoch,
+      'status': 'received',
+    });
+
+    final manager = WsConnectionManager(
+      _torManagerWithOnion(
+        dataDir: Directory.systemTemp.createTempSync('ws-manager-fastfail').path,
+        socksPort: socks.port,
+      ),
+    );
+    addTearDown(manager.dispose);
+    manager.start();
+    await _waitFor(() => manager.retryDelayForTest('peer.onion') != null);
+
+    // User-initiated connect against the throttled peer still fails fast...
+    await expectLater(
+      manager.ensureConnected(
+        'peer.onion',
+        connectBudget: WsConnectionManager.interactiveConnectBudget,
+      ),
+      throwsA(
+        isA<StateError>().having(
+          (e) => e.message,
+          'message',
+          contains('backoff'),
+        ),
+      ),
+    );
+
+    // ...and must not have been recorded as a fresh failure: the window stays
+    // the original 1s backoff instead of re-arming to 2s.
+    final delay = manager.retryDelayForTest('peer.onion');
+    expect(delay, isNotNull);
+    expect(delay!, lessThan(const Duration(seconds: 2)));
+  });
+
+  test('a peer is re-dialled after its backoff elapses and recovers', () async {
+    final socks = _FakeSocksServer(mode: _FakeSocksMode.hostUnreachable);
+    await socks.start();
+    addTearDown(socks.close);
+    final db = await _openMessagesDb();
+    MessagesDb.setDatabaseForTest(db);
+    addTearDown(() async {
+      await db.close();
+      MessagesDb.setDatabaseForTest(null);
+    });
+    await db.insert('messages', {
+      'id': 'm1',
+      'senderId': 'peer.onion',
+      'receiverId': 'me.onion',
+      'message': 'hello',
+      'type': 'text',
+      'timestamp': DateTime.now().millisecondsSinceEpoch,
+      'status': 'received',
+    });
+
+    final manager = WsConnectionManager(
+      _torManagerWithOnion(
+        dataDir: Directory.systemTemp.createTempSync('ws-manager-recover').path,
+        socksPort: socks.port,
+      ),
+    );
+    addTearDown(manager.dispose);
+    manager.start();
+    await _waitFor(() => manager.retryDelayForTest('peer.onion') != null);
+    expect(socks.dialCount, greaterThanOrEqualTo(1));
+
+    // Let the short backoff elapse, then make the peer reachable: the next
+    // dial must actually happen (not be swallowed by a self-perpetuating
+    // window) and must recover the peer.
+    await Future<void>.delayed(const Duration(milliseconds: 1100));
+    await socks.setMode(_FakeSocksMode.success);
+    manager.warmPeer('peer.onion');
+    await _waitFor(() => manager.isConnected('peer.onion'));
+
+    expect(socks.dialCount, greaterThan(1));
+    expect(manager.isConnected('peer.onion'), isTrue);
+    expect(manager.isPeerUnreachable('peer.onion'), isFalse);
+    expect(manager.retryDelayForTest('peer.onion'), isNull);
   });
 }
 
@@ -161,4 +488,181 @@ class _FakeWsPeerLink implements WsPeerLink {
 
   @override
   Future<void> sendPing() async {}
+}
+
+/// Failure/success mode for [_FakeSocksServer].
+enum _FakeSocksMode {
+  /// Accept then immediately destroy: the dial fails with a socket-level
+  /// error (connection reset), the dominant dead-peer shape in the device log.
+  close,
+
+  /// Answer the SOCKS CONNECT with 0x04 (host unreachable).
+  hostUnreachable,
+
+  /// Complete the SOCKS + WebSocket handshake so the dial succeeds.
+  success,
+}
+
+/// Minimal local SOCKS5/WebSocket server that lets the production dial path
+/// ([TorWebSocketClient.connect]) fail or succeed deterministically without a
+/// Tor daemon. Mirrors the real wire protocol the client speaks.
+class _FakeSocksServer {
+  _FakeSocksServer({this.mode = _FakeSocksMode.hostUnreachable});
+
+  _FakeSocksMode mode;
+  ServerSocket? _server;
+  int dialCount = 0;
+
+  int get port => _server!.port;
+
+  Future<void> start() async {
+    _server = await ServerSocket.bind(InternetAddress.loopbackIPv4, 0);
+    _server!.listen(_handleClient);
+  }
+
+  Future<void> setMode(_FakeSocksMode next) async {
+    mode = next;
+  }
+
+  Future<void> close() async {
+    await _server?.close();
+    _server = null;
+  }
+
+  Future<void> _handleClient(Socket client) async {
+    dialCount++;
+    final currentMode = mode;
+    if (currentMode == _FakeSocksMode.close) {
+      client.destroy();
+      return;
+    }
+    try {
+      final reader = _SocksReader(client);
+      // SOCKS5 greeting: version, nmethods, methods.
+      final greeting = await reader.readN(3);
+      if (greeting[0] != 5) {
+        client.destroy();
+        return;
+      }
+      client.add([5, 0]); // no authentication
+      await client.flush();
+      // SOCKS5 CONNECT request: version, cmd, rsv, atyp, address, port.
+      final header = await reader.readN(4);
+      final atyp = header[3];
+      final addrLen = switch (atyp) {
+        1 => 4,
+        3 => (await reader.readN(1))[0],
+        4 => 16,
+        _ => -1,
+      };
+      if (addrLen < 0) {
+        client.destroy();
+        return;
+      }
+      await reader.readN(addrLen + 2);
+
+      if (currentMode == _FakeSocksMode.hostUnreachable) {
+        // 0x04 = host unreachable: the exact reply a dead peer yields.
+        client.add([5, 4, 0, 1, 0, 0, 0, 0, 0, 0]);
+        await client.flush();
+        client.destroy();
+        return;
+      }
+
+      // success: accept the connection and complete the WebSocket upgrade.
+      client.add([5, 0, 0, 1, 0, 0, 0, 0, 0, 0]);
+      await client.flush();
+      final upgrade = utf8.decode(await reader.readUntil([13, 10, 13, 10]));
+      final key = RegExp(r'Sec-WebSocket-Key:\s*(\S+)', caseSensitive: false)
+          .firstMatch(upgrade)
+          ?.group(1);
+      if (key == null) {
+        client.destroy();
+        return;
+      }
+      client.add(utf8.encode(
+        'HTTP/1.1 101 Switching Protocols\r\n'
+        'Upgrade: websocket\r\n'
+        'Connection: Upgrade\r\n'
+        'Sec-WebSocket-Accept: ${computeWebSocketAccept(key)}\r\n\r\n',
+      ));
+      await client.flush();
+      // Server-side hello completes the client's handshake.
+      final hello = utf8.encode('{"v":1,"op":"hello","payload":{"supports":[]}}');
+      client.add([0x81, hello.length, ...hello]);
+      await client.flush();
+      // Keep the socket open: the client owns it from here.
+    } catch (_) {
+      client.destroy();
+    }
+  }
+}
+
+/// Incremental reader over a socket's byte stream.
+class _SocksReader {
+  _SocksReader(Socket socket) {
+    socket.listen(
+      (chunk) {
+        _buffer.addAll(chunk);
+        _wakeUp();
+      },
+      onDone: () {
+        _closed = true;
+        _wakeUp();
+      },
+      onError: (_) {
+        _closed = true;
+        _wakeUp();
+      },
+    );
+  }
+
+  final List<int> _buffer = [];
+  final List<Completer<void>> _wake = [];
+  bool _closed = false;
+
+  void _wakeUp() {
+    for (final c in _wake) {
+      if (!c.isCompleted) c.complete();
+    }
+    _wake.clear();
+  }
+
+  Future<void> _changed() async {
+    if (_buffer.isNotEmpty || _closed) return;
+    final c = Completer<void>();
+    _wake.add(c);
+    await c.future.timeout(const Duration(seconds: 10));
+  }
+
+  Future<List<int>> readN(int n) async {
+    while (_buffer.length < n) {
+      if (_closed) throw StateError('socket closed before $n bytes');
+      await _changed();
+    }
+    final out = _buffer.sublist(0, n);
+    _buffer.removeRange(0, n);
+    return out;
+  }
+
+  Future<List<int>> readUntil(List<int> terminator) async {
+    while (true) {
+      for (var i = 0; i + terminator.length <= _buffer.length; i++) {
+        var match = true;
+        for (var j = 0; j < terminator.length; j++) {
+          if (_buffer[i + j] != terminator[j]) {
+            match = false;
+            break;
+          }
+        }
+        if (match) {
+          final out = _buffer.sublist(0, i + terminator.length);
+          _buffer.removeRange(0, i + terminator.length);
+          return out;
+        }
+      }
+      if (_closed) throw StateError('socket closed before terminator');
+      await _changed();
+    }
+  }
 }

--- a/test/ws_connection_manager_test.dart
+++ b/test/ws_connection_manager_test.dart
@@ -308,6 +308,92 @@ void main() {
     timeout: const Timeout(Duration(minutes: 3)),
   );
 
+  test(
+    'quarantine is authoritative: survives stop()/start(), gates wake hints '
+    'through the final minute, and clears on a successful connect',
+    () async {
+      var now = DateTime.now();
+      final socks = _FakeSocksServer(mode: _FakeSocksMode.close);
+      await socks.start();
+      addTearDown(socks.close);
+      final db = await _openMessagesDb();
+      MessagesDb.setDatabaseForTest(db);
+      addTearDown(() async {
+        await db.close();
+        MessagesDb.setDatabaseForTest(null);
+      });
+      await db.insert('messages', {
+        'id': 'm1',
+        'senderId': 'peer.onion',
+        'receiverId': 'me.onion',
+        'message': 'hello',
+        'type': 'text',
+        'timestamp': DateTime.now().millisecondsSinceEpoch,
+        'status': 'received',
+      });
+
+      final manager = WsConnectionManager(
+        _torManagerWithOnion(
+          dataDir: Directory.systemTemp.createTempSync('ws-manager-q-auth').path,
+          socksPort: socks.port,
+        ),
+        now: () => now,
+      );
+      addTearDown(manager.dispose);
+
+      // Drive 10 real dial failures through the production heartbeat path.
+      manager.start();
+      await _waitFor(() => manager.retryDelayForTest('peer.onion') != null);
+      for (var i = 1;
+          i < WsConnectionManager.hostUnreachableQuarantineThreshold;
+          i++) {
+        manager.stop();
+        manager.start();
+        await _waitFor(() => manager.retryDelayForTest('peer.onion') != null);
+      }
+      expect(manager.isPeerUnreachable('peer.onion'), isTrue);
+
+      // (b) The quarantine gates wake hints for its whole window: with only
+      // 30s left, the retry bookkeeping is below the 60s hint-suppression
+      // threshold, but the peer must still count as unreachable —
+      // WakeHintService filters hints on exactly this predicate.
+      now = now.add(
+        WsConnectionManager.hostUnreachableQuarantine -
+            const Duration(seconds: 30),
+      );
+      expect(manager.isPeerUnreachable('peer.onion'), isTrue);
+
+      // (a) stop() clears the retry bookkeeping but must not lift the gate:
+      // the quarantined peer stays in backoff and hint-suppressed.
+      manager.stop();
+      expect(manager.retryDelayForTest('peer.onion'), isNull);
+      expect(manager.isPeerUnreachable('peer.onion'), isTrue);
+      await expectLater(
+        manager.ensureConnected(
+          'peer.onion',
+          connectBudget: WsConnectionManager.interactiveConnectBudget,
+        ),
+        throwsA(isA<PeerInBackoffError>()),
+      );
+      // The restarted heartbeat loop must skip the quarantined peer entirely.
+      manager.start();
+      final dialsBefore = socks.dialCount;
+      await Future<void>.delayed(const Duration(seconds: 4));
+      expect(socks.dialCount, dialsBefore);
+      manager.stop();
+
+      // (c) Once the window elapses and the peer proves reachable again, the
+      // successful connect clears the quarantine alongside the backoff.
+      now = now.add(const Duration(seconds: 31));
+      await socks.setMode(_FakeSocksMode.success);
+      manager.start();
+      await _waitFor(() => manager.isConnected('peer.onion'));
+      expect(manager.isPeerUnreachable('peer.onion'), isFalse);
+      expect(manager.retryDelayForTest('peer.onion'), isNull);
+    },
+    timeout: const Timeout(Duration(minutes: 3)),
+  );
+
   test('a fast-fail while the peer is in backoff does not extend the window',
       () async {
     final socks = _FakeSocksServer(mode: _FakeSocksMode.hostUnreachable);


### PR DESCRIPTION
## Problem

`TorDelivery.withTorRetry` called `_maybeRefreshCircuit(circuitError: true, force: i == 0)`, and
`isCircuitError` returned true for SOCKS `hostUnreachable`. A permanently offline peer fails
immediately with `hostUnreachable`, so **every** delivery attempt to a dead contact forced a global
`SIGNAL NEWNYM`, bypassing the rate limit and tearing down the circuits of reachable peers.

From the device log: 80 `hostUnreachable` failures, 116 `WebSocket not connected`, 63
`WebSocket disconnected`; the one reachable peer repeatedly loses its WebSocket and falls back to
HTTP. At startup six peers are wake-hinted and five are unreachable, several after a 15s timeout.

## Change

- A peer being down is not a circuit fault: drop `hostUnreachable` / `networkUnreachable` from the
  circuit-error set. They stay in `isRetryableError`, so retry behaviour is unchanged; only the
  NEWNYM classification differs. `ttlExpired` and SOCKS server failures remain circuit errors.
- Remove the `force` bypass so the rate limit always applies: a routine per-peer delivery failure
  can no longer force a global circuit reset.
- Skip wake hints for peers that are repeatedly unreachable, not merely once.
- A backoff fast-fail no longer counts as a fresh connect failure, so a peer in backoff is still
  re-dialled instead of having its window slid forward on every heartbeat.
- A user-initiated send to a peer in backoff fails fast to the queue/HTTP route instead of blocking
  the UI for the full interactive budget.

## Verification

- `flutter analyze` clean; full suite green on this branch.
- Tests drive the real maintenance loop rather than the test-only injection hook, so they fail if
  the production path stops reaching the behaviour.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Reduced unnecessary connection attempts to peers that remain unreachable.
  * Wake hints are now suppressed for persistently unreachable peers.
  * Incoming authenticated hints can restore a peer’s connection availability.
  * Improved handling of network failures without triggering unnecessary Tor circuit refreshes.
  * Connection retry behavior now fails fast during temporary backoff periods.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->