### PR TITLE
fix(ui): Material-free text selection in Prysm's inputs

### DIFF
--- a/lib/screens/home/home_screen.dart
+++ b/lib/screens/home/home_screen.dart
@@ -1337,7 +1337,8 @@ class _HomeScreenState extends State<HomeScreen> with WidgetsBindingObserver {
 
   bool _isEditableFocused() {
     final ctx = FocusManager.instance.primaryFocus?.context;
-    return ctx?.widget is EditableText;
+    // The focused context is EditableText's inner Focus, not the field.
+    return ctx?.findAncestorWidgetOfExactType<EditableText>() != null;
   }
 
   Map<ShortcutActivator, VoidCallback> _desktopShortcut(

--- a/lib/ui/core/prysm_text_field.dart
+++ b/lib/ui/core/prysm_text_field.dart
@@ -53,11 +53,36 @@ class _PrysmTextFieldState extends State<PrysmTextField> {
       _ownsFocus = true;
     }
     widget.controller.addListener(_onTextChanged);
+    _focusNode.addListener(_onFocusChanged);
+  }
+
+  @override
+  void didUpdateWidget(PrysmTextField oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (oldWidget.controller != widget.controller) {
+      oldWidget.controller.removeListener(_onTextChanged);
+      widget.controller.addListener(_onTextChanged);
+    }
+    if (oldWidget.focusNode != widget.focusNode) {
+      _focusNode.removeListener(_onFocusChanged);
+      if (widget.focusNode != null) {
+        if (_ownsFocus) {
+          _focusNode.dispose();
+          _ownsFocus = false;
+        }
+        _focusNode = widget.focusNode!;
+      } else {
+        _focusNode = FocusNode();
+        _ownsFocus = true;
+      }
+      _focusNode.addListener(_onFocusChanged);
+    }
   }
 
   @override
   void dispose() {
     widget.controller.removeListener(_onTextChanged);
+    _focusNode.removeListener(_onFocusChanged);
     if (_ownsFocus) _focusNode.dispose();
     super.dispose();
   }
@@ -65,6 +90,10 @@ class _PrysmTextFieldState extends State<PrysmTextField> {
   void _onTextChanged() {
     if (mounted) setState(() {});
     widget.onChanged?.call(widget.controller.text);
+  }
+
+  void _onFocusChanged() {
+    if (mounted) setState(() {});
   }
 
   @override

--- a/lib/ui/core/prysm_text_field.dart
+++ b/lib/ui/core/prysm_text_field.dart
@@ -90,6 +90,41 @@ class _PrysmTextFieldState extends State<PrysmTextField> {
       obscureText: widget.obscureText,
       onSubmitted: widget.onSubmitted,
       onChanged: widget.onChanged,
+      // The chrome lives INSIDE the decorate callback so the selection
+      // gesture detector — and with it requestKeyboard() on tap — covers the
+      // padding and border, not just the text strip.
+      decorate: (context, editable) => DecoratedBox(
+        decoration: BoxDecoration(
+          color: tokens.surfaceElevated,
+          borderRadius: style.composerRadius,
+          border: Border.all(
+            color: _focusNode.hasFocus ? tokens.accent : tokens.outline,
+            width: _focusNode.hasFocus ? 1.5 : 1,
+          ),
+        ),
+        child: Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 8),
+          child: Row(
+            children: [
+              if (widget.prefixIcon != null) ...[
+                widget.prefixIcon!,
+                const SizedBox(width: 8),
+              ],
+              Expanded(
+                child: Stack(
+                  alignment: Alignment.centerLeft,
+                  children: [
+                    if (showHint)
+                      Text(widget.hintText!, style: style.captionStyle),
+                    editable,
+                  ],
+                ),
+              ),
+              if (widget.suffixIcon != null) widget.suffixIcon!,
+            ],
+          ),
+        ),
+      ),
     );
 
     return Column(
@@ -100,38 +135,7 @@ class _PrysmTextFieldState extends State<PrysmTextField> {
           Text(widget.labelText!, style: style.captionStyle),
           const SizedBox(height: 6),
         ],
-        DecoratedBox(
-          decoration: BoxDecoration(
-            color: tokens.surfaceElevated,
-            borderRadius: style.composerRadius,
-            border: Border.all(
-              color: _focusNode.hasFocus ? tokens.accent : tokens.outline,
-              width: _focusNode.hasFocus ? 1.5 : 1,
-            ),
-          ),
-          child: Padding(
-            padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 8),
-            child: Row(
-              children: [
-                if (widget.prefixIcon != null) ...[
-                  widget.prefixIcon!,
-                  const SizedBox(width: 8),
-                ],
-                Expanded(
-                  child: Stack(
-                    alignment: Alignment.centerLeft,
-                    children: [
-                      if (showHint)
-                        Text(widget.hintText!, style: style.captionStyle),
-                      field,
-                    ],
-                  ),
-                ),
-                if (widget.suffixIcon != null) widget.suffixIcon!,
-              ],
-            ),
-          ),
-        ),
+        field,
       ],
     );
   }

--- a/lib/ui/core/prysm_text_field.dart
+++ b/lib/ui/core/prysm_text_field.dart
@@ -1,7 +1,8 @@
 import 'package:flutter/widgets.dart';
 import 'package:prysm/theme/prysm_style_scope.dart';
+import 'package:prysm/ui/core/prysm_text_selection.dart';
 
