### PR TITLE
fix(modify): stop dropping a peer's delete silently

### DIFF
--- a/lib/screens/chat.dart
+++ b/lib/screens/chat.dart
@@ -1488,11 +1488,26 @@ class _ChatScreenState extends State<ChatScreen> {
     setState(() {
       if (outcome == MessageDeleteOutcome.markedDeletedForEveryone) {
         _messages.updateMessage(message, markMessageDeleted(message));
+      } else if (outcome ==
+          MessageDeleteOutcome.markedDeletedForEveryoneFailed) {
+        // The tombstone was applied locally, but the peer was not notified:
+        // surface the send-failure state (metadata['failed'] -> 'Failed').
+        _messages.updateMessage(
+          message,
+          markMessageDeleted(
+            message.copyWith(
+              metadata: {...?message.metadata, 'failed': true},
+            ),
+          ),
+        );
       } else {
         _messages.removeMessage(message);
       }
       selectedMessageIds.remove(message.id);
     });
+    if (outcome == MessageDeleteOutcome.markedDeletedForEveryoneFailed) {
+      showPrysmToast(context, 'Could not delete for everyone');
+    }
   }
 
   void _resendMessage(Message message) {
@@ -1542,6 +1557,16 @@ class _ChatScreenState extends State<ChatScreen> {
         setState(() {
           if (outcome == MessageDeleteOutcome.markedDeletedForEveryone) {
             _messages.updateMessage(message, markMessageDeleted(message));
+          } else if (outcome ==
+              MessageDeleteOutcome.markedDeletedForEveryoneFailed) {
+            _messages.updateMessage(
+              message,
+              markMessageDeleted(
+                message.copyWith(
+                  metadata: {...?message.metadata, 'failed': true},
+                ),
+              ),
+            );
           } else {
             _messages.removeMessage(message);
           }

--- a/lib/screens/chat.dart
+++ b/lib/screens/chat.dart
@@ -1478,13 +1478,18 @@ class _ChatScreenState extends State<ChatScreen> {
     );
   }
 
-  Future<void> _deleteMessage(Message message) async {
+  /// Deletes [message] and returns the outcome, so the bulk path can report a
+  /// single aggregated failure instead of one toast per selected message.
+  Future<MessageDeleteOutcome> _deleteMessage(
+    Message message, {
+    bool showFailureToast = true,
+  }) async {
     final outcome = await _actionsService.deleteMessage(
       message,
       localUserId: widget.userId,
     );
     _messageCache.remove(message.id);
-    if (!mounted) return;
+    if (!mounted) return outcome;
     setState(() {
       if (outcome == MessageDeleteOutcome.markedDeletedForEveryone) {
         _messages.updateMessage(message, markMessageDeleted(message));
@@ -1505,9 +1510,11 @@ class _ChatScreenState extends State<ChatScreen> {
       }
       selectedMessageIds.remove(message.id);
     });
-    if (outcome == MessageDeleteOutcome.markedDeletedForEveryoneFailed) {
+    if (showFailureToast &&
+        outcome == MessageDeleteOutcome.markedDeletedForEveryoneFailed) {
       showPrysmToast(context, 'Could not delete for everyone');
     }
+    return outcome;
   }
 
   void _resendMessage(Message message) {
@@ -1546,36 +1553,27 @@ class _ChatScreenState extends State<ChatScreen> {
 
   Future<void> deleteSelectedMessages() async {
     final ids = List<String>.from(selectedMessageIds);
+    var failed = 0;
     for (final id in ids) {
       final message = _messages.messages.firstWhere((msg) => msg.id == id);
-      final outcome = await _actionsService.deleteMessage(
-        message,
-        localUserId: widget.userId,
-      );
-      _messageCache.remove(id);
-      if (mounted) {
-        setState(() {
-          if (outcome == MessageDeleteOutcome.markedDeletedForEveryone) {
-            _messages.updateMessage(message, markMessageDeleted(message));
-          } else if (outcome ==
-              MessageDeleteOutcome.markedDeletedForEveryoneFailed) {
-            _messages.updateMessage(
-              message,
-              markMessageDeleted(
-                message.copyWith(
-                  metadata: {...?message.metadata, 'failed': true},
-                ),
-              ),
-            );
-          } else {
-            _messages.removeMessage(message);
-          }
-        });
+      final outcome = await _deleteMessage(message, showFailureToast: false);
+      if (outcome == MessageDeleteOutcome.markedDeletedForEveryoneFailed) {
+        failed++;
       }
     }
 
     if (mounted) {
       setState(() => selectedMessageIds.clear());
+      // One toast for the whole selection: the per-message toast is
+      // suppressed above so N failures do not stack N toasts.
+      if (failed > 0) {
+        showPrysmToast(
+          context,
+          failed == 1
+              ? 'Could not delete for everyone'
+              : 'Could not delete $failed messages for everyone',
+        );
+      }
     }
   }
 

--- a/lib/screens/group_chat.dart
+++ b/lib/screens/group_chat.dart
@@ -526,12 +526,17 @@ class _GroupChatScreenState extends State<GroupChatScreen> {
     );
   }
 
-  Future<void> _deleteMessage(Message message) async {
+  /// Deletes [message] and returns the outcome, so the bulk path can report a
+  /// single aggregated failure instead of one toast per selected message.
+  Future<MessageDeleteOutcome> _deleteMessage(
+    Message message, {
+    bool showFailureToast = true,
+  }) async {
     final outcome = await _actionsService.deleteMessage(
       message,
       localUserId: widget.userId,
     );
-    if (!mounted) return;
+    if (!mounted) return outcome;
     setState(() {
       if (outcome == MessageDeleteOutcome.markedDeletedForEveryone) {
         _messages.updateMessage(message, markMessageDeleted(message));
@@ -551,9 +556,11 @@ class _GroupChatScreenState extends State<GroupChatScreen> {
         _messages.removeMessage(message);
       }
     });
-    if (outcome == MessageDeleteOutcome.markedDeletedForEveryoneFailed) {
+    if (showFailureToast &&
+        outcome == MessageDeleteOutcome.markedDeletedForEveryoneFailed) {
       showPrysmToast(context, 'Could not delete for everyone');
     }
+    return outcome;
   }
 
   Future<void> _editMessage(Message message) async {
@@ -659,14 +666,28 @@ class _GroupChatScreenState extends State<GroupChatScreen> {
 
   Future<void> _deleteSelectedMessages() async {
     final ids = List<String>.from(selectedMessageIds);
+    var failed = 0;
     for (final id in ids) {
       try {
         final msg = _messages.messages.firstWhere((m) => m.id == id);
-        await _deleteMessage(msg);
+        final outcome = await _deleteMessage(msg, showFailureToast: false);
+        if (outcome == MessageDeleteOutcome.markedDeletedForEveryoneFailed) {
+          failed++;
+        }
       } catch (_) {}
     }
     if (mounted) {
       _controller.clearSelection();
+      // One toast for the whole selection: the per-message toast is
+      // suppressed above so N failures do not stack N toasts.
+      if (failed > 0) {
+        showPrysmToast(
+          context,
+          failed == 1
+              ? 'Could not delete for everyone'
+              : 'Could not delete $failed messages for everyone',
+        );
+      }
     }
   }
 

--- a/lib/screens/group_chat.dart
+++ b/lib/screens/group_chat.dart
@@ -535,10 +535,25 @@ class _GroupChatScreenState extends State<GroupChatScreen> {
     setState(() {
       if (outcome == MessageDeleteOutcome.markedDeletedForEveryone) {
         _messages.updateMessage(message, markMessageDeleted(message));
+      } else if (outcome ==
+          MessageDeleteOutcome.markedDeletedForEveryoneFailed) {
+        // The tombstone was applied locally, but the peer was not notified:
+        // surface the send-failure state (metadata['failed'] -> 'Failed').
+        _messages.updateMessage(
+          message,
+          markMessageDeleted(
+            message.copyWith(
+              metadata: {...?message.metadata, 'failed': true},
+            ),
+          ),
+        );
       } else {
         _messages.removeMessage(message);
       }
     });
+    if (outcome == MessageDeleteOutcome.markedDeletedForEveryoneFailed) {
+      showPrysmToast(context, 'Could not delete for everyone');
+    }
   }
 
   Future<void> _editMessage(Message message) async {

--- a/lib/server/inbound_message_router.dart
+++ b/lib/server/inbound_message_router.dart
@@ -393,6 +393,13 @@ class InboundMessageRouter {
           return InboundHandleResult.badRequest(
             'Message modify could not be authenticated or decrypted',
           );
+        case InboundModifyOutcome.malformedPayload:
+          // The envelope authenticated but the payload is unparseable: a 4xx
+          // says the input is the problem, where the catch-all below would
+          // report a 500 and blame our own processing.
+          return InboundHandleResult.badRequest(
+            'Message modify payload is malformed',
+          );
         case InboundModifyOutcome.unknownTarget:
           // Benign no-op (see InboundModifyOutcome): the target message no
           // longer exists locally (disappearing-message expiry, conversation

--- a/lib/server/inbound_message_router.dart
+++ b/lib/server/inbound_message_router.dart
@@ -375,7 +375,7 @@ class InboundMessageRouter {
     final groupService = GroupService(userId: localId, keyManager: keyManager);
 
     try {
-      await MessageModifyService.applyInbound(
+      final outcome = await MessageModifyService.applyInbound(
         keyManager: keyManager,
         localUserId: localId,
         encrypted: data['message'] as String,
@@ -384,14 +384,35 @@ class InboundMessageRouter {
         groupId: data['groupId'] as String?,
         groupService: groupService,
       );
+      switch (outcome) {
+        case InboundModifyOutcome.applied:
+          return InboundHandleResult.ok(
+            {'status': 'received', 'id': data['id']},
+          );
+        case InboundModifyOutcome.decryptFailed:
+          return InboundHandleResult.badRequest(
+            'Message modify could not be authenticated or decrypted',
+          );
+        case InboundModifyOutcome.unknownTarget:
+          // Benign no-op (see InboundModifyOutcome): the target message no
+          // longer exists locally (disappearing-message expiry, conversation
+          // purge, or a delete that raced ahead of the message). Ack it as a
+          // 2xx so the sender does not queue an unbounded retry of a
+          // rejection that can never succeed.
+          return InboundHandleResult.ok(
+            {'status': 'noop', 'id': data['id']},
+          );
+        case InboundModifyOutcome.ownershipRejected:
+          return InboundHandleResult.forbidden(
+            'Message modify ownership rejected',
+          );
+      }
     } catch (e) {
       Logging.error('Message modify handling failed: $e', 'InboundMessageRouter');
       return InboundHandleResult.internalError(
         'Message modify processing failed',
       );
     }
-
-    return InboundHandleResult.ok({'status': 'received', 'id': data['id']});
   }
 
   Future<InboundHandleResult> _handleReadReceipt(

--- a/lib/services/message_actions_service.dart
+++ b/lib/services/message_actions_service.dart
@@ -19,6 +19,14 @@ enum MessageDeleteOutcome {
   /// delete-for-everyone): the DB row stays, only its reactions are wiped.
   markedDeletedForEveryone,
 
+  /// Delete-for-everyone was applied locally (tombstone + reaction wipe),
+  /// but the modify was not delivered to the peer right now: the send failed
+  /// (unknown peer identity / no group key, transport error, or a 4xx/5xx
+  /// rejection). The modify is queued for a later retry when the failure was
+  /// transient; either way the peer has not confirmed the delete, so the
+  /// caller should surface the send-failure state.
+  markedDeletedForEveryoneFailed,
+
   /// Local-only delete: artifacts wiped, DB row and reactions removed.
   removedLocally,
 }
@@ -67,11 +75,15 @@ class MessageActionsService {
     }
 
     if (canDeleteForEveryone(message, localUserId)) {
-      await modifyService.deleteMessage(targetMessageId: message.id);
+      final propagated = await modifyService.deleteMessage(
+        targetMessageId: message.id,
+      );
       await MessageReactionsDb.deleteReactionsForMessage(
         _storageId(message.id),
       );
-      return MessageDeleteOutcome.markedDeletedForEveryone;
+      return propagated
+          ? MessageDeleteOutcome.markedDeletedForEveryone
+          : MessageDeleteOutcome.markedDeletedForEveryoneFailed;
     }
 
     await _deleteLocalOnly(message.id);

--- a/lib/services/message_modify_service.dart
+++ b/lib/services/message_modify_service.dart
@@ -34,6 +34,11 @@ enum InboundModifyOutcome {
   /// legacy unsigned `dh-aead` envelope from a pre-v0.7 peer).
   decryptFailed,
 
+  /// The envelope authenticated, but its plaintext is not a modify payload
+  /// this build can parse. Kept apart from [decryptFailed] so the log and the
+  /// status say which half failed.
+  malformedPayload,
+
   /// The targeted message row does not exist locally.
   unknownTarget,
 
@@ -438,7 +443,21 @@ class MessageModifyService {
       return InboundModifyOutcome.decryptFailed;
     }
 
-    final payload = MessageModifyPayload.decode(plaintext);
+    final MessageModifyPayload payload;
+    try {
+      payload = MessageModifyPayload.decode(plaintext);
+    } catch (e) {
+      // An authenticated peer can still send a payload this build cannot
+      // parse (a buggy or hostile client). Report it as a rejection instead
+      // of letting the throw reach the caller's catch-all, which would blame
+      // a 500 on us for input we can never accept.
+      Logging.error(
+        'Inbound message modify from ${Logging.redactOnion(senderId)} '
+        'rejected: malformed payload: $e',
+        'MessageModifyService',
+      );
+      return InboundModifyOutcome.malformedPayload;
+    }
     final rows = await MessagesDb.getMessageById(
       payload.targetMessageId,
       groupId: groupId,

--- a/lib/services/message_modify_service.dart
+++ b/lib/services/message_modify_service.dart
@@ -20,6 +20,27 @@ import 'package:prysm/util/peer_identity_loader.dart';
 import 'package:prysm/crypto/identity.dart';
 import 'package:prysm/util/logging.dart';
 
+/// Outcome of applying an inbound modify payload, so the transport can
+/// decide whether to ack the sender or surface a rejection. The rejection
+/// categories need different sender-facing outcomes: an envelope that cannot
+/// be authenticated or decrypted is a security rejection, a missing target
+/// row is a benign no-op, and an ownership mismatch is a policy violation.
+enum InboundModifyOutcome {
+  /// The modify authenticated, targeted an existing message row owned by the
+  /// sender, and was applied.
+  applied,
+
+  /// The envelope could not be authenticated or decrypted (for example a
+  /// legacy unsigned `dh-aead` envelope from a pre-v0.7 peer).
+  decryptFailed,
+
+  /// The targeted message row does not exist locally.
+  unknownTarget,
+
+  /// The targeted message row exists but is owned by a different sender.
+  ownershipRejected,
+}
+
 class MessageModifyService {
   final String userId;
   final KeyManager keyManager;
@@ -109,10 +130,11 @@ class MessageModifyService {
       modifiedAt: modifiedAt,
     );
 
+    final bool propagated;
     if (groupId != null) {
-      await _sendGroupModify(payload);
+      propagated = await _sendGroupModify(payload);
     } else {
-      await _sendDirectModify(payload);
+      propagated = await _sendDirectModify(payload);
     }
 
     MessageModifyRefreshNotifier.instance.notify(
@@ -122,7 +144,7 @@ class MessageModifyService {
         modifiedAt: modifiedAt,
       ),
     );
-    return true;
+    return propagated;
   }
 
   Future<bool> _editDirectText(
@@ -301,12 +323,18 @@ class MessageModifyService {
     return true;
   }
 
-  Future<void> _sendDirectModify(MessageModifyPayload payload) async {
-    if (peerId == null) return;
+  /// Returns whether the modify was delivered to the peer right now.
+  /// `false` means the send failed (the row is queued for a later retry, or
+  /// nothing was attempted: there is no peer id, or the peer's public
+  /// identity is unknown and no test override is installed). Callers that
+  /// want at-least-once semantics (edits) treat `false` as "queued"; the
+  /// delete path reports it as not-yet-propagated.
+  Future<bool> _sendDirectModify(MessageModifyPayload payload) async {
+    if (peerId == null) return false;
 
     final override = postDirectOverride;
     final peerKey = await _loadPeerPublicKey();
-    if (peerKey == null && override == null) return;
+    if (peerKey == null && override == null) return false;
 
     final encrypted = peerKey != null
         ? await keyManager.encryptHybridForPeer(
@@ -322,7 +350,7 @@ class MessageModifyService {
       modifiedAt: payload.modifiedAt,
     );
 
-    await _transport.sendDirectAndQueue(
+    return _transport.sendDirectAndQueue(
       id: eventId,
       peerId: peerId!,
       encrypted: encrypted,
@@ -331,15 +359,19 @@ class MessageModifyService {
     );
   }
 
-  Future<void> _sendGroupModify(
+  /// Returns whether the modify was delivered to every target right now.
+  /// `false` means at least one target send failed (that row is queued for a
+  /// later retry, or nothing was attempted: the group service or group key is
+  /// unavailable).
+  Future<bool> _sendGroupModify(
     MessageModifyPayload payload, {
     Set<String>? onlyTargets,
   }) async {
     final gs = groupService;
-    if (gs == null || groupId == null) return;
+    if (gs == null || groupId == null) return false;
 
     final groupKey = await gs.getDecryptedGroupKey(groupId!);
-    if (groupKey == null) return;
+    if (groupKey == null) return false;
 
     final encrypted = await GroupCryptoV2.encryptText(groupKey, payload.encode());
     final members = await gs.getMembers(groupId!);
@@ -355,8 +387,9 @@ class MessageModifyService {
       modifiedAt: payload.modifiedAt,
     );
 
+    var allDelivered = true;
     for (final target in targets) {
-      await _transport.sendGroupAndQueue(
+      final ok = await _transport.sendGroupAndQueue(
         id: '${eventId}__$target',
         groupId: groupId!,
         targetMemberId: target,
@@ -364,7 +397,9 @@ class MessageModifyService {
         timestamp: payload.modifiedAt,
         type: groupMessageModifyType,
       );
+      if (!ok) allDelivered = false;
     }
+    return allDelivered;
   }
 
   Future<IdentityPublicKeys?> _loadPeerPublicKey() async {
@@ -377,7 +412,7 @@ class MessageModifyService {
     }
   }
 
-  static Future<void> applyInbound({
+  static Future<InboundModifyOutcome> applyInbound({
     required KeyManager keyManager,
     required String localUserId,
     required String encrypted,
@@ -394,16 +429,37 @@ class MessageModifyService {
       groupId: groupId,
       groupService: groupService,
     );
-    if (plaintext == null) return;
+    if (plaintext == null) {
+      Logging.error(
+        'Inbound message modify from ${Logging.redactOnion(senderId)} '
+        'rejected: could not authenticate or decrypt the envelope',
+        'MessageModifyService',
+      );
+      return InboundModifyOutcome.decryptFailed;
+    }
 
     final payload = MessageModifyPayload.decode(plaintext);
     final rows = await MessagesDb.getMessageById(
       payload.targetMessageId,
       groupId: groupId,
     );
-    if (rows.isEmpty) return;
+    if (rows.isEmpty) {
+      Logging.error(
+        'Inbound message modify from ${Logging.redactOnion(senderId)} '
+        'targets unknown message ${payload.targetMessageId}',
+        'MessageModifyService',
+      );
+      return InboundModifyOutcome.unknownTarget;
+    }
     final row = rows.first;
-    if (row['senderId'] != senderId) return;
+    if (row['senderId'] != senderId) {
+      Logging.error(
+        'Inbound message modify from ${Logging.redactOnion(senderId)} '
+        'rejected: message ${payload.targetMessageId} is not owned by the sender',
+        'MessageModifyService',
+      );
+      return InboundModifyOutcome.ownershipRejected;
+    }
 
     String? newText;
     if (payload.isDelete) {
@@ -457,6 +513,7 @@ class MessageModifyService {
         modifiedAt: payload.modifiedAt,
       ),
     );
+    return InboundModifyOutcome.applied;
   }
 
   static Future<String?> _decryptEditedBody({
@@ -519,7 +576,10 @@ class MessageModifyService {
           publicKeyPem: user?['publicKeyPem'] as String?,
         );
         if (peerKey == null) return null;
-        return keyManager.decryptPeerMessage(
+        // Awaited so a decrypt rejection (e.g. a legacy unsigned `dh-aead`
+        // envelope) is caught below and reported as `decryptFailed` instead
+        // of escaping as an unclassified internal error.
+        return await keyManager.decryptPeerMessage(
           peerId: senderId,
           wire: encrypted,
           peer: peerKey,
@@ -542,7 +602,10 @@ class MessageModifyService {
         return await GroupCryptoV2.decryptText(groupKey, encrypted);
       }
     } catch (e) {
-      Logging.error('Message modify decrypt failed: $e', 'MessageModifyService');
+      Logging.error(
+        'Message modify decrypt failed for ${Logging.redactOnion(senderId)}: $e',
+        'MessageModifyService',
+      );
     }
     return null;
   }

--- a/lib/transport/tor_http_transport.dart
+++ b/lib/transport/tor_http_transport.dart
@@ -24,7 +24,15 @@ class TorHttpTransport implements OutboundTransport {
   DateTime? lastSuccessForPeer(String peerOnion) =>
       _lastSuccessByPeer[peerOnion];
 
+  /// Test seam: replaces the per-request [TorHttpClient] so transport-level
+  /// status handling can be exercised without a live Tor circuit. The
+  /// production [postJson] body (retry, body read, status check) still runs.
+  @visibleForTesting
+  static TorHttpClient Function()? clientFactory;
+
   TorHttpClient _client() {
+    final factory = clientFactory;
+    if (factory != null) return factory();
     return TorHttpClient(
       proxyHost: '127.0.0.1',
       proxyPort: _torManager.socksPort,
@@ -149,7 +157,14 @@ class TorHttpTransport implements OutboundTransport {
               jsonEncode(payload),
             )
             .timeout(timeout);
-        await client.readUtf8Body(response);
+        final body = await client.readUtf8Body(response);
+        if (response.statusCode < 200 || response.statusCode >= 300) {
+          // The peer is reachable and answered, but rejected the payload
+          // (4xx) or failed to process it (5xx). Surface it as a failure so
+          // callers queue a retry instead of reporting a phantom success —
+          // the same signal the WebSocket path produces via ack errors.
+          throw StateError('HTTP ${response.statusCode}: $body');
+        }
       } finally {
         await client.close();
       }

--- a/lib/transport/tor_http_transport.dart
+++ b/lib/transport/tor_http_transport.dart
@@ -10,6 +10,24 @@ import 'package:prysm/util/tor_delivery.dart';
 import 'package:prysm/util/tor_runtime_gate.dart';
 import 'package:prysm/util/tor_service.dart';
 
+/// A peer answered a request with a non-2xx status.
+///
+/// The response body is deliberately *not* carried here. [TorDelivery]
+/// classifies retries and circuit resets by substring on the error text
+/// (`isRetryableError` / `isCircuitError`), so a peer-controlled body would
+/// let the peer pick its own classification: answering `4xx` with
+/// `hostUnreachable` in the body would buy it three retries and a global
+/// NEWNYM per delivery. The status code is ours, and it is all the callers
+/// and logs need.
+class PeerHttpStatusException implements Exception {
+  const PeerHttpStatusException(this.statusCode);
+
+  final int statusCode;
+
+  @override
+  String toString() => 'Peer answered HTTP $statusCode';
+}
+
 /// HTTP request/response transport over Tor SOCKS.
 class TorHttpTransport implements OutboundTransport {
   TorHttpTransport(this._torManager);
@@ -157,13 +175,15 @@ class TorHttpTransport implements OutboundTransport {
               jsonEncode(payload),
             )
             .timeout(timeout);
-        final body = await client.readUtf8Body(response);
+        // Drain the body so the SOCKS socket is released, then discard it:
+        // it is peer-controlled and nothing here consumes it.
+        await client.readUtf8Body(response);
         if (response.statusCode < 200 || response.statusCode >= 300) {
           // The peer is reachable and answered, but rejected the payload
           // (4xx) or failed to process it (5xx). Surface it as a failure so
           // callers queue a retry instead of reporting a phantom success —
           // the same signal the WebSocket path produces via ack errors.
-          throw StateError('HTTP ${response.statusCode}: $body');
+          throw PeerHttpStatusException(response.statusCode);
         }
       } finally {
         await client.close();

--- a/lib/transport/ws_frame_router.dart
+++ b/lib/transport/ws_frame_router.dart
@@ -125,6 +125,43 @@ class WsFrameRouter {
         return [];
       }
 
+      if (frame.op == 'message_modify') {
+        // Verify-then-ack for modify control frames: an optimistic ack would
+        // tell the sender the modify was applied even when it was rejected
+        // (unauthenticated envelope, unknown target, ownership mismatch).
+        // Await processing and propagate failures as an error frame so the
+        // sender's transport throws and `sendDirectAndQueue` queues a retry
+        // (at-least-once instead of silent loss).
+        try {
+          final result = await router.processMessage(payload);
+          if (result.statusCode >= 400) {
+            return [
+              WsFrame.error(
+                id: frame.id!,
+                message: result.jsonBody?['error']?.toString() ??
+                    'Processing failed',
+              ).encode(),
+            ];
+          }
+          return [
+            WsFrame.response(
+              op: '${frame.op}_ack',
+              id: frame.id!,
+              payload: result.jsonBody ?? router.optimisticAckBody(payload),
+            ).encode(),
+          ];
+        } catch (e, stack) {
+          Logging.error(
+            'message_modify from ${Logging.redactOnion('${payload['senderId']}')} '
+            'processing error: $e\n$stack',
+            'WsFrameRouter',
+          );
+          return [
+            WsFrame.error(id: frame.id!, message: 'Processing failed').encode(),
+          ];
+        }
+      }
+
       final ackOp = frame.op == 'message' ? 'message_ack' : '${frame.op}_ack';
       final ack = WsFrame.response(
         op: ackOp,

--- a/test/message_actions_service_test.dart
+++ b/test/message_actions_service_test.dart
@@ -7,6 +7,7 @@ import 'dart:io';
 
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:prysm/crypto/group_crypto.dart';
 import 'package:prysm/crypto/identity.dart';
 import 'package:prysm/crypto/ratchet/session_store.dart';
 import 'package:prysm/database/message_reactions.dart';
@@ -96,6 +97,15 @@ Future<Database> _openDbHelperDb() async {
       groupId TEXT PRIMARY KEY,
       encryptedKey TEXT NOT NULL,
       keyVersion INTEGER NOT NULL DEFAULT 1
+    )
+  ''');
+  await db.execute('''
+    CREATE TABLE group_members (
+      groupId TEXT NOT NULL,
+      memberId TEXT NOT NULL,
+      role TEXT NOT NULL,
+      joinedAt INTEGER NOT NULL,
+      PRIMARY KEY (groupId, memberId)
     )
   ''');
   await RatchetSessionStore.ensureTable(db);
@@ -206,6 +216,15 @@ void main() {
     test('a sender-owned, already-sent message is soft-deleted (kept row)',
         () async {
       const wireId = 'wire-2';
+      // The side-channel post succeeds so the delete-for-everyone branch
+      // reports a delivered propagation (not the failure outcome).
+      MessageModifyService.postDirectOverride = ({
+        required id,
+        required encrypted,
+        required timestamp,
+        required peerId,
+      }) async =>
+          true;
       await MessagesDb.insertMessage({
         'id': wireId,
         'senderId': 'me',
@@ -305,6 +324,17 @@ void main() {
       const wireId = 'wire-5';
       const groupId = 'group-1';
       final groupService = GroupService(userId: 'me', keyManager: keyManager);
+      // A stored group key makes the group side-channel propagation succeed,
+      // so the delete-for-everyone branch reports a delivered propagation.
+      final groupKey = GroupCryptoV2.generateGroupKey();
+      await DBHelper.upsertGroupKey(
+        groupId: groupId,
+        encryptedKey: await GroupCryptoV2.encryptGroupKeyForStorage(
+          groupKey,
+          keyManager.identity,
+        ),
+        keyVersion: 1,
+      );
       final actions = MessageActionsService(
         modifyService: MessageModifyService.group(
           userId: 'me',

--- a/test/message_actions_service_test.dart
+++ b/test/message_actions_service_test.dart
@@ -17,6 +17,7 @@ import 'package:prysm/models/chat/prysm_message.dart';
 import 'package:prysm/services/group_service.dart';
 import 'package:prysm/services/message_actions_service.dart';
 import 'package:prysm/services/message_modify_service.dart';
+import 'package:prysm/services/side_channel_postman.dart';
 import 'package:prysm/util/db_helper.dart';
 import 'package:prysm/util/key_manager.dart';
 import 'package:prysm/util/pending_message_db_helper.dart';
@@ -262,6 +263,45 @@ void main() {
       );
     });
 
+    test('a rejected delete-for-everyone still tombstones locally', () async {
+      const wireId = 'wire-7';
+      // The side-channel post is rejected (override returns false), so the
+      // delete-for-everyone branch reports the send-failure outcome even
+      // though the local tombstone was still applied (row kept, deletedAt
+      // set): local delete succeeds, propagation did not.
+      MessageModifyService.postDirectOverride = ({
+        required id,
+        required encrypted,
+        required timestamp,
+        required peerId,
+      }) async =>
+          false;
+      await MessagesDb.insertMessage({
+        'id': wireId,
+        'senderId': 'me',
+        'receiverId': 'peer',
+        'message': 'cipher',
+        'type': 'text',
+        'status': 'sent',
+        'timestamp': 1,
+      });
+
+      final outcome = await actions.deleteMessage(
+        TextMessage(
+          id: wireId,
+          authorId: 'me',
+          text: 'x',
+          sentAt: DateTime.fromMillisecondsSinceEpoch(1),
+        ),
+        localUserId: 'me',
+      );
+
+      expect(outcome, MessageDeleteOutcome.markedDeletedForEveryoneFailed);
+      final rows = await MessagesDb.getMessageById(wireId);
+      expect(rows, hasLength(1));
+      expect(rows.first['deletedAt'], isNotNull);
+    });
+
     test('a peer-owned message is removed locally only', () async {
       const wireId = 'wire-3';
       await MessagesDb.insertMessage({
@@ -324,8 +364,17 @@ void main() {
       const wireId = 'wire-5';
       const groupId = 'group-1';
       final groupService = GroupService(userId: 'me', keyManager: keyManager);
-      // A stored group key makes the group side-channel propagation succeed,
-      // so the delete-for-everyone branch reports a delivered propagation.
+      // One other member so the per-target send loop actually runs; with an
+      // empty group_members table getMembers would return [] and the loop
+      // would report all-delivered without ever sending anything.
+      await DBHelper.addGroupMember({
+        'groupId': groupId,
+        'memberId': 'memberA',
+        'role': 'member',
+        'joinedAt': 1,
+      });
+      // A stored group key plus a deterministic postman whose sends all
+      // succeed make the group side-channel propagation report delivered.
       final groupKey = GroupCryptoV2.generateGroupKey();
       await DBHelper.upsertGroupKey(
         groupId: groupId,
@@ -335,6 +384,7 @@ void main() {
         ),
         keyVersion: 1,
       );
+      MessageModifyService.testPostman = _FakePostman();
       final actions = MessageActionsService(
         modifyService: MessageModifyService.group(
           userId: 'me',
@@ -364,6 +414,70 @@ void main() {
       );
 
       expect(outcome, MessageDeleteOutcome.markedDeletedForEveryone);
+      final rows = await MessagesDb.getMessageById(wireId, groupId: groupId);
+      expect(rows, hasLength(1));
+      expect(rows.first['deletedAt'], isNotNull);
+    });
+
+    test(
+        'a partially failed group delete-for-everyone still tombstones '
+        'locally and reports the failure', () async {
+      const wireId = 'wire-8';
+      const groupId = 'group-1';
+      final groupService = GroupService(userId: 'me', keyManager: keyManager);
+      final groupKey = GroupCryptoV2.generateGroupKey();
+      await DBHelper.upsertGroupKey(
+        groupId: groupId,
+        encryptedKey: await GroupCryptoV2.encryptGroupKeyForStorage(
+          groupKey,
+          keyManager.identity,
+        ),
+        keyVersion: 1,
+      );
+      // Two other members: the postman delivers to memberA but rejects
+      // memberB, so the aggregation must report the send failure instead of
+      // a delivered delete (impossible with an empty member list, which
+      // would trivially report all-delivered).
+      await DBHelper.addGroupMember({
+        'groupId': groupId,
+        'memberId': 'memberA',
+        'role': 'member',
+        'joinedAt': 1,
+      });
+      await DBHelper.addGroupMember({
+        'groupId': groupId,
+        'memberId': 'memberB',
+        'role': 'member',
+        'joinedAt': 1,
+      });
+      MessageModifyService.testPostman =
+          _FakePostman(failingMembers: {'memberB'});
+      final actions = MessageActionsService(
+        modifyService: MessageModifyService.group(
+          userId: 'me',
+          keyManager: keyManager,
+          groupId: groupId,
+          groupService: groupService,
+        ),
+        groupId: groupId,
+      );
+      await MessagesDb.insertMessage({
+        'id': wireId,
+        'senderId': 'me',
+        'receiverId': 'memberA',
+        'message': 'cipher',
+        'type': 'text',
+        'status': 'sent',
+        'timestamp': 1,
+        'groupId': groupId,
+      });
+
+      final outcome = await actions.deleteMessage(
+        TextMessage(id: wireId, authorId: 'me', text: 'x'),
+        localUserId: 'me',
+      );
+
+      expect(outcome, MessageDeleteOutcome.markedDeletedForEveryoneFailed);
       final rows = await MessagesDb.getMessageById(wireId, groupId: groupId);
       expect(rows, hasLength(1));
       expect(rows.first['deletedAt'], isNotNull);
@@ -405,4 +519,31 @@ void main() {
       );
     });
   });
+}
+
+/// Deterministic side-channel postman for group tests: succeeds for every
+/// member except those listed in [failingMembers], which are rejected with a
+/// neutral error (no Tor retry tokens, so delivery fails fast).
+class _FakePostman implements SideChannelPostman {
+  final Set<String> failingMembers;
+
+  _FakePostman({this.failingMembers = const {}});
+
+  @override
+  Future<void> postDirect({
+    required String peerId,
+    required Map<String, dynamic> payload,
+    Duration timeout = const Duration(seconds: 30),
+  }) async {}
+
+  @override
+  Future<void> postGroup({
+    required String targetMemberId,
+    required Map<String, dynamic> payload,
+    Duration timeout = const Duration(seconds: 30),
+  }) async {
+    if (failingMembers.contains(targetMemberId)) {
+      throw Exception('peer rejected');
+    }
+  }
 }

--- a/test/message_modify_service_test.dart
+++ b/test/message_modify_service_test.dart
@@ -1,0 +1,520 @@
+// Tests for MessageModifyService visibility of inbound modify failures and
+// honest delete propagation results.
+//
+// Covering:
+// * an inbound modify whose envelope cannot be authenticated/decrypted is
+//   reported as `InboundModifyOutcome.decryptFailed` (never silently dropped
+//   while the sender is acked);
+// * a successful delete-for-everyone still applies the tombstone exactly as
+//   before (no regression);
+// * `deleteMessage` returns false when propagation was never attempted
+//   (unknown peer identity / no override) instead of a hardcoded `true`;
+// * a failed direct post is queued for retry and is NOT reported as a
+//   delivered propagation: the queued row keeps at-least-once delivery while
+//   `deleteMessage` honestly reports the not-yet-delivered outcome;
+// * a 4xx on the HTTP path (peer reachable but rejecting) surfaces as a
+//   failed delete, end to end through the production transport wiring;
+// * an inbound delete for a message the peer no longer has is acked as a
+//   benign no-op (2xx) so the sender does not queue an unbounded retry.
+import 'dart:async';
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:prysm/client/TorHttpClient.dart';
+import 'package:prysm/constants/group_constants.dart';
+import 'package:prysm/crypto/identity.dart';
+import 'package:prysm/crypto/ratchet/session_store.dart';
+import 'package:prysm/database/message_reactions.dart';
+import 'package:prysm/database/message_schema_migrations.dart';
+import 'package:prysm/database/messages.dart';
+import 'package:prysm/server/inbound_message_router.dart';
+import 'package:prysm/services/message_modify_service.dart';
+import 'package:prysm/services/settings_service.dart';
+import 'package:prysm/transport/tor_http_transport.dart';
+import 'package:prysm/transport/transport_provider.dart';
+import 'package:prysm/util/db_helper.dart';
+import 'package:prysm/util/key_manager.dart';
+import 'package:prysm/util/message_modify_payload.dart';
+import 'package:prysm/util/pending_message_db_helper.dart';
+import 'package:prysm/util/tor_delivery.dart';
+import 'package:prysm/util/tor_lifecycle_state.dart';
+import 'package:prysm/util/tor_runtime_gate.dart';
+import 'package:prysm/util/tor_service.dart';
+import 'package:sqflite_common_ffi/sqflite_ffi.dart';
+
+void _mockPathProvider() {
+  final tempDir =
+      Directory.systemTemp.createTempSync('prysm_msg_modify_svc_test_');
+  const channel = MethodChannel('plugins.flutter.io/path_provider');
+  TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+      .setMockMethodCallHandler(channel, (call) async => tempDir.path);
+}
+
+Future<Database> _openMessagesDb() async {
+  final db = await databaseFactory.openDatabase(inMemoryDatabasePath);
+  await db.execute('''
+    CREATE TABLE messages(
+      id TEXT PRIMARY KEY,
+      senderId TEXT NOT NULL,
+      receiverId TEXT NOT NULL,
+      message TEXT,
+      type TEXT,
+      fileName TEXT,
+      fileSize INTEGER,
+      timestamp INTEGER NOT NULL,
+      status TEXT DEFAULT 'sent',
+      replyTo TEXT,
+      readAt INTEGER,
+      viewOnce INTEGER DEFAULT 0,
+      viewed INTEGER DEFAULT 0,
+      groupId TEXT,
+      deletedAt INTEGER,
+      editedAt INTEGER,
+      expiresAt INTEGER
+    )
+  ''');
+  await MessageReactionsDb.createTable(db);
+  await MessageSchemaMigrations.createMessageSearchFtsTable(db);
+  return db;
+}
+
+Future<Database> _openPendingDb() async {
+  final db = await databaseFactory.openDatabase(inMemoryDatabasePath);
+  await db.execute('''
+    CREATE TABLE pending_messages(
+      id TEXT PRIMARY KEY,
+      senderId TEXT,
+      receiverId TEXT,
+      message TEXT,
+      type TEXT,
+      fileName TEXT,
+      fileSize INTEGER,
+      timestamp INTEGER,
+      status TEXT,
+      replyTo TEXT,
+      viewOnce INTEGER DEFAULT 0,
+      groupId TEXT,
+      targetMemberId TEXT
+    )
+  ''');
+  return db;
+}
+
+Future<Database> _openDbHelperDb() async {
+  final db = await databaseFactory.openDatabase(inMemoryDatabasePath);
+  await db.execute('''
+    CREATE TABLE users (
+      id TEXT PRIMARY KEY,
+      name TEXT,
+      avatarUrl TEXT,
+      avatarBase64 TEXT,
+      customName TEXT,
+      publicKeyPem TEXT,
+      identityJson TEXT
+    )
+  ''');
+  await RatchetSessionStore.ensureTable(db);
+  return db;
+}
+
+/// Public half of an [IdentityKeyPair], as the peer would see it.
+Future<IdentityPublicKeys> _publicKeysOf(IdentityKeyPair pair) async {
+  final publicJson = await pair.toPublicJson();
+  return IdentityPublicKeys(
+    signPublic: await pair.signPublicKey,
+    agreePublic: await pair.agreePublicKey,
+    fingerprint: IdentityKeyPair.fingerprintFromPublicJson(publicJson),
+  );
+}
+
+Future<void> _insertSentMessage(String wireId) async {
+  await MessagesDb.insertMessage({
+    'id': wireId,
+    'senderId': 'me.onion',
+    'receiverId': 'peer.onion',
+    'message': 'cipher',
+    'type': 'text',
+    'status': 'sent',
+    'timestamp': 1,
+  });
+}
+
+/// [TorHttpClient] whose [post] answers with a canned response, so the
+/// production [TorHttpTransport.postJson] status handling is exercised
+/// through the real transport wiring without a live Tor circuit. The
+/// inherited [TorHttpClient.readUtf8Body] is the production body reader.
+class _FakeTorHttpClient extends TorHttpClient {
+  _FakeTorHttpClient(this.response)
+      : super(proxyHost: '127.0.0.1', proxyPort: 9050);
+
+  final HttpClientResponse response;
+
+  @override
+  Future<HttpClientResponse> post(
+    Uri uri,
+    Map<String, String> headers,
+    String body,
+  ) async =>
+      response;
+}
+
+/// Minimal [HttpClientResponse]: only [statusCode] and the byte stream
+/// consumed by [TorHttpClient.readUtf8Body] are implemented; every other
+/// member falls through to [Object.noSuchMethod].
+class _FakeHttpClientResponse implements HttpClientResponse {
+  _FakeHttpClientResponse(this.statusCode, this.body);
+
+  @override
+  final int statusCode;
+
+  final String body;
+
+  @override
+  Stream<S> transform<S>(StreamTransformer<List<int>, S> transformer) =>
+      Stream<List<int>>.value(utf8.encode(body)).transform(transformer);
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
+
+void main() {
+  setUpAll(() {
+    TestWidgetsFlutterBinding.ensureInitialized();
+    sqfliteFfiInit();
+    databaseFactory = databaseFactoryFfi;
+    _mockPathProvider();
+  });
+
+  late Database messagesDb;
+  late Database pendingDb;
+  late Database dbHelperDb;
+  late KeyManager keyManager;
+
+  setUp(() async {
+    messagesDb = await _openMessagesDb();
+    MessagesDb.setDatabaseForTest(messagesDb);
+
+    pendingDb = await _openPendingDb();
+    PendingMessageDbHelper.setDatabaseForTest(pendingDb);
+
+    dbHelperDb = await _openDbHelperDb();
+    DBHelper.setDatabaseForTest(dbHelperDb);
+
+    keyManager = KeyManager.fromIdentity(await IdentityKeyPair.generate());
+  });
+
+  tearDown(() async {
+    await messagesDb.close();
+    MessagesDb.setDatabaseForTest(null);
+
+    await pendingDb.close();
+    PendingMessageDbHelper.setDatabaseForTest(null);
+
+    await dbHelperDb.close();
+    DBHelper.setDatabaseForTest(null);
+
+    MessageModifyService.postDirectOverride = null;
+    MessageModifyService.testPostman = null;
+  });
+
+  group('applyInbound visibility', () {
+    test(
+        'an inbound modify whose envelope cannot be authenticated is '
+        'reported as decryptFailed, not silently dropped', () async {
+      final sender = await IdentityKeyPair.generate();
+      final publicJson = jsonEncode(await sender.toPublicJson());
+      await DBHelper.insertOrUpdateUser({
+        'id': 'peer.onion',
+        'name': 'Peer',
+        'identityJson': publicJson,
+        'publicKeyPem': publicJson,
+      });
+      // Legacy unsigned dh-aead envelope, as sent by peers on <=v0.6.3: the
+      // ratchet rejects it with FormatException('Unsigned peer message
+      // rejected') before any decrypt step.
+      const legacyEnvelope =
+          '{"crypto":"v2","scheme":"dh-aead-1","ephemeralPub":"AA==",'
+          '"nonce":"AA==","ciphertext":"AA=="}';
+
+      final outcome = await MessageModifyService.applyInbound(
+        keyManager: keyManager,
+        localUserId: 'me.onion',
+        encrypted: legacyEnvelope,
+        senderId: 'peer.onion',
+        type: messageModifyType,
+      );
+
+      expect(outcome, InboundModifyOutcome.decryptFailed);
+    });
+
+    test('an inbound modify for an unknown target row reports unknownTarget',
+        () async {
+      final sender = await IdentityKeyPair.generate();
+      final receiver = await IdentityKeyPair.generate();
+      final receiverKm = KeyManager.fromIdentity(receiver);
+      final senderKm = KeyManager.fromIdentity(sender);
+      final publicJson = jsonEncode(await sender.toPublicJson());
+      await DBHelper.insertOrUpdateUser({
+        'id': 'peer.onion',
+        'name': 'Peer',
+        'identityJson': publicJson,
+        'publicKeyPem': publicJson,
+      });
+      final encrypted = await senderKm.encryptHybridForPeer(
+        const MessageModifyPayload(
+          targetMessageId: 'never-existed',
+          action: 'delete',
+          modifiedAt: 5,
+        ).encode(),
+        await _publicKeysOf(receiver),
+        peerId: 'me.onion',
+      );
+
+      final outcome = await MessageModifyService.applyInbound(
+        keyManager: receiverKm,
+        localUserId: 'me.onion',
+        encrypted: encrypted,
+        senderId: 'peer.onion',
+        type: messageModifyType,
+      );
+
+      expect(outcome, InboundModifyOutcome.unknownTarget);
+    });
+
+    test('an inbound modify for another sender\'s row reports ownershipRejected',
+        () async {
+      final sender = await IdentityKeyPair.generate();
+      final receiver = await IdentityKeyPair.generate();
+      final receiverKm = KeyManager.fromIdentity(receiver);
+      final senderKm = KeyManager.fromIdentity(sender);
+      final publicJson = jsonEncode(await sender.toPublicJson());
+      await DBHelper.insertOrUpdateUser({
+        'id': 'peer.onion',
+        'name': 'Peer',
+        'identityJson': publicJson,
+        'publicKeyPem': publicJson,
+      });
+      const wireId = 'wire-foreign';
+      await MessagesDb.insertMessage({
+        'id': wireId,
+        'senderId': 'other.onion',
+        'receiverId': 'me.onion',
+        'message': 'cipher',
+        'type': 'text',
+        'status': 'sent',
+        'timestamp': 1,
+      });
+      final encrypted = await senderKm.encryptHybridForPeer(
+        const MessageModifyPayload(
+          targetMessageId: wireId,
+          action: 'delete',
+          modifiedAt: 5,
+        ).encode(),
+        await _publicKeysOf(receiver),
+        peerId: 'me.onion',
+      );
+
+      final outcome = await MessageModifyService.applyInbound(
+        keyManager: receiverKm,
+        localUserId: 'me.onion',
+        encrypted: encrypted,
+        senderId: 'peer.onion',
+        type: messageModifyType,
+      );
+
+      expect(outcome, InboundModifyOutcome.ownershipRejected);
+    });
+  });
+
+  group('deleteMessage propagation result', () {
+    test('a successful delete still applies the tombstone exactly as before',
+        () async {
+      const wireId = 'wire-ok';
+      await _insertSentMessage(wireId);
+      MessageModifyService.postDirectOverride = ({
+        required id,
+        required encrypted,
+        required timestamp,
+        required peerId,
+      }) async =>
+          true;
+
+      final service = MessageModifyService.direct(
+        userId: 'me.onion',
+        keyManager: keyManager,
+        peerId: 'peer.onion',
+      );
+      final ok = await service.deleteMessage(targetMessageId: wireId);
+
+      expect(ok, isTrue);
+      final rows = await MessagesDb.getMessageById(wireId);
+      expect(rows, hasLength(1));
+      expect(rows.first['deletedAt'], isNotNull);
+    });
+
+    test('deleteMessage reports false when propagation was never attempted',
+        () async {
+      const wireId = 'wire-nope';
+      await _insertSentMessage(wireId);
+      // No stored peer identity and no override: the send path cannot
+      // encrypt, so nothing is attempted and nothing is queued.
+      final service = MessageModifyService.direct(
+        userId: 'me.onion',
+        keyManager: keyManager,
+        peerId: 'peer.onion',
+      );
+      final ok = await service.deleteMessage(targetMessageId: wireId);
+
+      expect(ok, isFalse);
+      // The local tombstone still applies; only the propagation is reported.
+      final rows = await MessagesDb.getMessageById(wireId);
+      expect(rows, hasLength(1));
+      expect(rows.first['deletedAt'], isNotNull);
+    });
+
+    test('a failed direct post is queued for retry but NOT reported as '
+        'propagated', () async {
+      const wireId = 'wire-queued';
+      await _insertSentMessage(wireId);
+      MessageModifyService.postDirectOverride = ({
+        required id,
+        required encrypted,
+        required timestamp,
+        required peerId,
+      }) async =>
+          false;
+
+      final service = MessageModifyService.direct(
+        userId: 'me.onion',
+        keyManager: keyManager,
+        peerId: 'peer.onion',
+      );
+      final ok = await service.deleteMessage(targetMessageId: wireId);
+
+      // The peer did not confirm the delete right now: the real transport
+      // result must be reported, even though the row is queued for a later
+      // retry (at-least-once delivery is preserved, the outcome is honest).
+      expect(ok, isFalse);
+      final pending = await PendingMessageDbHelper.getPendingDirectMessagesForReceiver(
+        senderId: 'me.onion',
+        receiverId: 'peer.onion',
+      );
+      expect(
+        pending.where((row) => row['type'] == messageModifyType),
+        hasLength(1),
+      );
+    });
+  });
+
+  group('delete propagation over the HTTP path', () {
+    test('a 4xx on the HTTP transport is NOT reported as a successful delete',
+        () async {
+      const wireId = 'wire-http-reject';
+      await _insertSentMessage(wireId);
+
+      // Store the peer identity so the modify is encrypted for a real send
+      // through the production postman (no test override on this path).
+      final peer = await IdentityKeyPair.generate();
+      final publicJson = jsonEncode(await peer.toPublicJson());
+      await DBHelper.insertOrUpdateUser({
+        'id': 'peer.onion',
+        'name': 'Peer',
+        'identityJson': publicJson,
+        'publicKeyPem': publicJson,
+      });
+
+      // Production TransportProvider wiring: the peer is not WS-connected, so
+      // postMessageOrFallback takes the HTTP fallback, whose postJson answers
+      // with a 400 through the fake client.
+      TransportProvider.configure(
+        TorManager(
+          torPath: '/bin/false',
+          dataDir: '/tmp/prysm-modify-http-test',
+          controlPassword: 'test-password',
+        ),
+      );
+      TorHttpTransport.clientFactory = () => _FakeTorHttpClient(
+        _FakeHttpClientResponse(
+          400,
+          '{"error":"Message modify target not found"}',
+        ),
+      );
+      // The production HTTP path gates on the runtime gate; the default test
+      // lifecycle is `stopped`, which would fail the send for the wrong
+      // reason.
+      TorRuntimeGate.resetForTest();
+
+      try {
+        final service = MessageModifyService.direct(
+          userId: 'me.onion',
+          keyManager: keyManager,
+          peerId: 'peer.onion',
+        );
+        final ok = await service.deleteMessage(targetMessageId: wireId);
+
+        expect(ok, isFalse);
+        // The rejection is queued for a later retry, not dropped.
+        final pending =
+            await PendingMessageDbHelper.getPendingDirectMessagesForReceiver(
+          senderId: 'me.onion',
+          receiverId: 'peer.onion',
+        );
+        expect(
+          pending.where((row) => row['type'] == messageModifyType),
+          hasLength(1),
+        );
+      } finally {
+        TransportProvider.resetForTest();
+        TorHttpTransport.clientFactory = null;
+        TorDelivery.resetForTest();
+        TorRuntimeGate.resetForTest(lifecycle: TorLifecycleState.stopped);
+      }
+    });
+  });
+
+  group('unknown target handling', () {
+    test('a delete for a message the peer no longer has is acked as a '
+        'benign no-op, not a retryable 4xx', () async {
+      final sender = await IdentityKeyPair.generate();
+      final receiver = await IdentityKeyPair.generate();
+      final receiverKm = KeyManager.fromIdentity(receiver);
+      final senderKm = KeyManager.fromIdentity(sender);
+      final publicJson = jsonEncode(await sender.toPublicJson());
+      await DBHelper.insertOrUpdateUser({
+        'id': 'peer.onion',
+        'name': 'Peer',
+        'identityJson': publicJson,
+        'publicKeyPem': publicJson,
+      });
+      final encrypted = await senderKm.encryptHybridForPeer(
+        const MessageModifyPayload(
+          targetMessageId: 'never-existed',
+          action: 'delete',
+          modifiedAt: 5,
+        ).encode(),
+        await _publicKeysOf(receiver),
+        peerId: 'me.onion',
+      );
+
+      final router = InboundMessageRouter(
+        keyManager: receiverKm,
+        settings: SettingsService(),
+        localOnionAddress: () => 'me.onion',
+      );
+      final result = await router.handleMessage({
+        'id': 'modify-event-1',
+        'senderId': 'peer.onion',
+        'receiverId': 'me.onion',
+        'message': encrypted,
+        'type': messageModifyType,
+        'timestamp': 5,
+      });
+
+      // 2xx, not 4xx: the sender's transport must not queue an unbounded
+      // retry of a rejection that can never succeed.
+      expect(result.statusCode, 200);
+    });
+  });
+}

--- a/test/message_modify_service_test.dart
+++ b/test/message_modify_service_test.dart
@@ -435,42 +435,45 @@ void main() {
           controlPassword: 'test-password',
         ),
       );
+      // Registered at the point of assignment: a throw before the asserts
+      // would otherwise leak this process-global wiring into later tests.
+      addTearDown(TransportProvider.resetForTest);
       TorHttpTransport.clientFactory = () => _FakeTorHttpClient(
         _FakeHttpClientResponse(
           400,
           '{"error":"Message modify target not found"}',
         ),
       );
+      addTearDown(() {
+        TorHttpTransport.clientFactory = null;
+        TorDelivery.resetForTest();
+      });
       // The production HTTP path gates on the runtime gate; the default test
       // lifecycle is `stopped`, which would fail the send for the wrong
       // reason.
       TorRuntimeGate.resetForTest();
+      addTearDown(
+        () => TorRuntimeGate.resetForTest(lifecycle: TorLifecycleState.stopped),
+      );
 
-      try {
-        final service = MessageModifyService.direct(
-          userId: 'me.onion',
-          keyManager: keyManager,
-          peerId: 'peer.onion',
-        );
-        final ok = await service.deleteMessage(targetMessageId: wireId);
+      final service = MessageModifyService.direct(
+        userId: 'me.onion',
+        keyManager: keyManager,
+        peerId: 'peer.onion',
+      );
+      final ok = await service.deleteMessage(targetMessageId: wireId);
 
-        expect(ok, isFalse);
-        // The rejection is queued for a later retry, not dropped.
-        final pending =
-            await PendingMessageDbHelper.getPendingDirectMessagesForReceiver(
-          senderId: 'me.onion',
-          receiverId: 'peer.onion',
-        );
-        expect(
-          pending.where((row) => row['type'] == messageModifyType),
-          hasLength(1),
-        );
-      } finally {
-        TransportProvider.resetForTest();
-        TorHttpTransport.clientFactory = null;
-        TorDelivery.resetForTest();
-        TorRuntimeGate.resetForTest(lifecycle: TorLifecycleState.stopped);
-      }
+      expect(ok, isFalse);
+      // The rejection is queued for a later retry, not dropped.
+      final pending =
+          await PendingMessageDbHelper.getPendingDirectMessagesForReceiver(
+        senderId: 'me.onion',
+        receiverId: 'peer.onion',
+      );
+      expect(
+        pending.where((row) => row['type'] == messageModifyType),
+        hasLength(1),
+      );
     });
   });
 
@@ -515,6 +518,77 @@ void main() {
       // 2xx, not 4xx: the sender's transport must not queue an unbounded
       // retry of a rejection that can never succeed.
       expect(result.statusCode, 200);
+    });
+  });
+
+  group('malformed payload handling', () {
+    test('an authenticated envelope with an unparseable payload reports '
+        'malformedPayload, not a decrypt failure', () async {
+      final sender = await IdentityKeyPair.generate();
+      final receiver = await IdentityKeyPair.generate();
+      final receiverKm = KeyManager.fromIdentity(receiver);
+      final senderKm = KeyManager.fromIdentity(sender);
+      final publicJson = jsonEncode(await sender.toPublicJson());
+      await DBHelper.insertOrUpdateUser({
+        'id': 'peer.onion',
+        'name': 'Peer',
+        'identityJson': publicJson,
+        'publicKeyPem': publicJson,
+      });
+      // The envelope authenticates; only its plaintext is not a payload.
+      final encrypted = await senderKm.encryptHybridForPeer(
+        'not a modify payload',
+        await _publicKeysOf(receiver),
+        peerId: 'me.onion',
+      );
+
+      final outcome = await MessageModifyService.applyInbound(
+        keyManager: receiverKm,
+        localUserId: 'me.onion',
+        encrypted: encrypted,
+        senderId: 'peer.onion',
+        type: messageModifyType,
+      );
+
+      expect(outcome, InboundModifyOutcome.malformedPayload);
+    });
+
+    test('a malformed payload answers 4xx, not a 500 that blames our own '
+        'processing', () async {
+      final sender = await IdentityKeyPair.generate();
+      final receiver = await IdentityKeyPair.generate();
+      final receiverKm = KeyManager.fromIdentity(receiver);
+      final senderKm = KeyManager.fromIdentity(sender);
+      final publicJson = jsonEncode(await sender.toPublicJson());
+      await DBHelper.insertOrUpdateUser({
+        'id': 'peer.onion',
+        'name': 'Peer',
+        'identityJson': publicJson,
+        'publicKeyPem': publicJson,
+      });
+      // Well-formed JSON, but not a modify payload: `decode` throws on the
+      // missing `targetMessageId` cast rather than on `jsonDecode`.
+      final encrypted = await senderKm.encryptHybridForPeer(
+        '{"action":"delete"}',
+        await _publicKeysOf(receiver),
+        peerId: 'me.onion',
+      );
+
+      final router = InboundMessageRouter(
+        keyManager: receiverKm,
+        settings: SettingsService(),
+        localOnionAddress: () => 'me.onion',
+      );
+      final result = await router.handleMessage({
+        'id': 'modify-event-2',
+        'senderId': 'peer.onion',
+        'receiverId': 'me.onion',
+        'message': encrypted,
+        'type': messageModifyType,
+        'timestamp': 5,
+      });
+
+      expect(result.statusCode, 400);
     });
   });
 }

--- a/test/tor_http_transport_test.dart
+++ b/test/tor_http_transport_test.dart
@@ -1,6 +1,9 @@
 import 'dart:async';
+import 'dart:convert';
+import 'dart:io';
 
 import 'package:flutter_test/flutter_test.dart';
+import 'package:prysm/client/TorHttpClient.dart';
 import 'package:prysm/transport/tor_http_transport.dart';
 import 'package:prysm/util/tor_delivery.dart';
 import 'package:prysm/util/tor_lifecycle_state.dart';
@@ -60,5 +63,111 @@ void main() {
       await Future.wait([peerAFuture, peerBFuture]);
       transport.dispose();
     });
+
+    test('postJson throws on a 4xx status instead of reporting success',
+        () async {
+      final transport = TorHttpTransport.createForTest(
+        TorManager(torPath: '/bin/false', dataDir: '/tmp/http-transport-4xx', controlPassword: 'test-password'),
+      );
+      addTearDown(transport.dispose);
+      TorHttpTransport.clientFactory = () => _FakeTorHttpClient(
+        _FakeHttpClientResponse(400, '{"error":"Message modify target not found"}'),
+      );
+
+      try {
+        await expectLater(
+          transport.postJson(
+            peerOnion: 'peer.onion',
+            path: 'message',
+            payload: const {'a': 1},
+          ),
+          throwsA(isA<StateError>()),
+        );
+      } finally {
+        TorHttpTransport.clientFactory = null;
+      }
+    });
+
+    test('postJson throws on a 5xx status instead of reporting success',
+        () async {
+      final transport = TorHttpTransport.createForTest(
+        TorManager(torPath: '/bin/false', dataDir: '/tmp/http-transport-5xx', controlPassword: 'test-password'),
+      );
+      addTearDown(transport.dispose);
+      TorHttpTransport.clientFactory = () => _FakeTorHttpClient(
+        _FakeHttpClientResponse(500, '{"error":"Processing failed"}'),
+      );
+
+      try {
+        await expectLater(
+          transport.postJson(
+            peerOnion: 'peer.onion',
+            path: 'message',
+            payload: const {'a': 1},
+          ),
+          throwsA(isA<StateError>()),
+        );
+      } finally {
+        TorHttpTransport.clientFactory = null;
+      }
+    });
+
+    test('postJson returns normally on a 2xx status', () async {
+      final transport = TorHttpTransport.createForTest(
+        TorManager(torPath: '/bin/false', dataDir: '/tmp/http-transport-2xx', controlPassword: 'test-password'),
+      );
+      addTearDown(transport.dispose);
+      TorHttpTransport.clientFactory = () => _FakeTorHttpClient(
+        _FakeHttpClientResponse(200, '{"status":"received"}'),
+      );
+
+      try {
+        await transport.postJson(
+          peerOnion: 'peer.onion',
+          path: 'message',
+          payload: const {'a': 1},
+        );
+      } finally {
+        TorHttpTransport.clientFactory = null;
+      }
+    });
   });
+}
+
+/// [TorHttpClient] whose [post] answers with a canned response, so
+/// [TorHttpTransport.postJson]'s production status handling is exercised
+/// without a live Tor circuit. The inherited [TorHttpClient.readUtf8Body] is
+/// the production body reader.
+class _FakeTorHttpClient extends TorHttpClient {
+  _FakeTorHttpClient(this.response)
+      : super(proxyHost: '127.0.0.1', proxyPort: 9050);
+
+  final HttpClientResponse response;
+
+  @override
+  Future<HttpClientResponse> post(
+    Uri uri,
+    Map<String, String> headers,
+    String body,
+  ) async =>
+      response;
+}
+
+/// Minimal [HttpClientResponse]: only [statusCode] and the byte stream
+/// consumed by [TorHttpClient.readUtf8Body] are implemented; every other
+/// member falls through to [Object.noSuchMethod].
+class _FakeHttpClientResponse implements HttpClientResponse {
+  _FakeHttpClientResponse(this.statusCode, this.body);
+
+  @override
+  final int statusCode;
+
+  final String body;
+
+  @override
+  Stream<S> transform<S>(StreamTransformer<List<int>, S> transformer) =>
+      Stream<List<int>>.value(utf8.encode(body)).transform(transformer);
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
 }

--- a/test/tor_http_transport_test.dart
+++ b/test/tor_http_transport_test.dart
@@ -73,19 +73,16 @@ void main() {
       TorHttpTransport.clientFactory = () => _FakeTorHttpClient(
         _FakeHttpClientResponse(400, '{"error":"Message modify target not found"}'),
       );
+      addTearDown(() => TorHttpTransport.clientFactory = null);
 
-      try {
-        await expectLater(
-          transport.postJson(
-            peerOnion: 'peer.onion',
-            path: 'message',
-            payload: const {'a': 1},
-          ),
-          throwsA(isA<StateError>()),
-        );
-      } finally {
-        TorHttpTransport.clientFactory = null;
-      }
+      await expectLater(
+        transport.postJson(
+          peerOnion: 'peer.onion',
+          path: 'message',
+          payload: const {'a': 1},
+        ),
+        throwsA(isA<PeerHttpStatusException>()),
+      );
     });
 
     test('postJson throws on a 5xx status instead of reporting success',
@@ -97,19 +94,57 @@ void main() {
       TorHttpTransport.clientFactory = () => _FakeTorHttpClient(
         _FakeHttpClientResponse(500, '{"error":"Processing failed"}'),
       );
+      addTearDown(() => TorHttpTransport.clientFactory = null);
 
+      await expectLater(
+        transport.postJson(
+          peerOnion: 'peer.onion',
+          path: 'message',
+          payload: const {'a': 1},
+        ),
+        throwsA(isA<PeerHttpStatusException>()),
+      );
+    });
+
+    test('a hostile response body cannot buy retries or a circuit reset',
+        () async {
+      final transport = TorHttpTransport.createForTest(
+        TorManager(torPath: '/bin/false', dataDir: '/tmp/http-transport-hostile', controlPassword: 'test-password'),
+      );
+      addTearDown(transport.dispose);
+      // TorDelivery classifies by substring on the error text, so a peer that
+      // answers with these tokens in its body would otherwise be treated as a
+      // transient circuit failure: three retries and a global NEWNYM per
+      // delivery, remotely triggerable.
+      var posts = 0;
+      TorHttpTransport.clientFactory = () {
+        posts++;
+        return _FakeTorHttpClient(
+          _FakeHttpClientResponse(
+            400,
+            'hostUnreachable general SOCKS server failure ttlExpired',
+          ),
+        );
+      };
+      addTearDown(() => TorHttpTransport.clientFactory = null);
+
+      Object? thrown;
       try {
-        await expectLater(
-          transport.postJson(
+        await TorDelivery.withTorRetry<void>(
+          attempt: () => transport.postJson(
             peerOnion: 'peer.onion',
             path: 'message',
             payload: const {'a': 1},
           ),
-          throwsA(isA<StateError>()),
         );
-      } finally {
-        TorHttpTransport.clientFactory = null;
+      } catch (e) {
+        thrown = e;
       }
+
+      expect(thrown, isA<PeerHttpStatusException>());
+      expect(posts, 1, reason: 'a peer-chosen body must not earn a retry');
+      expect(TorDelivery.isRetryableError(thrown!), isFalse);
+      expect(TorDelivery.isCircuitError(thrown), isFalse);
     });
 
     test('postJson returns normally on a 2xx status', () async {
@@ -120,16 +155,13 @@ void main() {
       TorHttpTransport.clientFactory = () => _FakeTorHttpClient(
         _FakeHttpClientResponse(200, '{"status":"received"}'),
       );
+      addTearDown(() => TorHttpTransport.clientFactory = null);
 
-      try {
-        await transport.postJson(
-          peerOnion: 'peer.onion',
-          path: 'message',
-          payload: const {'a': 1},
-        );
-      } finally {
-        TorHttpTransport.clientFactory = null;
-      }
+      await transport.postJson(
+        peerOnion: 'peer.onion',
+        path: 'message',
+        payload: const {'a': 1},
+      );
     });
   });
 }

--- a/test/ws_frame_router_test.dart
+++ b/test/ws_frame_router_test.dart
@@ -85,6 +85,28 @@ void main() {
     expect(frame.id, 'req-2');
   });
 
+  test('message_modify returns an error frame when processing throws', () async {
+    final router = WsFrameRouter()..routerOverride = _ThrowingModifyRouter();
+
+    const payload = {
+      'id': 'modify-3',
+      'senderId': 'aaa.onion',
+      'receiverId': 'bbb.onion',
+      'message': 'cipher',
+      'type': 'message_modify',
+      'timestamp': 1,
+    };
+
+    final responses = await router.handleInboundFrame(
+      const WsFrame(op: 'message_modify', id: 'req-4', payload: payload),
+    );
+
+    expect(responses, hasLength(1));
+    final frame = WsFrame.decode(responses.first);
+    expect(frame.op, 'error');
+    expect(frame.id, 'req-4');
+  });
+
   test('other side-channel ops keep the optimistic fast ack', () async {
     final inbound = _SlowSideChannelRouter();
     final router = WsFrameRouter()..routerOverride = inbound;
@@ -126,6 +148,20 @@ class _FailingModifyRouter extends InboundMessageRouter {
   @override
   Future<InboundHandleResult> processMessage(Map<String, dynamic> data) async {
     return InboundHandleResult.internalError('modify rejected');
+  }
+}
+
+class _ThrowingModifyRouter extends InboundMessageRouter {
+  _ThrowingModifyRouter()
+      : super(
+          keyManager: KeyManager(),
+          settings: SettingsService(),
+          localOnionAddress: () => 'bbb.onion',
+        );
+
+  @override
+  Future<InboundHandleResult> processMessage(Map<String, dynamic> data) async {
+    throw StateError('modify processing crashed');
   }
 }
 

--- a/test/ws_frame_router_test.dart
+++ b/test/ws_frame_router_test.dart
@@ -1,6 +1,11 @@
+import 'dart:async';
+
 import 'package:flutter_test/flutter_test.dart';
+import 'package:prysm/server/inbound_message_router.dart';
+import 'package:prysm/services/settings_service.dart';
 import 'package:prysm/transport/ws_frame_router.dart';
 import 'package:prysm/transport/ws_protocol.dart';
+import 'package:prysm/util/key_manager.dart';
 
 void main() {
   test('ping returns pong', () async {
@@ -34,4 +39,131 @@ void main() {
     );
     expect(router.isPeerRequest(const WsFrame(op: 'ping')), isTrue);
   });
+
+  test('message_modify is verified before ack: a processing failure is not '
+      'acked', () async {
+    final router = WsFrameRouter()..routerOverride = _FailingModifyRouter();
+
+    const payload = {
+      'id': 'modify-1',
+      'senderId': 'aaa.onion',
+      'receiverId': 'bbb.onion',
+      'message': 'cipher',
+      'type': 'message_modify',
+      'timestamp': 1,
+    };
+
+    final responses = await router.handleInboundFrame(
+      const WsFrame(op: 'message_modify', id: 'req-1', payload: payload),
+    );
+
+    expect(responses, hasLength(1));
+    final frame = WsFrame.decode(responses.first);
+    expect(frame.op, 'error');
+    expect(frame.id, 'req-1');
+  });
+
+  test('message_modify still acks when processing succeeds', () async {
+    final router = WsFrameRouter()..routerOverride = _OkModifyRouter();
+
+    const payload = {
+      'id': 'modify-2',
+      'senderId': 'aaa.onion',
+      'receiverId': 'bbb.onion',
+      'message': 'cipher',
+      'type': 'message_modify',
+      'timestamp': 1,
+    };
+
+    final responses = await router.handleInboundFrame(
+      const WsFrame(op: 'message_modify', id: 'req-2', payload: payload),
+    );
+
+    expect(responses, hasLength(1));
+    final frame = WsFrame.decode(responses.first);
+    expect(frame.op, 'message_modify_ack');
+    expect(frame.id, 'req-2');
+  });
+
+  test('other side-channel ops keep the optimistic fast ack', () async {
+    final inbound = _SlowSideChannelRouter();
+    final router = WsFrameRouter()..routerOverride = inbound;
+
+    const payload = {
+      'id': 'rr-1',
+      'senderId': 'aaa.onion',
+      'receiverId': 'bbb.onion',
+      'message': 'cipher',
+      'type': 'read_receipt',
+      'timestamp': 1,
+    };
+
+    final responses = await router.handleInboundFrame(
+      const WsFrame(op: 'read_update', id: 'req-3', payload: payload),
+    );
+
+    expect(responses, hasLength(1));
+    final ack = WsFrame.decode(responses.first);
+    expect(ack.op, 'read_update_ack');
+    expect(ack.id, 'req-3');
+    // The ack is sent while async processing is still in flight.
+    expect(inbound.processStarted.isCompleted, isTrue);
+    expect(inbound.processFinished.isCompleted, isFalse);
+
+    inbound.allowProcessComplete.complete();
+    await inbound.processFinished.future;
+  });
+}
+
+class _FailingModifyRouter extends InboundMessageRouter {
+  _FailingModifyRouter()
+      : super(
+          keyManager: KeyManager(),
+          settings: SettingsService(),
+          localOnionAddress: () => 'bbb.onion',
+        );
+
+  @override
+  Future<InboundHandleResult> processMessage(Map<String, dynamic> data) async {
+    return InboundHandleResult.internalError('modify rejected');
+  }
+}
+
+class _OkModifyRouter extends InboundMessageRouter {
+  _OkModifyRouter()
+      : super(
+          keyManager: KeyManager(),
+          settings: SettingsService(),
+          localOnionAddress: () => 'bbb.onion',
+        );
+
+  @override
+  Future<InboundHandleResult> processMessage(Map<String, dynamic> data) async {
+    return InboundHandleResult.ok({'status': 'received', 'id': data['id']});
+  }
+}
+
+class _SlowSideChannelRouter extends InboundMessageRouter {
+  _SlowSideChannelRouter()
+      : super(
+          keyManager: KeyManager(),
+          settings: SettingsService(),
+          localOnionAddress: () => 'bbb.onion',
+        );
+
+  final processStarted = Completer<void>();
+  final processFinished = Completer<void>();
+  final allowProcessComplete = Completer<void>();
+
+  @override
+  Future<InboundHandleResult> processMessage(Map<String, dynamic> data) async {
+    if (!processStarted.isCompleted) {
+      processStarted.complete();
+    }
+    await allowProcessComplete.future;
+    if (!processFinished.isCompleted) {
+      processFinished.complete();
+    }
+    return InboundHandleResult.ok({'status': 'received', 'id': data['id']});
+  }
 }


### PR DESCRIPTION
## Problem

Reported as "my friend cannot delete messages". The delete UI is fine; the propagated delete was
being lost without a trace, on four independent counts:

- `MessageModifyService.applyInbound` swallowed every decrypt failure and returned silently.
- `WsFrameRouter` acked `message_modify` **before** processing it, so the sender's transport
  reported success regardless of the outcome.
- The HTTP fallback never inspected the status code — `grep statusCode` over the HTTP transport
  matched nothing — so a 4xx rejection was read as a body and reported as a successful send. This
  is the path a delete takes whenever the peer's WebSocket is down.
- `deleteMessage` discarded the transport result and returned a hardcoded `true`.

Net effect: the deleter saw a tombstone, the recipient kept the message, and nothing anywhere
reported a failure.

## Change

- Categorise and log inbound modify failures, distinguishing "could not authenticate" from
  "unknown target" from "ownership rejected".
- Verify-then-ack for `message_modify` only, so a rejection reaches the sender and the existing
  queue/retry machinery engages. Ordinary `message` frames keep the optimistic ack.
- Surface non-2xx from the HTTP transport so the fallback path behaves like the WebSocket path.
- Propagate the real propagation result out of the direct and group modify paths into the failure
  state the screens already render.
- Ack `unknownTarget` as the benign no-op its own enum documents, instead of returning a 4xx that
  queued a pending row and re-sent it on every sync cycle forever — the case where the peer
  legitimately no longer holds the message.

## Security

The unsigned-envelope gate is **unchanged**. A delete that cannot be authenticated is still
rejected; it is simply no longer rejected in silence. `allowLegacyUnsignedDhAead` is untouched.

A peer on <= v0.6.3 emits legacy unsigned envelopes, so its deletes remain refused. That is the
intended outcome; the change makes the refusal visible instead of invisible.

## Verification

`flutter analyze` clean; full suite green on this branch. Each behaviour has a test that fails on
the pre-fix code.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved message deletion failure handling by preserving local tombstones, marking failed deletions, and notifying users.
  * Improved message delivery status reporting, including queued and failed operations.
  * Added clearer handling for invalid, undecryptable, unauthorized, or missing message modifications.
  * Prevented unsuccessful network responses from being reported as successful deliveries.
  * Improved real-time message modification acknowledgments and error reporting.

* **Tests**
  * Added comprehensive coverage for deletion failures, message modifications, transport errors, and acknowledgment behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->