### PR TITLE
fix(ui): keep the composer from overflowing with the keyboard open

### DIFF
--- a/lib/screens/chat.dart
+++ b/lib/screens/chat.dart
@@ -30,6 +30,7 @@ import 'package:prysm/database/messages.dart';
 import 'package:prysm/screens/chat_profile_screen.dart';
 import 'package:prysm/ui/chat/prysm_bubble_renderer.dart';
 import 'package:prysm/ui/chat/prysm_chat_composer_column.dart';
+import 'package:prysm/ui/chat/prysm_constrained_composer.dart';
 import 'package:prysm/ui/chat/prysm_chat_list.dart';
 import 'package:prysm/ui/chat/chat_search_bar.dart';
 import 'package:prysm/ui/chat/prysm_date_header.dart';
@@ -1724,52 +1725,62 @@ class _ChatScreenState extends State<ChatScreen> {
       body: PrysmChatDropTarget(
         enabled: !_isPeerBlocked,
         onFileDropped: _handleDroppedFile,
-        child: Column(
-          children: [
-            Expanded(
-              child: PrysmChatList(
-                controller: _messages,
-                scrollController: _listScrollController,
-                onLoadMore: _controller.loadMoreMessages,
-                showJumpToBottom: selectedMessageIds.isEmpty,
-                onStickToBottomChanged: _controller.setStickToBottomSilently,
-                itemBuilder: _buildChatListItem,
-              ),
-            ),
-            if (_isPeerBlocked)
-              Container(
-                padding: const EdgeInsets.symmetric(
-                  horizontal: 16,
-                  vertical: 14,
+        child: LayoutBuilder(
+          builder: (context, constraints) => Column(
+            children: [
+              Expanded(
+                child: PrysmChatList(
+                  controller: _messages,
+                  scrollController: _listScrollController,
+                  onLoadMore: _controller.loadMoreMessages,
+                  showJumpToBottom: selectedMessageIds.isEmpty,
+                  onStickToBottomChanged: _controller.setStickToBottomSilently,
+                  itemBuilder: _buildChatListItem,
                 ),
-                decoration: BoxDecoration(
-                  color: context.prysmTokens.surfaceElevated,
-                  border: Border(
-                    top: BorderSide(color: context.prysmTokens.divider),
+              ),
+              if (_isPeerBlocked)
+                Container(
+                  padding: const EdgeInsets.symmetric(
+                    horizontal: 16,
+                    vertical: 14,
+                  ),
+                  decoration: BoxDecoration(
+                    color: context.prysmTokens.surfaceElevated,
+                    border: Border(
+                      top: BorderSide(color: context.prysmTokens.divider),
+                    ),
+                  ),
+                  child: Text(
+                    'Unblock to send messages',
+                    textAlign: TextAlign.center,
+                    style: TextStyle(color: context.prysmTokens.textMuted),
+                  ),
+                )
+              else
+                // With the keyboard open the app content is padded by the
+                // full keyboard inset (PrysmApp), so the composer (reply
+                // preview + typing bar + input row) can be taller than the
+                // body's remaining height; constrain and scroll it instead of
+                // overflowing the body Column.
+                PrysmConstrainedComposer(
+                  maxHeight: constraints.maxHeight,
+                  composer: PrysmChatComposerColumn(
+                    draftKey: _draftKey,
+                    replyPreview: _controller.replyToMessage != null || _controller.replyDraft != null
+                        ? _buildReplyPreview()
+                        : null,
+                    typingTypistNames: _controller.typingTypistNames(),
+                    onSendText: _controller.handleSendText,
+                    onSendImage: _handleSendImage,
+                    onSendFile: _handleSendFile,
+                    onSendVoice: _controller.sendVoice,
+                    onScheduleText:
+                        widget.detachedClient == null ? _scheduleText : null,
+                    onTypingChanged: _controller.onComposerTypingChanged,
                   ),
                 ),
-                child: Text(
-                  'Unblock to send messages',
-                  textAlign: TextAlign.center,
-                  style: TextStyle(color: context.prysmTokens.textMuted),
-                ),
-              )
-            else
-              PrysmChatComposerColumn(
-                draftKey: _draftKey,
-                replyPreview: _controller.replyToMessage != null || _controller.replyDraft != null
-                    ? _buildReplyPreview()
-                    : null,
-                typingTypistNames: _controller.typingTypistNames(),
-                onSendText: _controller.handleSendText,
-                onSendImage: _handleSendImage,
-                onSendFile: _handleSendFile,
-                onSendVoice: _controller.sendVoice,
-                onScheduleText:
-                    widget.detachedClient == null ? _scheduleText : null,
-                onTypingChanged: _controller.onComposerTypingChanged,
-              ),
-          ],
+            ],
+          ),
         ),
       ),
     );

--- a/lib/screens/group_chat.dart
+++ b/lib/screens/group_chat.dart
@@ -25,6 +25,7 @@ import 'package:prysm/models/group.dart';
 import 'package:prysm/screens/group_settings_screen.dart';
 import 'package:prysm/ui/chat/prysm_bubble_renderer.dart';
 import 'package:prysm/ui/chat/prysm_chat_composer_column.dart';
+import 'package:prysm/ui/chat/prysm_constrained_composer.dart';
 import 'package:prysm/ui/chat/prysm_date_header.dart';
 import 'package:prysm/ui/chat/prysm_chat_list.dart';
 import 'package:prysm/ui/chat/chat_search_bar.dart';
@@ -1664,33 +1665,42 @@ class _GroupChatScreenState extends State<GroupChatScreen> {
           : null,
       body: PrysmChatDropTarget(
         onFileDropped: _handleDroppedFile,
-        child: Column(
-          children: [
-            Expanded(
-              child: PrysmChatList(
-                controller: _messages,
-                scrollController: _listScrollController,
-                onLoadMore: _controller.loadMoreMessages,
-                showJumpToBottom: selectedMessageIds.isEmpty,
-                onStickToBottomChanged: _controller.setStickToBottomSilently,
-                itemBuilder: _buildGroupChatListItem,
+        child: LayoutBuilder(
+          builder: (context, constraints) => Column(
+            children: [
+              Expanded(
+                child: PrysmChatList(
+                  controller: _messages,
+                  scrollController: _listScrollController,
+                  onLoadMore: _controller.loadMoreMessages,
+                  showJumpToBottom: selectedMessageIds.isEmpty,
+                  onStickToBottomChanged: _controller.setStickToBottomSilently,
+                  itemBuilder: _buildGroupChatListItem,
+                ),
               ),
-            ),
-            PrysmChatComposerColumn(
-              draftKey: _draftKey,
-              replyPreview: _controller.replyToMessage != null || _controller.replyDraft != null
-                  ? _buildReplyPreview()
-                  : null,
-              typingTypistNames: _controller.typingTypistNames(),
-              onSendText: _controller.handleSendText,
-              onSendImage: _handleSendImage,
-              onSendFile: _handleSendFile,
-              onSendVoice: _controller.sendVoice,
-              onScheduleText:
-                  widget.detachedClient == null ? _scheduleText : null,
-              onTypingChanged: _controller.onComposerTypingChanged,
-            ),
-          ],
+              // Same keyboard-inset overflow as the 1:1 chat body: the
+              // composer is a non-flex Column child laid out with unbounded
+              // main-axis constraints, so constrain and scroll it instead of
+              // overflowing.
+              PrysmConstrainedComposer(
+                maxHeight: constraints.maxHeight,
+                composer: PrysmChatComposerColumn(
+                  draftKey: _draftKey,
+                  replyPreview: _controller.replyToMessage != null || _controller.replyDraft != null
+                      ? _buildReplyPreview()
+                      : null,
+                  typingTypistNames: _controller.typingTypistNames(),
+                  onSendText: _controller.handleSendText,
+                  onSendImage: _handleSendImage,
+                  onSendFile: _handleSendFile,
+                  onSendVoice: _controller.sendVoice,
+                  onScheduleText:
+                      widget.detachedClient == null ? _scheduleText : null,
+                  onTypingChanged: _controller.onComposerTypingChanged,
+                ),
+              ),
+            ],
+          ),
         ),
       ),
     );

--- a/lib/screens/pin_entry.dart
+++ b/lib/screens/pin_entry.dart
@@ -148,61 +148,67 @@ class _PinScreenState extends State<PinScreen> {
         color: tokens.background,
         child: SafeArea(
           child: Center(
-            child: Column(
-              mainAxisAlignment: MainAxisAlignment.center,
-              children: [
-                Text(
-                  _title,
-                  style: TextStyle(
-                    color: tokens.textPrimary,
-                    fontWeight: FontWeight.w500,
-                    fontSize: 30,
-                  ),
-                ),
-                if (widget.showBiometricButton &&
-                    !_isSetup &&
-                    widget.onTryBiometric != null) ...[
-                  const SizedBox(height: 16),
-                  PrysmIconButton(
-                    icon: PrysmIcons.fingerprint,
-                    tooltip: 'Unlock with biometrics',
-                    onPressed: widget.onTryBiometric,
-                  ),
-                ],
-                const SizedBox(height: 30),
-                isLoading
-                    ? const PrysmProgressIndicator()
-                    : PinDots(filledCount: _pin.length),
-                if (error != null) ...[
-                  const SizedBox(height: 12),
+            // The fixed-height keypad (4x80px rows plus spacing) plus title,
+            // biometrics, lockout status and Tor progress can exceed the
+            // screen height on small devices; scroll instead of overflowing.
+            child: SingleChildScrollView(
+              padding: const EdgeInsets.symmetric(vertical: 24),
+              child: Column(
+                mainAxisSize: MainAxisSize.min,
+                children: [
                   Text(
-                    error!,
-                    style: TextStyle(color: tokens.danger),
-                  ),
-                ],
-                UnlockLockoutStatus(
-                  showAttemptsRemaining: !_isSetup,
-                  lastFailure: _lastFailure,
-                ),
-                if (widget.torBootstrapProgress != null) ...[
-                  const SizedBox(height: 16),
-                  Text(
-                    'Tor: ${widget.torBootstrapProgress}%',
+                    _title,
                     style: TextStyle(
-                      fontSize: 13,
-                      color: tokens.textPrimary.withValues(alpha: 0.6),
+                      color: tokens.textPrimary,
+                      fontWeight: FontWeight.w500,
+                      fontSize: 30,
+                    ),
+                  ),
+                  if (widget.showBiometricButton &&
+                      !_isSetup &&
+                      widget.onTryBiometric != null) ...[
+                    const SizedBox(height: 16),
+                    PrysmIconButton(
+                      icon: PrysmIcons.fingerprint,
+                      tooltip: 'Unlock with biometrics',
+                      onPressed: widget.onTryBiometric,
+                    ),
+                  ],
+                  const SizedBox(height: 30),
+                  isLoading
+                      ? const PrysmProgressIndicator()
+                      : PinDots(filledCount: _pin.length),
+                  if (error != null) ...[
+                    const SizedBox(height: 12),
+                    Text(
+                      error!,
+                      style: TextStyle(color: tokens.danger),
+                    ),
+                  ],
+                  UnlockLockoutStatus(
+                    showAttemptsRemaining: !_isSetup,
+                    lastFailure: _lastFailure,
+                  ),
+                  if (widget.torBootstrapProgress != null) ...[
+                    const SizedBox(height: 16),
+                    Text(
+                      'Tor: ${widget.torBootstrapProgress}%',
+                      style: TextStyle(
+                        fontSize: 13,
+                        color: tokens.textPrimary.withValues(alpha: 0.6),
+                      ),
+                    ),
+                  ],
+                  const SizedBox(height: 50),
+                  Opacity(
+                    opacity: inputDisabled ? 0.4 : 1,
+                    child: IgnorePointer(
+                      ignoring: inputDisabled,
+                      child: PinKeypad(onKeyPress: _onKeyPress),
                     ),
                   ),
                 ],
-                const SizedBox(height: 50),
-                Opacity(
-                  opacity: inputDisabled ? 0.4 : 1,
-                  child: IgnorePointer(
-                    ignoring: inputDisabled,
-                    child: PinKeypad(onKeyPress: _onKeyPress),
-                  ),
-                ),
-              ],
+              ),
             ),
           ),
         ),

--- a/lib/screens/self_chat_screen.dart
+++ b/lib/screens/self_chat_screen.dart
@@ -28,6 +28,7 @@ import 'package:prysm/services/self_chat_service.dart';
 import 'package:prysm/util/chat_attachment_ingress.dart';
 import 'package:prysm/theme/prysm_theme.dart';
 import 'package:prysm/ui/chat/prysm_chat_composer_column.dart';
+import 'package:prysm/ui/chat/prysm_constrained_composer.dart';
 import 'package:prysm/ui/chat/prysm_chat_list.dart';
 import 'package:prysm/ui/chat/chat_search_bar.dart';
 import 'package:prysm/models/conversation.dart';
@@ -650,88 +651,97 @@ class _SelfChatScreenState extends State<SelfChatScreen> {
           : null,
       body: PrysmChatDropTarget(
         onFileDropped: _handleDroppedFile,
-        child: Column(
-          children: [
-            Expanded(
-              child: PrysmChatList(
-                controller: _controller.messages,
-                scrollController: _scrollController,
-                onLoadMore: _controller.loadMoreMessages,
-                onStickToBottomChanged: _controller.setStickToBottomSilently,
-                itemBuilder: (context, message, index) {
-                  final showHeader = shouldShowChatDateHeader(
-                    _controller.messages.messages,
-                    index,
-                  );
-                  final msgDate = message.createdAt ?? DateTime.now();
-                  Widget child;
-                  if (message is TextMessage) {
-                    child = _textMessageBuilder(
-                      context,
-                      message,
+        child: LayoutBuilder(
+          builder: (context, constraints) => Column(
+            children: [
+              Expanded(
+                child: PrysmChatList(
+                  controller: _controller.messages,
+                  scrollController: _scrollController,
+                  onLoadMore: _controller.loadMoreMessages,
+                  onStickToBottomChanged: _controller.setStickToBottomSilently,
+                  itemBuilder: (context, message, index) {
+                    final showHeader = shouldShowChatDateHeader(
+                      _controller.messages.messages,
                       index,
-                      isSentByMe: true,
                     );
-                  } else if (message is ImageMessage) {
-                    child = _imageMessageBuilder(
-                      context,
-                      message,
-                      index,
-                      isSentByMe: true,
-                    );
-                  } else if (message is FileMessage) {
-                    child = _fileMessageBuilder(
-                      context,
-                      message,
-                      index,
-                      isSentByMe: true,
-                    );
-                  } else {
-                    child = const SizedBox.shrink();
-                  }
-
-                  final isHighlighted = _highlightedMessageId == message.id;
-                  final tokens = context.prysmStyle.tokens;
-
-                  return Column(
-                    children: [
-                      if (showHeader) PrysmDateHeader(date: msgDate),
-                      GestureDetector(
-                        onLongPress: () => _showMessageMenu(context, message),
-                        child: ColoredBox(
-                          color: isHighlighted
-                              ? Color.lerp(
-                                  tokens.background,
-                                  tokens.accentMuted,
-                                  0.25,
-                                )!
-                              : const Color(0x00000000),
-                          child: Padding(
-                            padding: const EdgeInsets.symmetric(vertical: 4),
-                            child: Row(
-                              mainAxisAlignment: MainAxisAlignment.end,
-                              children: [
-                                Flexible(
-                                  child: _displayChildForMessage(message, child),
-                                ),
-                              ],
+                    final msgDate = message.createdAt ?? DateTime.now();
+                    Widget child;
+                    if (message is TextMessage) {
+                      child = _textMessageBuilder(
+                        context,
+                        message,
+                        index,
+                        isSentByMe: true,
+                      );
+                    } else if (message is ImageMessage) {
+                      child = _imageMessageBuilder(
+                        context,
+                        message,
+                        index,
+                        isSentByMe: true,
+                      );
+                    } else if (message is FileMessage) {
+                      child = _fileMessageBuilder(
+                        context,
+                        message,
+                        index,
+                        isSentByMe: true,
+                      );
+                    } else {
+                      child = const SizedBox.shrink();
+                    }
+  
+                    final isHighlighted = _highlightedMessageId == message.id;
+                    final tokens = context.prysmStyle.tokens;
+  
+                    return Column(
+                      children: [
+                        if (showHeader) PrysmDateHeader(date: msgDate),
+                        GestureDetector(
+                          onLongPress: () => _showMessageMenu(context, message),
+                          child: ColoredBox(
+                            color: isHighlighted
+                                ? Color.lerp(
+                                    tokens.background,
+                                    tokens.accentMuted,
+                                    0.25,
+                                  )!
+                                : const Color(0x00000000),
+                            child: Padding(
+                              padding: const EdgeInsets.symmetric(vertical: 4),
+                              child: Row(
+                                mainAxisAlignment: MainAxisAlignment.end,
+                                children: [
+                                  Flexible(
+                                    child: _displayChildForMessage(message, child),
+                                  ),
+                                ],
+                              ),
                             ),
                           ),
                         ),
-                      ),
-                    ],
-                  );
-                },
+                      ],
+                    );
+                  },
+                ),
               ),
-            ),
-            PrysmChatComposerColumn(
-              draftKey: 'self:${widget.userId}',
-              onSendText: _handleSendText,
-              onSendImage: _handleSendImage,
-              onSendFile: _handleSendFile,
-              onSendVoice: _handleSendVoice,
-            ),
-          ],
+              // Same keyboard-inset overflow as the 1:1 chat body: the
+              // composer is a non-flex Column child laid out with unbounded
+              // main-axis constraints, so constrain and scroll it instead of
+              // overflowing.
+              PrysmConstrainedComposer(
+                maxHeight: constraints.maxHeight,
+                composer: PrysmChatComposerColumn(
+                  draftKey: 'self:${widget.userId}',
+                  onSendText: _handleSendText,
+                  onSendImage: _handleSendImage,
+                  onSendFile: _handleSendFile,
+                  onSendVoice: _handleSendVoice,
+                ),
+              ),
+            ],
+          ),
         ),
       ),
     );

--- a/lib/ui/chat/prysm_constrained_composer.dart
+++ b/lib/ui/chat/prysm_constrained_composer.dart
@@ -1,0 +1,35 @@
+import 'package:flutter/widgets.dart';
+
+/// Bottom-composer wrapper shared by the 1:1, group and self chat bodies.
+///
+/// The chat body is `Column [ Expanded(list), composer ]`: the composer is a
+/// non-flex child, so with the keyboard open the app content is padded by the
+/// full keyboard inset (PrysmApp) and the composer (reply preview + typing
+/// bar + input row) can be taller than the body's remaining height and
+/// overflow the outer Column. Constrain it to the available height and let it
+/// scroll instead.
+class PrysmConstrainedComposer extends StatelessWidget {
+  const PrysmConstrainedComposer({
+    required this.maxHeight,
+    required this.composer,
+    super.key,
+  });
+
+  /// The height the chat body can still give the composer (the body
+  /// LayoutBuilder's `constraints.maxHeight`).
+  final double maxHeight;
+
+  /// The bottom composer column ([PrysmChatComposerColumn]).
+  final Widget composer;
+
+  @override
+  Widget build(BuildContext context) {
+    return ConstrainedBox(
+      constraints: BoxConstraints(maxHeight: maxHeight),
+      child: SingleChildScrollView(
+        reverse: true,
+        child: composer,
+      ),
+    );
+  }
+}

--- a/test/renderflex_overflow_test.dart
+++ b/test/renderflex_overflow_test.dart
@@ -1,0 +1,217 @@
+// Widget tests for the bottom RenderFlex overflows seen on a real Android
+// device (prysm_chat.log, 2026-08-09): "A RenderFlex overflowed by 34 pixels
+// on the bottom" ~6s after app start, and three "overflowed by 18 pixels on
+// the bottom" during an active 1:1 chat.
+//
+// The log does not capture the widget tree, so the suspects are reproduced
+// structurally from the screens active at those moments:
+//  - app startup: the PIN unlock screen (fixed-height centered column that
+//    ends with a 400px keypad, plus biometric button and Tor progress);
+//  - active chat: the composer column at the bottom of the chat body. The
+//    body is `Column [ Expanded(list), composer ]` (chat.dart:1758-1810) and
+//    the whole app is padded by the keyboard inset in PrysmApp's builder
+//    (prysm_app.dart:47-51), so with the keyboard open the composer's fixed
+//    intrinsic height (reply preview + typing bar + input row) can exceed the
+//    body's remaining height and overflow the outer Column.
+//
+// ChatScreen itself is not pumpable in a widget test (its initState drives
+// ChatService/sqflite, the same hang documented for
+// group_invite_mode_screens_test.dart and HANDOFF.md), so the chat tests pump
+// the body layout with the real shared widgets: the fixed-structure test
+// builds the exact `LayoutBuilder -> Column [ Expanded(list),
+// PrysmConstrainedComposer ]` body the 1:1, group and self chat screens
+// share (lib/ui/chat/prysm_constrained_composer.dart), and the pre-fix test
+// pumps the real PrysmChatComposerColumn as a plain non-flex Column child to
+// prove that same setup overflows without the wrapper. The PIN test pumps the
+// real PinScreen.
+//
+// Style follows quoted_reply_preview_test.dart / view_once_image_screen_test.dart:
+// testWidgets/pumpWidget with a hand-resolved PrysmStyleScope.
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:prysm/models/appearance_settings.dart';
+import 'package:prysm/models/reply_preview_data.dart';
+import 'package:prysm/screens/pin_entry.dart';
+import 'package:prysm/screens/widgets/quoted_reply_preview.dart';
+import 'package:prysm/services/unlock_lockout_service.dart';
+import 'package:prysm/theme/prysm_style_resolver.dart';
+import 'package:prysm/theme/prysm_style_scope.dart';
+import 'package:prysm/ui/chat/prysm_chat_composer_column.dart';
+import 'package:prysm/ui/chat/prysm_constrained_composer.dart';
+import 'package:prysm/ui/prysm_scaffold.dart';
+
+Widget wrapWithStyle(Widget child) {
+  final style = PrysmStyleResolver.resolve(
+    themePalette: 0,
+    appearance: const AppearanceSettings(),
+  );
+  return PrysmStyleScope(style: style, child: child);
+}
+
+/// Pumps a chat body the way ChatScreen.build does (chat.dart:1761-1810)
+/// inside PrysmApp's keyboard-inset padding (prysm_app.dart:47-51).
+///
+/// [wrapBody] lets the test exercise both the pre-fix structure (composer as
+/// a plain non-flex child of the body Column) and the fixed structure (the
+/// shared [PrysmConstrainedComposer] the 1:1, group and self chat screens
+/// build, constrained to the body's remaining height and scrollable).
+Future<void> pumpChatBody(
+  WidgetTester tester, {
+  required Widget Function(Widget list, Widget composer) wrapBody,
+  required double logicalWidth,
+  required double logicalHeight,
+  required double keyboardInset,
+}) async {
+  tester.view.physicalSize = Size(logicalWidth * 3, logicalHeight * 3);
+  tester.view.devicePixelRatio = 3.0;
+  tester.view.viewInsets = FakeViewPadding(bottom: keyboardInset * 3);
+  addTearDown(tester.view.reset);
+
+  final composer = PrysmChatComposerColumn(
+    draftKey: 'overflow-test',
+    replyPreview: QuotedReplyPreview(
+      data: const ReplyPreviewData(
+        messageId: '1',
+        authorId: 'a',
+        label: 'A quoted message that wraps onto two lines',
+        kind: ReplyPreviewKind.text,
+      ),
+      isSentByMe: false,
+      authorName: 'Alice',
+    ),
+    typingTypistNames: const ['Alice'],
+    onSendText: (_) {},
+    onSendImage: () {},
+    onSendFile: () {},
+  );
+  final list = ListView.builder(
+    itemCount: 0,
+    itemBuilder: (_, _) => const SizedBox.shrink(),
+  );
+
+  await tester.pumpWidget(
+    MaterialApp(
+      home: Builder(
+        builder: (context) {
+          final bottomInset = MediaQuery.viewInsetsOf(context).bottom;
+          return AnimatedPadding(
+            padding: EdgeInsets.only(bottom: bottomInset),
+            duration: const Duration(milliseconds: 100),
+            curve: Curves.easeOut,
+            child: wrapWithStyle(
+              PrysmPage(
+                headerHeight: 70,
+                title: 'Peer',
+                body: wrapBody(list, composer),
+              ),
+            ),
+          );
+        },
+      ),
+    ),
+  );
+  await tester.pump(const Duration(milliseconds: 120));
+}
+
+void main() {
+  testWidgets(
+    'the pre-fix chat body overflows with keyboard + reply + typing bar '
+    '(reproduces the device error)',
+    (tester) async {
+      // MessageComposer constructs AudioRecorder, which pings the record
+      // method channel in its constructor (record_platform_interface
+      // RecordMethodChannel.create); a no-op handler keeps the test hermetic.
+      tester.binding.defaultBinaryMessenger.setMockMethodCallHandler(
+        const MethodChannel('com.llfbandit.record/messages'),
+        (call) async => null,
+      );
+
+      // 360x496 with a 300px keyboard leaves 126px for the body under the
+      // 70px header — the composer (reply preview + typing bar + input row)
+      // is taller than that, exactly like the device errors.
+      await pumpChatBody(
+        tester,
+        logicalWidth: 360,
+        logicalHeight: 496,
+        keyboardInset: 300,
+        wrapBody: (list, composer) => Column(
+          children: [
+            Expanded(child: list),
+            composer,
+          ],
+        ),
+      );
+
+      final exc = tester.takeException();
+      expect(exc, isA<FlutterError>());
+      // Assert that the composer overflowed the bottom of the body Column —
+      // not the exact pixel count, which depends on font metrics and surface
+      // size (the device log reported 18px; the count is not a contract).
+      expect(exc.toString(), contains('A RenderFlex overflowed by'));
+      expect(exc.toString(), contains('pixels on the bottom'));
+    },
+  );
+
+  testWidgets(
+    'chat composer with reply preview and typing bar fits above the keyboard '
+    'through the shared PrysmConstrainedComposer the 1:1/group/self chat '
+    'screens build (the fix)',
+    (tester) async {
+      tester.binding.defaultBinaryMessenger.setMockMethodCallHandler(
+        const MethodChannel('com.llfbandit.record/messages'),
+        (call) async => null,
+      );
+
+      await pumpChatBody(
+        tester,
+        logicalWidth: 360,
+        logicalHeight: 496,
+        keyboardInset: 300,
+        wrapBody: (list, composer) => LayoutBuilder(
+          builder: (context, constraints) => Column(
+            children: [
+              Expanded(child: list),
+              PrysmConstrainedComposer(
+                maxHeight: constraints.maxHeight,
+                composer: composer,
+              ),
+            ],
+          ),
+        ),
+      );
+
+      expect(tester.takeException(), isNull,
+          reason: 'composer must not overflow the chat body above the keyboard');
+    },
+  );
+
+  testWidgets(
+    'PIN unlock screen fits on a small screen (360x640) with biometrics and '
+    'Tor progress',
+    (tester) async {
+      UnlockLockoutService.setUseInMemoryStorageOnly(true);
+      tester.view.physicalSize = const Size(360 * 3, 640 * 3);
+      tester.view.devicePixelRatio = 3.0;
+      addTearDown(tester.view.reset);
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: wrapWithStyle(
+            PinScreen(
+              onVerifyPin: (_) async => true,
+              isPinSet: Future.value(true),
+              showBiometricButton: true,
+              onTryBiometric: () {},
+              torBootstrapProgress: 45,
+            ),
+          ),
+        ),
+      );
+      await tester.pump();
+
+      expect(tester.takeException(), isNull,
+          reason: 'PIN screen column must fit on a small phone screen');
+    },
+  );
+}

--- a/test/renderflex_overflow_test.dart
+++ b/test/renderflex_overflow_test.dart
@@ -191,6 +191,9 @@ void main() {
     'Tor progress',
     (tester) async {
       UnlockLockoutService.setUseInMemoryStorageOnly(true);
+      // Process-global: restore it so the mode does not depend on this test
+      // being last in the file.
+      addTearDown(() => UnlockLockoutService.setUseInMemoryStorageOnly(false));
       tester.view.physicalSize = const Size(360 * 3, 640 * 3);
       tester.view.devicePixelRatio = 3.0;
       addTearDown(tester.view.reset);


### PR DESCRIPTION
## Problem

The device log reports `A RenderFlex overflowed by 18 pixels on the bottom` during a chat session
and 34 pixels shortly after startup.

The chat body is `Column [ Expanded(list), composer ]`. The composer is a non-flex child, so
RenderFlex lays it out with unbounded main-axis constraints and it keeps its full intrinsic height
(reply preview + typing bar + input row), while the keyboard inset shrinks the body. When the
composer is taller than the space left, the Column overflows.

Reproduced at 360x496 with a 300px inset: 144px composer into 126px of body.

## Change

- Constrain the composer to the available height and let it scroll.
- The wrapper lives in a single `PrysmConstrainedComposer` used by the 1:1, group and self chats,
  instead of being triplicated inline. This is what makes the fix testable: the overflow test now
  exercises the shipped widget, so reverting the fix fails the test. The previous test pumped a
  hand-rolled copy of the screen's body and stayed green when the fix was removed.
- The PIN screen gets the same treatment for the startup case.
- The assertion no longer pins an exact pixel count, which depended on font metrics.

## Verification

- `flutter analyze` clean; full suite green on this branch.
- Mordancy demonstrated: reverting the wrapper makes the test fail with the overflow error;
  restoring it passes.
- The three chat screens render correctly in the running Linux app, with
  `PrysmConstrainedComposer` present in the live widget tree and no overflow errors logged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented chat composers in direct, group, and self chats from overflowing when keyboards, reply previews, or typing indicators reduce available space.
  * Improved PIN entry layout on small screens by allowing content to scroll instead of overflowing.

* **Tests**
  * Added coverage for chat overflow scenarios and PIN entry layouts with biometric authentication and Tor progress elements.
  * Verified composer behavior under constrained screen sizes and keyboard insets.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->