-/// Material-free text input using [EditableText].
+/// Material-free text input using [PrysmEditableText].
 class PrysmTextField extends StatefulWidget {
   const PrysmTextField({
     required this.controller,
@@ -73,7 +74,7 @@ class _PrysmTextFieldState extends State<PrysmTextField> {
     final showHint =
         widget.hintText != null && widget.controller.text.isEmpty;
 
-    final field = EditableText(
+    final field = PrysmEditableText(
       controller: widget.controller,
       focusNode: _focusNode,
       style: style.bodyStyle.copyWith(
@@ -81,6 +82,7 @@ class _PrysmTextFieldState extends State<PrysmTextField> {
       ),
       cursorColor: tokens.accent,
       backgroundCursorColor: tokens.textMuted,
+      selectionColor: tokens.accent.withValues(alpha: 0.40),
       minLines: widget.obscureText ? 1 : widget.minLines,
       maxLines: widget.obscureText ? 1 : widget.maxLines,
       autofocus: widget.autofocus,

--- a/lib/ui/core/prysm_text_selection.dart
+++ b/lib/ui/core/prysm_text_selection.dart
@@ -392,6 +392,7 @@ class PrysmEditableText extends StatefulWidget {
     this.obscureText = false,
     this.onChanged,
     this.onSubmitted,
+    this.decorate,
     super.key,
   });
 
@@ -408,6 +409,20 @@ class PrysmEditableText extends StatefulWidget {
   final bool obscureText;
   final ValueChanged<String>? onChanged;
   final ValueChanged<String>? onSubmitted;
+
+  /// Builds the field's visual chrome AROUND [editable], inside the selection
+  /// gesture detector.
+  ///
+  /// The detector — tap, long press, drag-select, and the `requestKeyboard()`
+  /// in [TextSelectionGestureDetectorBuilder.onSingleTapUp] — covers whatever
+  /// this returns. That is deliberate: Material's TextField wraps its
+  /// InputDecorator the same way, because a detector that stops at the bare
+  /// EditableText leaves the field's padding, border and horizontal chrome
+  /// dead — taps there neither focus the field nor reopen a dismissed
+  /// keyboard (measured: ~44% of the field's visible height was dead). Keep
+  /// the chrome here, inside the detector.
+  final Widget Function(BuildContext context, Widget editable)? decorate;
+
   @override
   State<PrysmEditableText> createState() => _PrysmEditableTextState();
 }
@@ -503,9 +518,10 @@ class _PrysmEditableTextState extends State<PrysmEditableText>
       onSubmitted: widget.onSubmitted,
     );
 
+    final child = widget.decorate?.call(context, editable) ?? editable;
     return _gestureBuilder.buildGestureDetector(
       behavior: HitTestBehavior.translucent,
-      child: editable,
+      child: child,
     );
   }
 }

--- a/lib/ui/core/prysm_text_selection.dart
+++ b/lib/ui/core/prysm_text_selection.dart
@@ -1,0 +1,379 @@
+import 'dart:math' as math;
+
+import 'package:flutter/widgets.dart';
+import 'package:prysm/theme/prysm_style_scope.dart';
+import 'package:prysm/theme/prysm_tokens.dart';
+import 'package:prysm/ui/core/prysm_pressable.dart';
+
+/// Material-free text selection for Prysm's inputs.
+///
+/// A bare [EditableText] paints no selection highlight, grows no drag handles
+/// and opens no context menu: `selectionColor`, `selectionControls` and
+/// `contextMenuBuilder` all default to null, and `RenderEditable`'s built-in
+/// long-press recogniser only calls `selectWord`. The result on a phone is a
+/// long press that appears to do nothing — no visible selection, no
+/// copy/paste menu.
+///
+/// [PrysmEditableText] supplies the three missing pieces the way
+/// `TextField`/`CupertinoTextField` do, but drawn from [PrysmTokens] instead of
+/// a Material theme: a [TextSelectionGestureDetectorBuilder] for the gestures,
+/// [PrysmTextSelectionControls] for the handles, and
+/// [prysmEditableTextContextMenuBuilder] for the toolbar.
+
+/// Diameter of a selection handle's circular head.
+const double _kHandleSize = 20.0;
+
+/// Gap kept between the toolbar and the screen edges.
+const double _kToolbarScreenPadding = 8.0;
+
+/// Gap between the toolbar and the top of the selection.
+const double _kToolbarContentDistance = 8.0;
+
+/// Gap between the toolbar and the bottom of the selection. Larger than the
+/// distance above so the toolbar clears the handles it would otherwise cover.
+const double _kToolbarContentDistanceBelow = _kHandleSize + 8.0;
+
+// ============================================================ handles
+
+/// Prysm-styled drag handles for a text selection.
+///
+/// Mixes in [TextSelectionHandleControls] so [EditableText] routes the toolbar
+/// through [EditableText.contextMenuBuilder] instead of the deprecated
+/// `buildToolbar`.
+class PrysmTextSelectionControls extends TextSelectionControls
+    with TextSelectionHandleControls {
+  @override
+  Size getHandleSize(double textLineHeight) =>
+      const Size(_kHandleSize, _kHandleSize);
+
+  @override
+  Widget buildHandle(
+    BuildContext context,
+    TextSelectionHandleType type,
+    double textLineHeight, [
+    VoidCallback? onTap,
+  ]) {
+    final tokens = context.prysmStyle.tokens;
+    final handle = SizedBox.square(
+      dimension: _kHandleSize,
+      child: CustomPaint(
+        painter: _PrysmHandlePainter(color: tokens.accent),
+        child: GestureDetector(
+          onTap: onTap,
+          behavior: HitTestBehavior.translucent,
+        ),
+      ),
+    );
+
+    // The painter draws a disc with a square corner in its top-left quadrant:
+    // a teardrop pointing up-left. Each handle is anchored by a different
+    // corner (see getHandleAnchor), so the rotation has to put the point on
+    // the anchored corner or the teardrop aims away from the caret it marks.
+    return switch (type) {
+      // anchored top-right -> point must be top-right
+      TextSelectionHandleType.left =>
+        Transform.rotate(angle: math.pi / 2.0, child: handle),
+      // anchored top-left -> the painter already points there
+      TextSelectionHandleType.right => handle,
+      // anchored top-centre -> point straight up
+      TextSelectionHandleType.collapsed =>
+        Transform.rotate(angle: math.pi / 4.0, child: handle),
+    };
+  }
+
+  @override
+  Offset getHandleAnchor(TextSelectionHandleType type, double textLineHeight) {
+    return switch (type) {
+      TextSelectionHandleType.left => const Offset(_kHandleSize, 0),
+      TextSelectionHandleType.right => Offset.zero,
+      TextSelectionHandleType.collapsed => const Offset(_kHandleSize / 2, -4),
+    };
+  }
+}
+
+/// The single instance used by every Prysm input.
+final TextSelectionControls prysmTextSelectionControls =
+    PrysmTextSelectionControls();
+
+class _PrysmHandlePainter extends CustomPainter {
+  const _PrysmHandlePainter({required this.color});
+
+  final Color color;
+
+  @override
+  void paint(Canvas canvas, Size size) {
+    final radius = size.width / 2;
+    final paint = Paint()..color = color;
+    canvas.drawCircle(Offset(radius, radius), radius, paint);
+    canvas.drawRect(Rect.fromLTWH(0, 0, radius, radius), paint);
+  }
+
+  @override
+  bool shouldRepaint(_PrysmHandlePainter oldDelegate) =>
+      color != oldDelegate.color;
+}
+
+// ============================================================ context menu
+
+/// [EditableText.contextMenuBuilder] for every Prysm input.
+Widget prysmEditableTextContextMenuBuilder(
+  BuildContext context,
+  EditableTextState editableTextState,
+) {
+  return PrysmTextSelectionToolbar(
+    anchors: editableTextState.contextMenuAnchors,
+    buttonItems: editableTextState.contextMenuButtonItems,
+  );
+}
+
+/// The cut/copy/paste/select-all bar, positioned against a selection.
+class PrysmTextSelectionToolbar extends StatelessWidget {
+  const PrysmTextSelectionToolbar({
+    required this.anchors,
+    required this.buttonItems,
+    super.key,
+  });
+
+  final TextSelectionToolbarAnchors anchors;
+  final List<ContextMenuButtonItem> buttonItems;
+
+  static String labelFor(ContextMenuButtonItem item) {
+    return item.label ??
+        switch (item.type) {
+          ContextMenuButtonType.cut => 'Cut',
+          ContextMenuButtonType.copy => 'Copy',
+          ContextMenuButtonType.paste => 'Paste',
+          ContextMenuButtonType.selectAll => 'Select all',
+          ContextMenuButtonType.delete => 'Delete',
+          ContextMenuButtonType.lookUp => 'Look up',
+          ContextMenuButtonType.searchWeb => 'Search web',
+          ContextMenuButtonType.share => 'Share',
+          ContextMenuButtonType.liveTextInput => 'Scan text',
+          ContextMenuButtonType.custom => 'Action',
+        };
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    if (buttonItems.isEmpty) return const SizedBox.shrink();
+
+    final style = context.prysmStyle;
+    final tokens = style.tokens;
+    final media = MediaQuery.of(context);
+    final paddingAbove = media.padding.top + _kToolbarScreenPadding;
+
+    // Anchors arrive in global coordinates; the Padding below shifts the
+    // layout origin, so the delegate needs them in its own local space.
+    final localAdjustment = Offset(_kToolbarScreenPadding, paddingAbove);
+    final anchorAbove =
+        anchors.primaryAnchor - const Offset(0, _kToolbarContentDistance);
+    final anchorBelow = anchors.secondaryAnchor == null
+        ? anchors.primaryAnchor
+        : anchors.secondaryAnchor! +
+            const Offset(0, _kToolbarContentDistanceBelow);
+
+    final children = <Widget>[];
+    for (var i = 0; i < buttonItems.length; i++) {
+      if (i > 0) {
+        children.add(
+          Container(width: 1, height: 20, color: tokens.divider),
+        );
+      }
+      final item = buttonItems[i];
+      children.add(
+        PrysmPressable(
+          onTap: item.onPressed,
+          child: Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 11),
+            child: Text(
+              labelFor(item),
+              style: style.bodyStyle.copyWith(
+                color: tokens.textPrimary,
+                fontWeight: FontWeight.w500,
+              ),
+            ),
+          ),
+        ),
+      );
+    }
+
+    return Padding(
+      padding: EdgeInsets.fromLTRB(
+        _kToolbarScreenPadding,
+        paddingAbove,
+        _kToolbarScreenPadding,
+        _kToolbarScreenPadding,
+      ),
+      child: CustomSingleChildLayout(
+        delegate: TextSelectionToolbarLayoutDelegate(
+          anchorAbove: anchorAbove - localAdjustment,
+          anchorBelow: anchorBelow - localAdjustment,
+        ),
+        child: ConstrainedBox(
+          // Wrap + a hard cap is what keeps a long menu (Android contributes
+          // extra PROCESS_TEXT entries) from overflowing instead of folding
+          // onto a second line.
+          constraints: BoxConstraints(
+            maxWidth: media.size.width - 2 * _kToolbarScreenPadding,
+          ),
+          child: DecoratedBox(
+            decoration: BoxDecoration(
+              color: tokens.surfaceElevated,
+              borderRadius: BorderRadius.circular(PrysmTokens.radiusCard),
+              border: Border.all(color: tokens.outline),
+              boxShadow: style.bubbleShadow,
+            ),
+            child: ClipRRect(
+              borderRadius: BorderRadius.circular(PrysmTokens.radiusCard),
+              child: Wrap(
+                crossAxisAlignment: WrapCrossAlignment.center,
+                children: children,
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+// ============================================================ editable text
+
+/// [EditableText] with Prysm's selection gestures, handles and context menu.
+///
+/// Both [PrysmTextField] and [PrysmSearchField] build on this, so the wiring
+/// lives in one place: duplicating it would be a second convention beside an
+/// existing one, and the halves would drift.
+class PrysmEditableText extends StatefulWidget {
+  const PrysmEditableText({
+    required this.controller,
+    required this.focusNode,
+    required this.style,
+    required this.cursorColor,
+    required this.backgroundCursorColor,
+    required this.selectionColor,
+    this.minLines = 1,
+    this.maxLines = 1,
+    this.autofocus = false,
+    this.readOnly = false,
+    this.obscureText = false,
+    this.onChanged,
+    this.onSubmitted,
+    super.key,
+  });
+
+  final TextEditingController controller;
+  final FocusNode focusNode;
+  final TextStyle style;
+  final Color cursorColor;
+  final Color backgroundCursorColor;
+  final Color selectionColor;
+  final int minLines;
+  final int maxLines;
+  final bool autofocus;
+  final bool readOnly;
+  final bool obscureText;
+  final ValueChanged<String>? onChanged;
+  final ValueChanged<String>? onSubmitted;
+
+  @override
+  State<PrysmEditableText> createState() => _PrysmEditableTextState();
+}
+
+class _PrysmEditableTextState extends State<PrysmEditableText>
+    implements TextSelectionGestureDetectorBuilderDelegate {
+  late final TextSelectionGestureDetectorBuilder _gestureBuilder;
+  bool _showSelectionHandles = false;
+
+  // TextSelectionGestureDetectorBuilderDelegate
+  @override
+  final GlobalKey<EditableTextState> editableTextKey =
+      GlobalKey<EditableTextState>();
+
+  /// Force press is an iOS 3D-Touch affordance no shipping device exposes.
+  @override
+  bool get forcePressEnabled => false;
+
+  @override
+  bool get selectionEnabled => !widget.obscureText && !widget.readOnly;
+
+  @override
+  void initState() {
+    super.initState();
+    _gestureBuilder = TextSelectionGestureDetectorBuilder(delegate: this);
+  }
+
+  /// Whether the handles should be visible for a selection changed by [cause].
+  ///
+  /// Keeping them off for keyboard-driven changes is what stops handles from
+  /// appearing while the user types.
+  bool _shouldShowSelectionHandles(SelectionChangedCause? cause) {
+    if (!_gestureBuilder.shouldShowSelectionToolbar ||
+        !_gestureBuilder.shouldShowSelectionHandles) {
+      return false;
+    }
+    if (cause == SelectionChangedCause.keyboard) return false;
+    if (!selectionEnabled) return false;
+    if (cause == SelectionChangedCause.longPress ||
+        cause == SelectionChangedCause.stylusHandwriting) {
+      return true;
+    }
+    return widget.controller.text.isNotEmpty;
+  }
+
+  void _handleSelectionChanged(
+    TextSelection selection,
+    SelectionChangedCause? cause,
+  ) {
+    final willShow = _shouldShowSelectionHandles(cause);
+    if (willShow != _showSelectionHandles) {
+      setState(() => _showSelectionHandles = willShow);
+    }
+    if (cause == SelectionChangedCause.longPress) {
+      editableTextKey.currentState?.bringIntoView(selection.extent);
+    }
+  }
+
+  /// Tapping a collapsed handle toggles the toolbar — the gesture that lets a
+  /// user paste without selecting anything first.
+  void _handleSelectionHandleTapped() {
+    if (widget.controller.selection.isCollapsed) {
+      editableTextKey.currentState?.toggleToolbar();
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final editable = EditableText(
+      key: editableTextKey,
+      controller: widget.controller,
+      focusNode: widget.focusNode,
+      style: widget.style,
+      cursorColor: widget.cursorColor,
+      backgroundCursorColor: widget.backgroundCursorColor,
+      selectionColor: widget.selectionColor,
+      selectionControls: selectionEnabled ? prysmTextSelectionControls : null,
+      contextMenuBuilder: prysmEditableTextContextMenuBuilder,
+      showSelectionHandles: _showSelectionHandles,
+      onSelectionChanged: _handleSelectionChanged,
+      onSelectionHandleTapped: _handleSelectionHandleTapped,
+      enableInteractiveSelection: selectionEnabled,
+      // The gesture detector below owns tap and long press; leaving
+      // RenderEditable's own recognisers on would make the two fight over the
+      // same pointer.
+      rendererIgnoresPointer: true,
+      minLines: widget.minLines,
+      maxLines: widget.maxLines,
+      autofocus: widget.autofocus,
+      readOnly: widget.readOnly,
+      obscureText: widget.obscureText,
+      onChanged: widget.onChanged,
+      onSubmitted: widget.onSubmitted,
+    );
+
+    return _gestureBuilder.buildGestureDetector(
+      behavior: HitTestBehavior.translucent,
+      child: editable,
+    );
+  }
+}

--- a/lib/ui/core/prysm_text_selection.dart
+++ b/lib/ui/core/prysm_text_selection.dart
@@ -1,8 +1,10 @@
 import 'dart:math' as math;
 
 import 'package:flutter/widgets.dart';
+import 'package:prysm/theme/prysm_style_resolver.dart';
 import 'package:prysm/theme/prysm_style_scope.dart';
 import 'package:prysm/theme/prysm_tokens.dart';
+import 'package:prysm/ui/core/prysm_icons.dart';
 import 'package:prysm/ui/core/prysm_pressable.dart';
 
 /// Material-free text selection for Prysm's inputs.
@@ -127,7 +129,14 @@ Widget prysmEditableTextContextMenuBuilder(
 }
 
 /// The cut/copy/paste/select-all bar, positioned against a selection.
-class PrysmTextSelectionToolbar extends StatelessWidget {
+///
+/// Android contributes an extra PROCESS_TEXT entry to the context menu for
+/// every installed app that offers one, so
+/// [EditableTextState.contextMenuButtonItems] can grow far beyond the
+/// standard four actions. Only cut/copy/paste/select all render up front;
+/// everything else is folded behind a "more" button that opens a scrollable
+/// overflow page, so the bar always stays a single row on a phone.
+class PrysmTextSelectionToolbar extends StatefulWidget {
   const PrysmTextSelectionToolbar({
     required this.anchors,
     required this.buttonItems,
@@ -154,8 +163,56 @@ class PrysmTextSelectionToolbar extends StatelessWidget {
   }
 
   @override
+  State<PrysmTextSelectionToolbar> createState() =>
+      _PrysmTextSelectionToolbarState();
+}
+
+/// Whether [type] belongs to the primary row instead of the overflow page.
+bool _isPrimaryButtonType(ContextMenuButtonType type) {
+  return switch (type) {
+    ContextMenuButtonType.cut ||
+    ContextMenuButtonType.copy ||
+    ContextMenuButtonType.paste ||
+    ContextMenuButtonType.selectAll =>
+      true,
+    _ => false,
+  };
+}
+
+class _PrysmTextSelectionToolbarState extends State<PrysmTextSelectionToolbar> {
+  /// Whether the overflow page (everything but cut/copy/paste/select all) is
+  /// showing instead of the primary row.
+  bool _showOverflow = false;
+
+  bool _sameLabels(
+    List<ContextMenuButtonItem> a,
+    List<ContextMenuButtonItem> b,
+  ) {
+    if (a.length != b.length) return false;
+    for (var i = 0; i < a.length; i++) {
+      if (PrysmTextSelectionToolbar.labelFor(a[i]) !=
+          PrysmTextSelectionToolbar.labelFor(b[i])) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  @override
+  void didUpdateWidget(PrysmTextSelectionToolbar oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    // A new selection reuses this element with a different button list; an
+    // open overflow page would then show stale actions. Rebuilds that keep
+    // the same labels (e.g. the clipboard status flipping Paste on/off) must
+    // not reset it, or the page would close under the user.
+    if (!_sameLabels(oldWidget.buttonItems, widget.buttonItems)) {
+      _showOverflow = false;
+    }
+  }
+
+  @override
   Widget build(BuildContext context) {
-    if (buttonItems.isEmpty) return const SizedBox.shrink();
+    if (widget.buttonItems.isEmpty) return const SizedBox.shrink();
 
     final style = context.prysmStyle;
     final tokens = style.tokens;
@@ -165,37 +222,20 @@ class PrysmTextSelectionToolbar extends StatelessWidget {
     // Anchors arrive in global coordinates; the Padding below shifts the
     // layout origin, so the delegate needs them in its own local space.
     final localAdjustment = Offset(_kToolbarScreenPadding, paddingAbove);
-    final anchorAbove =
-        anchors.primaryAnchor - const Offset(0, _kToolbarContentDistance);
-    final anchorBelow = anchors.secondaryAnchor == null
-        ? anchors.primaryAnchor
-        : anchors.secondaryAnchor! +
+    final anchorAbove = widget.anchors.primaryAnchor -
+        const Offset(0, _kToolbarContentDistance);
+    final anchorBelow = widget.anchors.secondaryAnchor == null
+        ? widget.anchors.primaryAnchor
+        : widget.anchors.secondaryAnchor! +
             const Offset(0, _kToolbarContentDistanceBelow);
 
-    final children = <Widget>[];
-    for (var i = 0; i < buttonItems.length; i++) {
-      if (i > 0) {
-        children.add(
-          Container(width: 1, height: 20, color: tokens.divider),
-        );
-      }
-      final item = buttonItems[i];
-      children.add(
-        PrysmPressable(
-          onTap: item.onPressed,
-          child: Padding(
-            padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 11),
-            child: Text(
-              labelFor(item),
-              style: style.bodyStyle.copyWith(
-                color: tokens.textPrimary,
-                fontWeight: FontWeight.w500,
-              ),
-            ),
-          ),
-        ),
-      );
+    final primary = <ContextMenuButtonItem>[];
+    final overflow = <ContextMenuButtonItem>[];
+    for (final item in widget.buttonItems) {
+      (_isPrimaryButtonType(item.type) ? primary : overflow).add(item);
     }
+
+    final overflowOpen = _showOverflow && overflow.isNotEmpty;
 
     return Padding(
       padding: EdgeInsets.fromLTRB(
@@ -210,9 +250,8 @@ class PrysmTextSelectionToolbar extends StatelessWidget {
           anchorBelow: anchorBelow - localAdjustment,
         ),
         child: ConstrainedBox(
-          // Wrap + a hard cap is what keeps a long menu (Android contributes
-          // extra PROCESS_TEXT entries) from overflowing instead of folding
-          // onto a second line.
+          // The width cap keeps both pages inside the screen; the overflow
+          // page adds its own height cap on top of this.
           constraints: BoxConstraints(
             maxWidth: media.size.width - 2 * _kToolbarScreenPadding,
           ),
@@ -225,11 +264,105 @@ class PrysmTextSelectionToolbar extends StatelessWidget {
             ),
             child: ClipRRect(
               borderRadius: BorderRadius.circular(PrysmTokens.radiusCard),
-              child: Wrap(
-                crossAxisAlignment: WrapCrossAlignment.center,
-                children: children,
-              ),
+              child: overflowOpen
+                  ? _overflowPage(style, tokens, media, overflow)
+                  : _primaryRow(style, tokens, primary, overflow.isNotEmpty),
             ),
+          ),
+        ),
+      ),
+    );
+  }
+
+  Widget _primaryRow(
+    PrysmResolvedStyle style,
+    PrysmTokens tokens,
+    List<ContextMenuButtonItem> primary,
+    bool hasOverflow,
+  ) {
+    final children = <Widget>[];
+    for (var i = 0; i < primary.length; i++) {
+      if (i > 0) {
+        children.add(Container(width: 1, height: 20, color: tokens.divider));
+      }
+      children.add(_itemButton(style, tokens, primary[i]));
+    }
+    if (hasOverflow) {
+      children.add(Container(width: 1, height: 20, color: tokens.divider));
+      children.add(
+        PrysmPressable(
+          onTap: () => setState(() => _showOverflow = true),
+          child: Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 11),
+            child: Icon(
+              PrysmIcons.more,
+              // 15px body text at weight 500 reads the same as an 18px icon;
+              // both colour and size come from tokens, never a hard-coded
+              // value.
+              size: 18,
+              color: tokens.textPrimary,
+            ),
+          ),
+        ),
+      );
+    }
+    return Wrap(
+      crossAxisAlignment: WrapCrossAlignment.center,
+      children: children,
+    );
+  }
+
+  Widget _overflowPage(
+    PrysmResolvedStyle style,
+    PrysmTokens tokens,
+    MediaQueryData media,
+    List<ContextMenuButtonItem> overflow,
+  ) {
+    final children = <Widget>[
+      PrysmPressable(
+        onTap: () => setState(() => _showOverflow = false),
+        child: Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 11),
+          child: Icon(
+            PrysmIcons.chevronLeft,
+            size: 18,
+            color: tokens.textPrimary,
+          ),
+        ),
+      ),
+    ];
+    for (var i = 0; i < overflow.length; i++) {
+      children.add(Container(height: 1, color: tokens.divider));
+      children.add(_itemButton(style, tokens, overflow[i]));
+    }
+    return ConstrainedBox(
+      // An arbitrarily long PROCESS_TEXT list must never run off screen: cap
+      // the page at a third of the screen and let the rest scroll.
+      constraints: BoxConstraints(maxHeight: media.size.height / 3),
+      child: SingleChildScrollView(
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: children,
+        ),
+      ),
+    );
+  }
+
+  Widget _itemButton(
+    PrysmResolvedStyle style,
+    PrysmTokens tokens,
+    ContextMenuButtonItem item,
+  ) {
+    return PrysmPressable(
+      onTap: item.onPressed,
+      child: Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 11),
+        child: Text(
+          PrysmTextSelectionToolbar.labelFor(item),
+          style: style.bodyStyle.copyWith(
+            color: tokens.textPrimary,
+            fontWeight: FontWeight.w500,
           ),
         ),
       ),
@@ -275,7 +408,6 @@ class PrysmEditableText extends StatefulWidget {
   final bool obscureText;
   final ValueChanged<String>? onChanged;
   final ValueChanged<String>? onSubmitted;
-
   @override
   State<PrysmEditableText> createState() => _PrysmEditableTextState();
 }

--- a/lib/ui/prysm_search_field.dart
+++ b/lib/ui/prysm_search_field.dart
@@ -49,39 +49,45 @@ class _PrysmSearchFieldState extends State<PrysmSearchField> {
     final showHint =
         widget.hintText.isNotEmpty && widget.controller.text.isEmpty;
 
-    return Container(
-      height: 40,
-      decoration: BoxDecoration(
-        color: tokens.surfaceElevated,
-        borderRadius: style.composerRadius,
-      ),
-      padding: const EdgeInsets.symmetric(horizontal: PrysmTokens.spacing12),
-      child: Row(
-        children: [
-          Icon(PrysmIcons.search, size: 20, color: tokens.textMuted),
-          const SizedBox(width: PrysmTokens.spacing8),
-          Expanded(
-            child: Stack(
-              alignment: Alignment.centerLeft,
-              children: [
-                if (showHint)
-                  Text(widget.hintText, style: style.captionStyle),
-                PrysmEditableText(
-                  controller: widget.controller,
-                  focusNode: _focusNode,
-                  style: style.bodyStyle.copyWith(color: tokens.textPrimary),
-                  cursorColor: tokens.accent,
-                  backgroundCursorColor: tokens.textMuted,
-                  selectionColor: tokens.accent.withValues(alpha: 0.40),
-                  maxLines: 1,
-                  onChanged: widget.onChanged,
-                ),
-              ],
+    return PrysmEditableText(
+      controller: widget.controller,
+      focusNode: _focusNode,
+      style: style.bodyStyle.copyWith(color: tokens.textPrimary),
+      cursorColor: tokens.accent,
+      backgroundCursorColor: tokens.textMuted,
+      selectionColor: tokens.accent.withValues(alpha: 0.40),
+      maxLines: 1,
+      onChanged: widget.onChanged,
+      // Same shape as PrysmTextField: the chrome sits inside the decorate
+      // callback, under the selection gesture detector, so taps on the
+      // container's padding reopen the keyboard instead of landing on dead
+      // space. PrysmClearButton keeps its own PrysmPressable, which is deeper
+      // in the tree and still wins taps aimed at it.
+      decorate: (context, editable) => Container(
+        height: 40,
+        decoration: BoxDecoration(
+          color: tokens.surfaceElevated,
+          borderRadius: style.composerRadius,
+        ),
+        padding: const EdgeInsets.symmetric(horizontal: PrysmTokens.spacing12),
+        child: Row(
+          children: [
+            Icon(PrysmIcons.search, size: 20, color: tokens.textMuted),
+            const SizedBox(width: PrysmTokens.spacing8),
+            Expanded(
+              child: Stack(
+                alignment: Alignment.centerLeft,
+                children: [
+                  if (showHint)
+                    Text(widget.hintText, style: style.captionStyle),
+                  editable,
+                ],
+              ),
             ),
-          ),
-          if (widget.controller.text.isNotEmpty && widget.onClear != null)
-            PrysmClearButton(onPressed: widget.onClear!),
-        ],
+            if (widget.controller.text.isNotEmpty && widget.onClear != null)
+              PrysmClearButton(onPressed: widget.onClear!),
+          ],
+        ),
       ),
     );
   }

--- a/lib/ui/prysm_search_field.dart
+++ b/lib/ui/prysm_search_field.dart
@@ -3,6 +3,7 @@ import 'package:prysm/theme/prysm_style_scope.dart';
 import 'package:prysm/theme/prysm_tokens.dart';
 import 'package:prysm/ui/core/prysm_icons.dart';
 import 'package:prysm/ui/core/prysm_pressable.dart';
+import 'package:prysm/ui/core/prysm_text_selection.dart';
 
 class PrysmSearchField extends StatefulWidget {
   const PrysmSearchField({
@@ -65,12 +66,13 @@ class _PrysmSearchFieldState extends State<PrysmSearchField> {
               children: [
                 if (showHint)
                   Text(widget.hintText, style: style.captionStyle),
-                EditableText(
+                PrysmEditableText(
                   controller: widget.controller,
                   focusNode: _focusNode,
                   style: style.bodyStyle.copyWith(color: tokens.textPrimary),
                   cursorColor: tokens.accent,
                   backgroundCursorColor: tokens.textMuted,
+                  selectionColor: tokens.accent.withValues(alpha: 0.40),
                   maxLines: 1,
                   onChanged: widget.onChanged,
                 ),

--- a/test/prysm_text_selection_test.dart
+++ b/test/prysm_text_selection_test.dart
@@ -58,6 +58,18 @@ Future<void> pumpInPrysmApp(
 EditableTextState editableState(WidgetTester tester) =>
     tester.state<EditableTextState>(find.byType(EditableText));
 
+/// The field's border, read from the [DecoratedBox] the decorate callback
+/// builds — the only one inside the field, as the chrome tests below rely on
+/// too. Reading the widget (not a painted pixel) keeps the assertion on the
+/// exact BoxDecoration the callback produced.
+Border fieldBorder(WidgetTester tester) {
+  final box = tester.widget<DecoratedBox>(find.descendant(
+    of: find.byType(PrysmTextField),
+    matching: find.byType(DecoratedBox),
+  ));
+  return (box.decoration as BoxDecoration).border! as Border;
+}
+
 ContextMenuButtonItem buttonItem(
   String label, {
   ContextMenuButtonType type = ContextMenuButtonType.custom,
@@ -302,6 +314,104 @@ void main() {
     expect(editableState(tester).widget.selectionControls, isNull);
     expect(find.byType(PrysmTextSelectionToolbar), findsNothing);
   }, variant: onAndroid);
+
+  // --- focus border repaints from the focus listener ----------------------
+
+  // The reported defect: the focused border is read inside the decorate
+  // callback, which PrysmEditableText invokes from its own state — a state
+  // that does not listen to the focus node, so focusing the field left the
+  // border unfocused until an unrelated rebuild (e.g. the first keystroke).
+  // A tap-driven test cannot see this: a tap makes _PrysmEditableTextState
+  // call setState for the selection handles, which re-invokes decorate and
+  // hides the defect. These tests drive focus programmatically instead —
+  // requestFocus()/unfocus() and nothing else.
+
+  testWidgets('programmatic focus repaints the border without any other '
+      'state change', (tester) async {
+    final controller = TextEditingController();
+    addTearDown(controller.dispose);
+    final focusNode = FocusNode();
+    addTearDown(focusNode.dispose);
+
+    await pumpInPrysmApp(
+      tester,
+      PrysmTextField(controller: controller, focusNode: focusNode),
+    );
+
+    // The same resolved style the widget reads (PrysmStyleScope.of), never a
+    // hard-coded colour literal.
+    final tokens = PrysmStyleScope.of(
+      tester.element(find.byType(PrysmTextField)),
+    ).tokens;
+
+    expect(fieldBorder(tester).top.color, tokens.outline);
+    expect(fieldBorder(tester).top.width, 1);
+
+    // The ONLY state change: programmatic focus. No tap, no typing. Two
+    // pumps: the first flushes the focus notification microtask and runs the
+    // listener's setState, the second builds the frame that re-invokes
+    // decorate (a single pump only builds if a frame happened to be pending
+    // at entry, which depends on what the previous pump left behind).
+    focusNode.requestFocus();
+    await tester.pump();
+    await tester.pump();
+
+    expect(fieldBorder(tester).top.color, tokens.accent);
+    expect(fieldBorder(tester).top.width, 1.5);
+
+    focusNode.unfocus();
+    await tester.pump();
+    await tester.pump();
+
+    expect(fieldBorder(tester).top.color, tokens.outline);
+    expect(fieldBorder(tester).top.width, 1);
+  });
+
+  testWidgets('swapping the focusNode moves the focus listener to the new '
+      'node', (tester) async {
+    final controller = TextEditingController();
+    addTearDown(controller.dispose);
+    final firstNode = FocusNode();
+    final secondNode = FocusNode();
+    addTearDown(firstNode.dispose);
+    addTearDown(secondNode.dispose);
+
+    await pumpInPrysmApp(
+      tester,
+      PrysmTextField(controller: controller, focusNode: firstNode),
+    );
+
+    // The same element is updated with a different focusNode: the state must
+    // move its listener off the old node (and, never having created it, leave
+    // firstNode alone).
+    await pumpInPrysmApp(
+      tester,
+      PrysmTextField(controller: controller, focusNode: secondNode),
+    );
+
+    final tokens = PrysmStyleScope.of(
+      tester.element(find.byType(PrysmTextField)),
+    ).tokens;
+
+    // The field now watches the NEW node, which is not focused.
+    expect(fieldBorder(tester).top.color, tokens.outline);
+    expect(fieldBorder(tester).top.width, 1);
+
+    // Focusing the new node must repaint the border (two pumps: notification
+    // microtask + build frame, as in the test above).
+    secondNode.requestFocus();
+    await tester.pump();
+    await tester.pump();
+
+    expect(fieldBorder(tester).top.color, tokens.accent);
+    expect(fieldBorder(tester).top.width, 1.5);
+
+    secondNode.unfocus();
+    await tester.pump();
+    await tester.pump();
+
+    expect(fieldBorder(tester).top.color, tokens.outline);
+  });
 
   testWidgets('the context menu labels every button type without Material '
       'localizations', (tester) async {

--- a/test/prysm_text_selection_test.dart
+++ b/test/prysm_text_selection_test.dart
@@ -535,4 +535,223 @@ void main() {
     );
   }, variant: onAndroid);
 
+  // --- keyboard reopens from the field chrome -----------------------------
+
+  // The reported defect: with the keyboard dismissed (BACK key) and the field
+  // still focused, tapping the input again did nothing until the user tapped
+  // something else first. Measured on the device, the selection gesture
+  // detector covered only the bare EditableText, so the field's padding,
+  // border and horizontal chrome (~44% of its visible height) were dead
+  // space. These tests tap that chrome and require the IME to come back.
+  group('tapping the field chrome reopens a dismissed keyboard', () {
+    /// Taps `inset` inside [box], asserting the point is outside [editable]
+    /// first — the tap must land on the field's chrome, not on the text
+    /// strip, or the test silently stops testing the fix.
+    Future<void> tapChrome(
+      WidgetTester tester, {
+      required Rect box,
+      required Rect editable,
+      required Offset inset,
+    }) async {
+      final point = box.topLeft + inset;
+      expect(box.contains(point), isTrue,
+          reason: 'the tap point must land on the field box');
+      expect(editable.contains(point), isFalse,
+          reason: 'the tap point must be outside the editable strip');
+      await tester.tapAt(point);
+      await tester.pump();
+    }
+
+    testWidgets('tapping the text strip focuses the field and opens the '
+        'keyboard', (tester) async {
+      final controller = TextEditingController(text: 'hello world');
+      addTearDown(controller.dispose);
+
+      await pumpInPrysmApp(
+        tester,
+        PrysmTextField(controller: controller),
+      );
+
+      await tester.tap(find.byType(EditableText));
+      await tester.pump();
+
+      expect(editableState(tester).widget.focusNode.hasFocus, isTrue);
+      expect(tester.testTextInput.isVisible, isTrue,
+          reason: 'tapping the input must open the keyboard');
+    });
+
+    testWidgets('text field chrome reopens a dismissed keyboard without '
+        'losing focus', (tester) async {
+      final controller = TextEditingController(text: 'hello world');
+      addTearDown(controller.dispose);
+
+      await pumpInPrysmApp(
+        tester,
+        PrysmTextField(controller: controller),
+      );
+
+      // Focus the field and open the keyboard the normal way.
+      await tester.tap(find.byType(EditableText));
+      await tester.pump();
+      expect(tester.testTextInput.isVisible, isTrue);
+
+      // The user dismisses the keyboard (BACK key); focus stays on the field.
+      // TestTextInput.hide() only flips a flag — it never closes the IME
+      // connection the way a real BACK press does — so the selection toolbar
+      // would stay open and cover the field's chrome. Dismiss it explicitly
+      // to reach the state the reported repro was in.
+      tester.testTextInput.hide();
+      editableState(tester).hideToolbar();
+      await tester.pump();
+      expect(tester.testTextInput.isVisible, isFalse);
+      expect(editableState(tester).widget.focusNode.hasFocus, isTrue,
+          reason: 'dismissing the keyboard must not move focus');
+
+      final box = tester.getRect(find.descendant(
+        of: find.byType(PrysmTextField),
+        matching: find.byType(DecoratedBox),
+      ));
+      final editable = tester.getRect(find.byType(EditableText));
+
+      // Top edge: 4 dp inside the box, above the editable strip.
+      await tapChrome(
+        tester,
+        box: box,
+        editable: editable,
+        inset: Offset(box.width / 2, 4),
+      );
+      expect(tester.testTextInput.isVisible, isTrue,
+          reason: 'a tap on the top padding must reopen the keyboard');
+      tester.testTextInput.hide();
+      editableState(tester).hideToolbar();
+      await tester.pump();
+
+      // Bottom edge: 4 dp inside the box, below the editable strip.
+      await tapChrome(
+        tester,
+        box: box,
+        editable: editable,
+        inset: Offset(box.width / 2, box.height - 4),
+      );
+      expect(tester.testTextInput.isVisible, isTrue,
+          reason: 'a tap on the bottom padding must reopen the keyboard');
+      tester.testTextInput.hide();
+      editableState(tester).hideToolbar();
+      await tester.pump();
+
+      // Horizontal padding: 4 dp inside the box's left edge.
+      await tapChrome(
+        tester,
+        box: box,
+        editable: editable,
+        inset: Offset(4, box.height / 2),
+      );
+      expect(tester.testTextInput.isVisible, isTrue,
+          reason: 'a tap on the horizontal padding must reopen the keyboard');
+    });
+
+    testWidgets('search field chrome reopens a dismissed keyboard',
+        (tester) async {
+      final controller = TextEditingController(text: 'axolotl dossier');
+      addTearDown(controller.dispose);
+
+      await pumpInPrysmApp(
+        tester,
+        PrysmSearchField(controller: controller),
+      );
+
+      await tester.tap(find.byType(EditableText));
+      await tester.pump();
+      expect(tester.testTextInput.isVisible, isTrue);
+
+      // Same as the text field: a real BACK press clears the selection
+      // toolbar along with the keyboard; the mock hide() alone would leave it
+      // covering the field's chrome.
+      tester.testTextInput.hide();
+      editableState(tester).hideToolbar();
+      await tester.pump();
+      expect(tester.testTextInput.isVisible, isFalse);
+
+      final box = tester.getRect(find.descendant(
+        of: find.byType(PrysmSearchField),
+        matching: find.byType(DecoratedBox),
+      ));
+      final editable = tester.getRect(find.byType(EditableText));
+
+      await tapChrome(
+        tester,
+        box: box,
+        editable: editable,
+        inset: Offset(box.width / 2, 4),
+      );
+      expect(tester.testTextInput.isVisible, isTrue,
+          reason: 'a tap on the search field top padding must reopen the '
+              'keyboard');
+      tester.testTextInput.hide();
+      editableState(tester).hideToolbar();
+      await tester.pump();
+
+      await tapChrome(
+        tester,
+        box: box,
+        editable: editable,
+        inset: Offset(box.width / 2, box.height - 4),
+      );
+      expect(tester.testTextInput.isVisible, isTrue,
+          reason: 'a tap on the search field bottom padding must reopen the '
+              'keyboard');
+    });
+
+    testWidgets('the clear button wins its own taps and leaves the caret '
+        'alone', (tester) async {
+      final controller = TextEditingController(text: 'hello world');
+      addTearDown(controller.dispose);
+      // A caret the clear button must not move.
+      controller.selection = const TextSelection.collapsed(offset: 0);
+
+      var cleared = false;
+      await pumpInPrysmApp(
+        tester,
+        PrysmSearchField(
+          controller: controller,
+          onClear: () => cleared = true,
+        ),
+      );
+
+      await tester.tap(find.byType(PrysmClearButton));
+      await tester.pump();
+
+      expect(cleared, isTrue,
+          reason: 'the clear button must win the tap against the selection '
+              'gesture detector');
+      expect(controller.selection, const TextSelection.collapsed(offset: 0),
+          reason: 'the tap must not be stolen by the field caret placement');
+    });
+
+    testWidgets('a disabled field stays keyboard-free when its chrome is '
+        'tapped', (tester) async {
+      final controller = TextEditingController(text: 'read only');
+      addTearDown(controller.dispose);
+
+      await pumpInPrysmApp(
+        tester,
+        PrysmTextField(controller: controller, enabled: false),
+      );
+
+      final box = tester.getRect(find.descendant(
+        of: find.byType(PrysmTextField),
+        matching: find.byType(DecoratedBox),
+      ));
+      final editable = tester.getRect(find.byType(EditableText));
+
+      await tapChrome(
+        tester,
+        box: box,
+        editable: editable,
+        inset: Offset(box.width / 2, 4),
+      );
+      expect(tester.testTextInput.isVisible, isFalse,
+          reason: 'a tap on a disabled field must not open the keyboard');
+    });
+  });
 }

--- a/test/prysm_text_selection_test.dart
+++ b/test/prysm_text_selection_test.dart
@@ -1,0 +1,275 @@
+// Guards the Material-free text selection wired into every Prysm input.
+//
+// Before the fix, PrysmTextField and PrysmSearchField built a bare
+// EditableText: `selectionColor`, `selectionControls` and `contextMenuBuilder`
+// all defaulted to null, so on a phone a long press selected a word that was
+// never painted, grew no drag handles and opened no copy/paste menu. That is
+// the reported defect ("hold down like on WhatsApp: it does not let you select
+// the text, no copy menu").
+//
+// These tests pump a WidgetsApp — NOT a MaterialApp — on purpose: MaterialApp
+// installs its own DefaultSelectionStyle, selection controls and
+// AdaptiveTextSelectionToolbar, so a Material-based fix would pass under
+// MaterialApp and still be broken in the real app, whose root is
+// PrysmApp -> WidgetsApp (lib/ui/core/prysm_app.dart:28).
+//
+// Style follows quoted_reply_preview_test.dart: a hand-resolved
+// PrysmStyleScope around the tree.
+import 'package:flutter/services.dart';
+import 'package:flutter/widgets.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:prysm/models/appearance_settings.dart';
+import 'package:prysm/theme/prysm_style_resolver.dart';
+import 'package:prysm/theme/prysm_style_scope.dart';
+import 'package:prysm/ui/core/prysm_text_field.dart';
+import 'package:prysm/ui/core/prysm_text_selection.dart';
+import 'package:prysm/ui/prysm_search_field.dart';
+
+Widget wrapWithStyle(Widget child) {
+  final style = PrysmStyleResolver.resolve(
+    themePalette: 0,
+    appearance: const AppearanceSettings(),
+  );
+  return PrysmStyleScope(style: style, child: child);
+}
+
+Future<void> pumpInPrysmApp(WidgetTester tester, Widget child) async {
+  await tester.pumpWidget(
+    wrapWithStyle(
+      WidgetsApp(
+        color: const Color(0xFF000000),
+        pageRouteBuilder: <T>(RouteSettings settings, WidgetBuilder builder) =>
+            PageRouteBuilder<T>(
+          settings: settings,
+          pageBuilder: (context, animation, secondaryAnimation) =>
+              builder(context),
+        ),
+        home: Center(child: SizedBox(width: 320, child: child)),
+      ),
+    ),
+  );
+}
+
+EditableTextState editableState(WidgetTester tester) =>
+    tester.state<EditableTextState>(find.byType(EditableText));
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  late List<MethodCall> platformCalls;
+
+  setUp(() {
+    platformCalls = <MethodCall>[];
+    // The paste button is withheld until the clipboard status is known
+    // (EditableText.getEditableButtonItems), and an unmocked channel leaves it
+    // `unknown` — which would empty the whole menu.
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(SystemChannels.platform, (call) async {
+      platformCalls.add(call);
+      return switch (call.method) {
+        'Clipboard.hasStrings' => <String, dynamic>{'value': true},
+        'Clipboard.getData' => <String, dynamic>{'text': 'clip'},
+        _ => null,
+      };
+    });
+  });
+
+  tearDown(() {
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(SystemChannels.platform, null);
+  });
+
+  // The report is about a phone; the override goes through the variant so the
+  // binding's debug-variable invariant check stays happy.
+  final onAndroid = TargetPlatformVariant.only(TargetPlatform.android);
+
+  testWidgets('long press in a text field selects a word and opens the '
+      'Prysm context menu', (tester) async {
+    final controller = TextEditingController(text: 'hello world');
+    addTearDown(controller.dispose);
+
+    await pumpInPrysmApp(
+      tester,
+      PrysmTextField(controller: controller),
+    );
+
+    expect(find.byType(PrysmTextSelectionToolbar), findsNothing);
+
+    await tester.longPress(find.byType(PrysmEditableText));
+    await tester.pumpAndSettle();
+
+    final state = editableState(tester);
+    expect(
+      state.textEditingValue.selection.isCollapsed,
+      isFalse,
+      reason: 'a long press must select the word under the finger',
+    );
+    expect(
+      state.textEditingValue.selection.textInside(controller.text),
+      'world',
+    );
+
+    // The menu, and the two entries the report named.
+    expect(find.byType(PrysmTextSelectionToolbar), findsOneWidget);
+    expect(find.text('Copy'), findsOneWidget);
+    expect(find.text('Paste'), findsOneWidget);
+
+    // The drag handles: without controls the overlay draws none, and without
+    // showSelectionHandles it never asks for them.
+    expect(state.widget.selectionControls, isA<PrysmTextSelectionControls>());
+    expect(state.widget.showSelectionHandles, isTrue);
+
+    // The selection must actually be painted; a null selectionColor is why the
+    // pre-fix long press looked like it did nothing at all.
+    expect(state.widget.selectionColor, isNotNull);
+  }, variant: onAndroid);
+
+  testWidgets('Copy in the context menu puts the selection on the clipboard',
+      (tester) async {
+    final controller = TextEditingController(text: 'hello world');
+    addTearDown(controller.dispose);
+
+    await pumpInPrysmApp(
+      tester,
+      PrysmTextField(controller: controller),
+    );
+
+    await tester.longPress(find.byType(PrysmEditableText));
+    await tester.pumpAndSettle();
+
+    platformCalls.clear();
+    await tester.tap(find.text('Copy'));
+    await tester.pumpAndSettle();
+
+    final setData = platformCalls
+        .where((call) => call.method == 'Clipboard.setData')
+        .toList();
+    expect(setData, hasLength(1));
+    expect((setData.single.arguments as Map)['text'], 'world');
+  }, variant: onAndroid);
+
+  testWidgets('the search field gets the same selection affordances',
+      (tester) async {
+    final controller = TextEditingController(text: 'axolotl dossier');
+    addTearDown(controller.dispose);
+
+    await pumpInPrysmApp(
+      tester,
+      PrysmSearchField(controller: controller),
+    );
+
+    await tester.longPress(find.byType(PrysmEditableText));
+    await tester.pumpAndSettle();
+
+    expect(find.byType(PrysmTextSelectionToolbar), findsOneWidget);
+    expect(find.text('Copy'), findsOneWidget);
+    expect(
+      editableState(tester).widget.selectionControls,
+      isA<PrysmTextSelectionControls>(),
+    );
+  }, variant: onAndroid);
+
+  testWidgets('an obscured field offers no selection, handles or menu',
+      (tester) async {
+    final controller = TextEditingController(text: '123456');
+    addTearDown(controller.dispose);
+
+    await pumpInPrysmApp(
+      tester,
+      PrysmTextField(controller: controller, obscureText: true),
+    );
+
+    await tester.longPress(find.byType(PrysmEditableText));
+    await tester.pumpAndSettle();
+
+    // Copying a passphrase out of the field it was typed into is not an
+    // affordance we want; EditableText's own default is the same.
+    expect(editableState(tester).widget.selectionControls, isNull);
+    expect(find.byType(PrysmTextSelectionToolbar), findsNothing);
+  }, variant: onAndroid);
+
+  testWidgets('a disabled field offers no selection', (tester) async {
+    final controller = TextEditingController(text: 'read only');
+    addTearDown(controller.dispose);
+
+    await pumpInPrysmApp(
+      tester,
+      PrysmTextField(controller: controller, enabled: false),
+    );
+
+    await tester.longPress(find.byType(PrysmEditableText));
+    await tester.pumpAndSettle();
+
+    expect(editableState(tester).widget.selectionControls, isNull);
+    expect(find.byType(PrysmTextSelectionToolbar), findsNothing);
+  }, variant: onAndroid);
+
+  testWidgets('the context menu labels every button type without Material '
+      'localizations', (tester) async {
+    // WidgetsApp installs DefaultWidgetsLocalizations, which has no
+    // cut/copy/paste strings: the labels are ours, so every ContextMenuButtonType
+    // must map to one or a button renders blank.
+    for (final type in ContextMenuButtonType.values) {
+      final label = PrysmTextSelectionToolbar.labelFor(
+        ContextMenuButtonItem(onPressed: () {}, type: type),
+      );
+      expect(label, isNotEmpty, reason: 'no label for $type');
+    }
+    // A platform-supplied action (Android PROCESS_TEXT) carries its own label.
+    expect(
+      PrysmTextSelectionToolbar.labelFor(
+        ContextMenuButtonItem(
+          onPressed: () {},
+          type: ContextMenuButtonType.custom,
+          label: 'Translate',
+        ),
+      ),
+      'Translate',
+    );
+  });
+
+  // The teardrop point is the painter's local origin; mapping it through the
+  // handle's rotation must land on the corner getHandleAnchor reports.
+  testWidgets('the teardrop point of every handle lands on its anchor',
+      (tester) async {
+    final controls = PrysmTextSelectionControls();
+    await pumpInPrysmApp(
+      tester,
+      Builder(
+        builder: (context) => Column(
+          children: [
+            for (final type in TextSelectionHandleType.values)
+              KeyedSubtree(
+                key: ValueKey(type),
+                child: controls.buildHandle(context, type, 20.0),
+              ),
+          ],
+        ),
+      ),
+    );
+
+    const centre = Offset(10, 10);
+    for (final type in TextSelectionHandleType.values) {
+      final transform = find.descendant(
+        of: find.byKey(ValueKey(type)),
+        matching: find.byType(Transform),
+      );
+      // The right handle is drawn unrotated, so keep the identity matrix.
+      var matrix = Matrix4.identity();
+      if (transform.evaluate().isNotEmpty) {
+        matrix = tester.widget<Transform>(transform).transform;
+      }
+      final d = Offset.zero - centre;
+      final point = centre +
+          Offset(
+            matrix.storage[0] * d.dx + matrix.storage[4] * d.dy,
+            matrix.storage[1] * d.dx + matrix.storage[5] * d.dy,
+          );
+      // Collapsed is Material's (10,-4) vs the exact (10,-4.142).
+      expect(
+        (point - controls.getHandleAnchor(type, 20.0)).distance,
+        lessThan(0.2),
+      );
+    }
+  });
+}

--- a/test/prysm_text_selection_test.dart
+++ b/test/prysm_text_selection_test.dart
@@ -24,6 +24,7 @@ import 'package:prysm/theme/prysm_style_scope.dart';
 import 'package:prysm/ui/core/prysm_text_field.dart';
 import 'package:prysm/ui/core/prysm_text_selection.dart';
 import 'package:prysm/ui/core/prysm_icons.dart';
+import 'package:prysm/ui/core/prysm_pressable.dart';
 import 'package:prysm/ui/prysm_search_field.dart';
 
 Widget wrapWithStyle(Widget child) {
@@ -108,6 +109,19 @@ List<ContextMenuButtonItem> itemsWithOverflow() => [
       buttonItem('Read aloud'),
     ];
 
+/// Sets the surface size for a toolbar test and restores it afterwards, then
+/// pumps [child] inside the Prysm app. Shared by [pumpToolbar] and
+/// [pumpHarness] so the size bookkeeping lives in one place.
+Future<void> pumpSized(
+  WidgetTester tester,
+  Widget child, {
+  required double width,
+}) async {
+  await tester.binding.setSurfaceSize(Size(width, 800));
+  addTearDown(() => tester.binding.setSurfaceSize(null));
+  await pumpInPrysmApp(tester, child, width: width);
+}
+
 /// Pumps the toolbar directly with a hand-built item list. The surface is
 /// wider than a test's default 800x600 so the Ahem test font (every glyph a
 /// 15px square) still fits the primaries plus the more button on one row.
@@ -116,9 +130,7 @@ Future<void> pumpToolbar(
   List<ContextMenuButtonItem> items, {
   double width = 600,
 }) async {
-  await tester.binding.setSurfaceSize(Size(width, 800));
-  addTearDown(() => tester.binding.setSurfaceSize(null));
-  await pumpInPrysmApp(
+  await pumpSized(
     tester,
     PrysmTextSelectionToolbar(
       anchors: const TextSelectionToolbarAnchors(
@@ -159,9 +171,7 @@ Future<void> pumpHarness(
   List<ContextMenuButtonItem> items, {
   double width = 600,
 }) async {
-  await tester.binding.setSurfaceSize(Size(width, 800));
-  addTearDown(() => tester.binding.setSurfaceSize(null));
-  await pumpInPrysmApp(tester, ToolbarHarness(items: items), width: width);
+  await pumpSized(tester, ToolbarHarness(items: items), width: width);
 }
 
 void main() {
@@ -570,8 +580,14 @@ void main() {
       reason: 'the more button sits beside the primaries, not below them',
     );
 
-    final oneRowHeight = tester.getSize(find.text('Cut')).height +
-        const EdgeInsets.symmetric(horizontal: 14, vertical: 11).vertical;
+    // The height of one rendered row, measured from the widget that carries
+    // the toolbar's own vertical padding: the pressable holding the Cut
+    // label. A rendered baseline (not a copied EdgeInsets) stays honest if
+    // the production padding ever changes.
+    final oneRowHeight = tester.getSize(find.ancestor(
+      of: find.text('Cut'),
+      matching: find.byType(PrysmPressable),
+    )).height;
     expect(
       tester.getSize(find.byType(Wrap)).height,
       lessThan(oneRowHeight * 1.5),
@@ -812,32 +828,6 @@ void main() {
               'keyboard');
     });
 
-    testWidgets('the clear button wins its own taps and leaves the caret '
-        'alone', (tester) async {
-      final controller = TextEditingController(text: 'hello world');
-      addTearDown(controller.dispose);
-      // A caret the clear button must not move.
-      controller.selection = const TextSelection.collapsed(offset: 0);
-
-      var cleared = false;
-      await pumpInPrysmApp(
-        tester,
-        PrysmSearchField(
-          controller: controller,
-          onClear: () => cleared = true,
-        ),
-      );
-
-      await tester.tap(find.byType(PrysmClearButton));
-      await tester.pump();
-
-      expect(cleared, isTrue,
-          reason: 'the clear button must win the tap against the selection '
-              'gesture detector');
-      expect(controller.selection, const TextSelection.collapsed(offset: 0),
-          reason: 'the tap must not be stolen by the field caret placement');
-    });
-
     testWidgets('a disabled field stays keyboard-free when its chrome is '
         'tapped', (tester) async {
       final controller = TextEditingController(text: 'read only');
@@ -862,6 +852,34 @@ void main() {
       );
       expect(tester.testTextInput.isVisible, isFalse,
           reason: 'a tap on a disabled field must not open the keyboard');
+    });
+  });
+
+  group('the clear button wins its own taps and leaves the caret alone', () {
+    testWidgets('the clear button wins its own taps and leaves the caret '
+        'alone', (tester) async {
+      final controller = TextEditingController(text: 'hello world');
+      addTearDown(controller.dispose);
+      // A caret the clear button must not move.
+      controller.selection = const TextSelection.collapsed(offset: 0);
+
+      var cleared = false;
+      await pumpInPrysmApp(
+        tester,
+        PrysmSearchField(
+          controller: controller,
+          onClear: () => cleared = true,
+        ),
+      );
+
+      await tester.tap(find.byType(PrysmClearButton));
+      await tester.pump();
+
+      expect(cleared, isTrue,
+          reason: 'the clear button must win the tap against the selection '
+              'gesture detector');
+      expect(controller.selection, const TextSelection.collapsed(offset: 0),
+          reason: 'the tap must not be stolen by the field caret placement');
     });
   });
 }

--- a/test/prysm_text_selection_test.dart
+++ b/test/prysm_text_selection_test.dart
@@ -23,6 +23,7 @@ import 'package:prysm/theme/prysm_style_resolver.dart';
 import 'package:prysm/theme/prysm_style_scope.dart';
 import 'package:prysm/ui/core/prysm_text_field.dart';
 import 'package:prysm/ui/core/prysm_text_selection.dart';
+import 'package:prysm/ui/core/prysm_icons.dart';
 import 'package:prysm/ui/prysm_search_field.dart';
 
 Widget wrapWithStyle(Widget child) {
@@ -33,7 +34,11 @@ Widget wrapWithStyle(Widget child) {
   return PrysmStyleScope(style: style, child: child);
 }
 
-Future<void> pumpInPrysmApp(WidgetTester tester, Widget child) async {
+Future<void> pumpInPrysmApp(
+  WidgetTester tester,
+  Widget child, {
+  double width = 320,
+}) async {
   await tester.pumpWidget(
     wrapWithStyle(
       WidgetsApp(
@@ -44,7 +49,7 @@ Future<void> pumpInPrysmApp(WidgetTester tester, Widget child) async {
           pageBuilder: (context, animation, secondaryAnimation) =>
               builder(context),
         ),
-        home: Center(child: SizedBox(width: 320, child: child)),
+        home: Center(child: SizedBox(width: width, child: child)),
       ),
     ),
   );
@@ -52,6 +57,100 @@ Future<void> pumpInPrysmApp(WidgetTester tester, Widget child) async {
 
 EditableTextState editableState(WidgetTester tester) =>
     tester.state<EditableTextState>(find.byType(EditableText));
+
+ContextMenuButtonItem buttonItem(
+  String label, {
+  ContextMenuButtonType type = ContextMenuButtonType.custom,
+  VoidCallback? onPressed,
+}) {
+  return ContextMenuButtonItem(
+    onPressed: onPressed ?? () {},
+    type: type,
+    label: label,
+  );
+}
+
+/// The standard cut/copy/paste/select-all set EditableText reports on Android.
+List<ContextMenuButtonItem> standardItems() => [
+      ContextMenuButtonItem(onPressed: () {}, type: ContextMenuButtonType.cut),
+      ContextMenuButtonItem(onPressed: () {}, type: ContextMenuButtonType.copy),
+      ContextMenuButtonItem(
+        onPressed: () {},
+        type: ContextMenuButtonType.paste,
+      ),
+      ContextMenuButtonItem(
+        onPressed: () {},
+        type: ContextMenuButtonType.selectAll,
+      ),
+    ];
+
+/// The standard four actions plus the Android PROCESS_TEXT extras the bug
+/// report showed (installed apps arrive as `.custom` with a label).
+List<ContextMenuButtonItem> itemsWithOverflow() => [
+      ...standardItems(),
+      ContextMenuButtonItem(
+        onPressed: () {},
+        type: ContextMenuButtonType.share,
+      ),
+      buttonItem('Translate'),
+      buttonItem('Read aloud'),
+    ];
+
+/// Pumps the toolbar directly with a hand-built item list. The surface is
+/// wider than a test's default 800x600 so the Ahem test font (every glyph a
+/// 15px square) still fits the primaries plus the more button on one row.
+Future<void> pumpToolbar(
+  WidgetTester tester,
+  List<ContextMenuButtonItem> items, {
+  double width = 600,
+}) async {
+  await tester.binding.setSurfaceSize(Size(width, 800));
+  addTearDown(() => tester.binding.setSurfaceSize(null));
+  await pumpInPrysmApp(
+    tester,
+    PrysmTextSelectionToolbar(
+      anchors: const TextSelectionToolbarAnchors(
+        primaryAnchor: Offset(300, 120),
+      ),
+      buttonItems: items,
+    ),
+    width: width,
+  );
+}
+
+/// Rebuilds the toolbar in place across pumps, the way a new selection does:
+/// the same element receives a new [buttonItems] list, so `didUpdateWidget`
+/// runs instead of a fresh State being created.
+class ToolbarHarness extends StatefulWidget {
+  const ToolbarHarness({required this.items, super.key});
+
+  final List<ContextMenuButtonItem> items;
+
+  @override
+  State<ToolbarHarness> createState() => _ToolbarHarnessState();
+}
+
+class _ToolbarHarnessState extends State<ToolbarHarness> {
+  @override
+  Widget build(BuildContext context) {
+    return PrysmTextSelectionToolbar(
+      anchors: const TextSelectionToolbarAnchors(
+        primaryAnchor: Offset(300, 120),
+      ),
+      buttonItems: widget.items,
+    );
+  }
+}
+
+Future<void> pumpHarness(
+  WidgetTester tester,
+  List<ContextMenuButtonItem> items, {
+  double width = 600,
+}) async {
+  await tester.binding.setSurfaceSize(Size(width, 800));
+  addTearDown(() => tester.binding.setSurfaceSize(null));
+  await pumpInPrysmApp(tester, ToolbarHarness(items: items), width: width);
+}
 
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
@@ -272,4 +371,168 @@ void main() {
       );
     }
   });
+
+  // --- overflow folding (Android PROCESS_TEXT entries) -------------------
+
+  testWidgets('more than four items show the primaries and a more button, '
+      'folding the rest away', (tester) async {
+    await pumpToolbar(tester, itemsWithOverflow());
+
+    for (final label in ['Cut', 'Copy', 'Paste', 'Select all']) {
+      expect(find.text(label), findsOneWidget);
+    }
+    expect(find.byIcon(PrysmIcons.more), findsOneWidget);
+    for (final label in ['Share', 'Translate', 'Read aloud']) {
+      expect(find.text(label), findsNothing,
+          reason: 'overflow actions stay folded behind the more button');
+    }
+  }, variant: onAndroid);
+
+  testWidgets('the more button opens the overflow page and the back chevron '
+      'closes it', (tester) async {
+    await pumpToolbar(tester, itemsWithOverflow());
+
+    await tester.tap(find.byIcon(PrysmIcons.more));
+    await tester.pumpAndSettle();
+
+    expect(find.byIcon(PrysmIcons.chevronLeft), findsOneWidget);
+    for (final label in ['Share', 'Translate', 'Read aloud']) {
+      expect(find.text(label), findsOneWidget);
+    }
+    for (final label in ['Cut', 'Copy', 'Paste', 'Select all']) {
+      expect(find.text(label), findsNothing);
+    }
+
+    await tester.tap(find.byIcon(PrysmIcons.chevronLeft));
+    await tester.pumpAndSettle();
+
+    expect(find.byIcon(PrysmIcons.chevronLeft), findsNothing);
+    for (final label in ['Cut', 'Copy', 'Paste', 'Select all']) {
+      expect(find.text(label), findsOneWidget);
+    }
+    for (final label in ['Share', 'Translate', 'Read aloud']) {
+      expect(find.text(label), findsNothing);
+    }
+  }, variant: onAndroid);
+
+  testWidgets('tapping an overflow item invokes its onPressed',
+      (tester) async {
+    var translateTapped = false;
+    await pumpToolbar(
+      tester,
+      [
+        ...standardItems(),
+        buttonItem('Translate', onPressed: () => translateTapped = true),
+      ],
+    );
+
+    await tester.tap(find.byIcon(PrysmIcons.more));
+    await tester.pumpAndSettle();
+
+    expect(translateTapped, isFalse);
+    await tester.tap(find.text('Translate'));
+    await tester.pumpAndSettle();
+    expect(translateTapped, isTrue);
+  }, variant: onAndroid);
+
+  testWidgets('exactly the standard four items render no more button',
+      (tester) async {
+    await pumpToolbar(tester, standardItems());
+
+    for (final label in ['Cut', 'Copy', 'Paste', 'Select all']) {
+      expect(find.text(label), findsOneWidget);
+    }
+    expect(find.byIcon(PrysmIcons.more), findsNothing);
+  }, variant: onAndroid);
+
+  testWidgets('the collapsed page keeps the primaries and the more button on '
+      'a single row', (tester) async {
+    await pumpToolbar(tester, itemsWithOverflow());
+
+    final rowTop = tester.getTopLeft(find.text('Cut')).dy;
+    for (final label in ['Copy', 'Paste', 'Select all']) {
+      expect(tester.getTopLeft(find.text(label)).dy, rowTop,
+          reason: '$label sits on the same row as Cut');
+    }
+    expect(
+      tester.getTopLeft(find.byIcon(PrysmIcons.more)).dy,
+      closeTo(rowTop, 2),
+      reason: 'the more button sits beside the primaries, not below them',
+    );
+
+    final oneRowHeight = tester.getSize(find.text('Cut')).height +
+        const EdgeInsets.symmetric(horizontal: 14, vertical: 11).vertical;
+    expect(
+      tester.getSize(find.byType(Wrap)).height,
+      lessThan(oneRowHeight * 1.5),
+      reason: 'one row of items, not a wrapped stack',
+    );
+  }, variant: onAndroid);
+
+  testWidgets('a different item set closes the open overflow page',
+      (tester) async {
+    await pumpHarness(tester, itemsWithOverflow());
+    await tester.tap(find.byIcon(PrysmIcons.more));
+    await tester.pumpAndSettle();
+    expect(find.text('Translate'), findsOneWidget);
+
+    // A new selection reuses the same element with a different button list —
+    // here one with overflow actions of its own, which must not show stale.
+    await pumpHarness(
+      tester,
+      [
+        ...standardItems(),
+        buttonItem('Ask Meta AI'),
+        buttonItem('Ask ChatGPT'),
+      ],
+    );
+    expect(find.byIcon(PrysmIcons.more), findsOneWidget);
+    for (final label in ['Ask Meta AI', 'Ask ChatGPT', 'Translate']) {
+      expect(find.text(label), findsNothing,
+          reason: 'a different item set must fall back to the collapsed page');
+    }
+  }, variant: onAndroid);
+
+  testWidgets('rebuilding with the same labels keeps the overflow page open',
+      (tester) async {
+    await pumpHarness(tester, itemsWithOverflow());
+    await tester.tap(find.byIcon(PrysmIcons.more));
+    await tester.pumpAndSettle();
+    expect(find.text('Translate'), findsOneWidget);
+
+    // The toolbar rebuilds while open (e.g. the clipboard status flipping
+    // Paste on/off); the labels are unchanged, so the page must stay open.
+    await pumpHarness(tester, itemsWithOverflow());
+    expect(find.text('Translate'), findsOneWidget);
+    expect(find.text('Cut'), findsNothing);
+  }, variant: onAndroid);
+
+  testWidgets('a long PROCESS_TEXT list is capped at a third of the screen',
+      (tester) async {
+    await pumpToolbar(
+      tester,
+      [
+        ...standardItems(),
+        for (var i = 0; i < 25; i++) buttonItem('Action $i'),
+      ],
+    );
+    await tester.tap(find.byIcon(PrysmIcons.more));
+    await tester.pumpAndSettle();
+
+    final page = find.descendant(
+      of: find.byType(PrysmTextSelectionToolbar),
+      matching: find.byType(SingleChildScrollView),
+    );
+    expect(page, findsOneWidget);
+    final media = MediaQuery.of(
+      tester.element(find.byType(PrysmTextSelectionToolbar)),
+    );
+    expect(
+      tester.getSize(page).height,
+      lessThanOrEqualTo(media.size.height / 3 + 1),
+      reason: 'an arbitrarily long PROCESS_TEXT list must never run off '
+          'screen',
+    );
+  }, variant: onAndroid);
+
 }


### PR DESCRIPTION
Reported from a phone: holding down in a text field selects nothing and offers no copy/paste menu.

**Cause.** `PrysmTextField` and `PrysmSearchField` built a bare `EditableText`. It has no selection gestures of its own, and `selectionColor`, `selectionControls` and `contextMenuBuilder` all default to null. `RenderEditable`'s internal long-press recogniser *did* call `selectWord`, so the word was selected the whole time — just never painted, never grabbable, never actionable. The defect is three optional arguments that were never passed.

**Fix.** `PrysmEditableText` supplies the three missing pieces the way `TextField` does, but built only from `package:flutter/widgets.dart` and `PrysmTokens`: a `TextSelectionGestureDetectorBuilder` for the gestures, teardrop handles, and a toolbar with our own labels (`WidgetsApp` installs no cut/copy/paste strings). No Material import is added; `lib/` still has exactly one, the pre-existing `emoji_search_wrapper.dart`. Handles are withheld for obscured and read-only fields.

Also here, because reviewing the above surfaced it: `_isEditableFocused()` was **always false**. `FocusNode.context` is set by the `Focus` widget that owns the node, and `EditableText` wraps its subtree in one — so `primaryFocus.context.widget` is that `Focus`, never an `EditableText`. Desktop Ctrl shortcuts fired while the user was typing. One-line ancestor walk fixes it.

**Verification.** `flutter analyze` 0, full suite green. Driven live on an Android emulator and on the Linux desktop build: long press selects a word, the menu shows Cut/Copy/Share/Select all, Cut mutates the field, the toolbar tracks the field across a 269 dp relayout, and a magnified screenshot confirms each handle's point lands on its anchor. The focus guard was measured live on Linux: caret in the composer -> `oldCheck=false newCheck=true`, focus elsewhere -> both false.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added consistent text selection support across text and search fields, including custom selection handles and Prysm-styled context menus.
  * Added cut, copy, and paste actions with accent-colored selection highlights.
  * Improved selection behavior, scrolling, and interaction across supported fields.

* **Bug Fixes**
  * Improved keyboard shortcut handling when focus is inside a text field.

* **Tests**
  * Expanded coverage for selection, clipboard actions, search fields, disabled and obscured inputs, toolbars, and handle positioning.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->