### PR TITLE
fix(chat): Copy existed in only one of the three chat screens

### DIFF
--- a/lib/screens/chat.dart
+++ b/lib/screens/chat.dart
@@ -39,6 +39,7 @@ import 'package:prysm/theme/prysm_style_scope.dart';
 import 'package:prysm/theme/prysm_theme.dart';
 import 'package:prysm/util/scroll_to_chat_message.dart';
 import 'package:prysm/screens/widgets/contact_avatar.dart';
+import 'package:prysm/screens/widgets/message_copy_action.dart';
 import 'package:prysm/screens/widgets/message_reaction_bar.dart';
 import 'package:prysm/screens/widgets/message_reaction_picker.dart';
 import 'package:prysm/screens/widgets/file_attachment_bubble.dart';
@@ -1322,11 +1323,8 @@ class _ChatScreenState extends State<ChatScreen> {
   }
 
   String _getMessageText(Message message) {
-    if (message is TextMessage) return message.text;
-    if (message is FileMessage) return message.name;
-    if (message is ImageMessage) return '📷 Image';
     if (message is PrysmCallMessage) return _callMessageLabel(message);
-    return '';
+    return messageCopyText(message);
   }
 
   String _callMessageLabel(PrysmCallMessage message) {
@@ -1427,16 +1425,7 @@ class _ChatScreenState extends State<ChatScreen> {
     final isSentByMe = message.authorId == widget.userId;
     final danger = context.prysmStyle.tokens.danger;
     final tiles = <Widget>[
-      if (text.isNotEmpty)
-        PrysmListRow(
-          leading: const Icon(PrysmIcons.copy),
-          title: 'Copy',
-          onTap: () {
-            Navigator.pop(context);
-            Clipboard.setData(ClipboardData(text: text));
-            showPrysmToast(context, 'Copied to clipboard');
-          },
-        ),
+      if (text.isNotEmpty) copyMessageTile(context: context, text: text),
       if (canEditMessage(message, widget.userId))
         PrysmListRow(
           leading: const Icon(PrysmIcons.editOutlined),

--- a/lib/screens/group_chat.dart
+++ b/lib/screens/group_chat.dart
@@ -33,6 +33,7 @@ import 'package:prysm/ui/chat/prysm_message_row.dart';
 import 'package:prysm/util/logging.dart';
 import 'package:prysm/util/scroll_to_chat_message.dart';
 import 'package:prysm/screens/widgets/message_reaction_bar.dart';
+import 'package:prysm/screens/widgets/message_copy_action.dart';
 import 'package:prysm/screens/widgets/message_reaction_picker.dart';
 import 'package:prysm/screens/widgets/file_attachment_bubble.dart';
 import 'package:prysm/screens/widgets/linked_message_text.dart';
@@ -477,10 +478,12 @@ class _GroupChatScreenState extends State<GroupChatScreen> {
   void _showMessageMenu(Message message) {
     if (isMessageDeleted(message)) return;
     final isSentByMe = message.authorId == widget.userId;
+    final text = messageCopyText(message);
     showMessageActionsSheet(
       context: context,
       onReactionSelected: (emoji) => _controller.onReactionSelected(message, emoji),
       actionTiles: [
+        if (text.isNotEmpty) copyMessageTile(context: context, text: text),
         if (canEditMessage(message, widget.userId))
           PrysmListRow(
             leading: const Icon(PrysmIcons.editOutlined),

--- a/lib/screens/self_chat_screen.dart
+++ b/lib/screens/self_chat_screen.dart
@@ -15,6 +15,7 @@ import 'package:image_picker/image_picker.dart';
 import 'package:prysm/crypto/wire.dart';
 import 'package:prysm/database/self_messages_db.dart';
 import 'package:prysm/screens/widgets/deleted_message_bubble.dart';
+import 'package:prysm/screens/widgets/message_copy_action.dart';
 import 'package:prysm/screens/widgets/file_attachment_bubble.dart';
 import 'package:prysm/screens/widgets/image_message_bubble.dart';
 import 'package:prysm/screens/widgets/linked_message_text.dart';
@@ -359,11 +360,13 @@ class _SelfChatScreenState extends State<SelfChatScreen> {
   void _showMessageMenu(BuildContext context, Message message) {
     if (isMessageDeleted(message)) return;
 
+    final text = messageCopyText(message);
     showPrysmSheet(
       context: context,
       builder: (ctx) => Column(
         mainAxisSize: MainAxisSize.min,
         children: [
+          if (text.isNotEmpty) copyMessageTile(context: context, text: text),
           PrysmListRow(
             leading: const Icon(PrysmIcons.deleteOutline),
             title: 'Delete',

--- a/lib/screens/widgets/message_copy_action.dart
+++ b/lib/screens/widgets/message_copy_action.dart
@@ -30,10 +30,17 @@ PrysmListRow copyMessageTile({
   return PrysmListRow(
     leading: const Icon(PrysmIcons.copy),
     title: 'Copy',
-    onTap: () {
+    onTap: () async {
       Navigator.pop(context);
-      Clipboard.setData(ClipboardData(text: text));
-      showPrysmToast(context, 'Copied to clipboard');
+      // Claiming success before the write lands makes the toast a lie when
+      // the platform refuses the clipboard (PlatformException). Await it.
+      try {
+        await Clipboard.setData(ClipboardData(text: text));
+      } catch (_) {
+        if (context.mounted) showPrysmToast(context, 'Could not copy');
+        return;
+      }
+      if (context.mounted) showPrysmToast(context, 'Copied to clipboard');
     },
   );
 }

--- a/lib/screens/widgets/message_copy_action.dart
+++ b/lib/screens/widgets/message_copy_action.dart
@@ -1,0 +1,39 @@
+import 'package:flutter/services.dart';
+import 'package:flutter/widgets.dart';
+import 'package:prysm/models/chat/prysm_message.dart';
+import 'package:prysm/ui/core/prysm_icons.dart';
+import 'package:prysm/ui/core/prysm_list_row.dart';
+import 'package:prysm/ui/core/prysm_toast.dart';
+
+/// The plain text a message copies as, or '' when it carries none.
+///
+/// Call messages are deliberately not handled here: their label is built from
+/// direction, status and duration by the only screen that renders them.
+String messageCopyText(Message message) {
+  if (message is TextMessage) return message.text;
+  if (message is FileMessage) return message.name;
+  if (message is ImageMessage) return '📷 Image';
+  return '';
+}
+
+/// The 'Copy' row of a message action sheet.
+///
+/// Shared because all three chat screens need the identical row and only the
+/// 1:1 chat had it: long-pressing a message in a group or in the self-chat
+/// offered no way to copy its text at all. `context` must be the screen's, not
+/// the sheet builder's: the tap dismisses the sheet's route, so the context
+/// must outlive the sheet.
+PrysmListRow copyMessageTile({
+  required BuildContext context,
+  required String text,
+}) {
+  return PrysmListRow(
+    leading: const Icon(PrysmIcons.copy),
+    title: 'Copy',
+    onTap: () {
+      Navigator.pop(context);
+      Clipboard.setData(ClipboardData(text: text));
+      showPrysmToast(context, 'Copied to clipboard');
+    },
+  );
+}

--- a/test/message_copy_action_test.dart
+++ b/test/message_copy_action_test.dart
@@ -1,0 +1,134 @@
+// Guards the shared 'Copy' action of the message menus.
+//
+// Long-pressing a message opened an action sheet with no Copy row in the group
+// chat and in the self-chat: only the 1:1 chat had one, because the sheet was
+// written three times instead of once. That is half of the reported defect
+// ("hold down and you get no copy menu"); the other half — selection inside the
+// composer — is covered by prysm_text_selection_test.dart.
+//
+// The three screens themselves are not pumpable (their initState drives
+// ChatService/sqflite; see HANDOFF.md and group_invite_mode_screens_test.dart),
+// so the seam under test is the shared tile they now all build. That the three
+// screens actually call it was verified on the running app, not here.
+import 'package:flutter/services.dart';
+import 'package:flutter/widgets.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:prysm/models/appearance_settings.dart';
+import 'package:prysm/models/chat/prysm_message.dart';
+import 'package:prysm/screens/widgets/message_copy_action.dart';
+import 'package:prysm/theme/prysm_style_resolver.dart';
+import 'package:prysm/theme/prysm_style_scope.dart';
+
+Widget wrapWithStyle(Widget child) {
+  final style = PrysmStyleResolver.resolve(
+    themePalette: 0,
+    appearance: const AppearanceSettings(),
+  );
+  return PrysmStyleScope(style: style, child: child);
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  group('messageCopyText', () {
+    test('a text message copies its body', () {
+      expect(
+        messageCopyText(
+          PrysmTextMessage(id: 'm1', authorId: 'a', text: 'axolotl dossier'),
+        ),
+        'axolotl dossier',
+      );
+    });
+
+    test('a file message copies its name, not its source path', () {
+      expect(
+        messageCopyText(
+          PrysmFileMessage(
+            id: 'm2',
+            authorId: 'a',
+            name: 'report.pdf',
+            source: 'blob:deadbeef',
+            size: 12,
+          ),
+        ),
+        'report.pdf',
+      );
+    });
+
+    test('an image message copies a placeholder, never its source', () {
+      final text = messageCopyText(
+        PrysmImageMessage(
+          id: 'm3',
+          authorId: 'a',
+          source: 'blob:deadbeef',
+          size: 12,
+        ),
+      );
+      expect(text, '📷 Image');
+      expect(text.contains('blob:'), isFalse);
+    });
+
+    test('a call message has no copy text — its label belongs to the '
+        'screen that renders it', () {
+      expect(
+        messageCopyText(
+          PrysmCallMessage(
+            id: 'm4',
+            authorId: 'a',
+            direction: 'outbound',
+            callStatus: 'completed',
+            durationMs: 1000,
+          ),
+        ),
+        '',
+      );
+    });
+  });
+
+  testWidgets('the Copy tile writes the message text to the clipboard',
+      (tester) async {
+    final calls = <MethodCall>[];
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(SystemChannels.platform, (call) async {
+      calls.add(call);
+      return null;
+    });
+    addTearDown(
+      () => TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+          .setMockMethodCallHandler(SystemChannels.platform, null),
+    );
+
+    await tester.pumpWidget(
+      wrapWithStyle(
+        WidgetsApp(
+          color: const Color(0xFF000000),
+          pageRouteBuilder: <T>(RouteSettings settings, WidgetBuilder builder) =>
+              PageRouteBuilder<T>(
+            settings: settings,
+            pageBuilder: (context, animation, secondaryAnimation) =>
+                builder(context),
+          ),
+          home: Builder(
+            builder: (context) =>
+                copyMessageTile(context: context, text: 'axolotl dossier'),
+          ),
+        ),
+      ),
+    );
+
+    expect(find.text('Copy'), findsOneWidget);
+    await tester.tap(find.text('Copy'));
+    await tester.pump();
+
+    // The row also confirms the copy, and showPrysmToast holds a 3s
+    // Future.delayed to pull its overlay entry: the binding fails the test on
+    // any timer that outlives the tree, so it has to be drained here.
+    expect(find.text('Copied to clipboard'), findsOneWidget);
+    await tester.pump(const Duration(seconds: 4));
+
+    final setData =
+        calls.where((call) => call.method == 'Clipboard.setData').toList();
+    expect(setData, hasLength(1));
+    expect((setData.single.arguments as Map)['text'], 'axolotl dossier');
+  });
+}

--- a/test/message_copy_action_test.dart
+++ b/test/message_copy_action_test.dart
@@ -18,6 +18,7 @@ import 'package:prysm/models/chat/prysm_message.dart';
 import 'package:prysm/screens/widgets/message_copy_action.dart';
 import 'package:prysm/theme/prysm_style_resolver.dart';
 import 'package:prysm/theme/prysm_style_scope.dart';
+import 'package:prysm/ui/core/prysm_list_row.dart';
 
 Widget wrapWithStyle(Widget child) {
   final style = PrysmStyleResolver.resolve(
@@ -118,7 +119,7 @@ void main() {
 
     expect(find.text('Copy'), findsOneWidget);
     await tester.tap(find.text('Copy'));
-    await tester.pump();
+    await tester.pumpAndSettle();
 
     // The row also confirms the copy, and showPrysmToast holds a 3s
     // Future.delayed to pull its overlay entry: the binding fails the test on
@@ -130,5 +131,54 @@ void main() {
         calls.where((call) => call.method == 'Clipboard.setData').toList();
     expect(setData, hasLength(1));
     expect((setData.single.arguments as Map)['text'], 'axolotl dossier');
+  });
+
+  testWidgets('tapping Copy dismisses the sheet it sits in', (tester) async {
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(SystemChannels.platform, (call) async => null);
+    addTearDown(
+      () => TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+          .setMockMethodCallHandler(SystemChannels.platform, null),
+    );
+
+    late BuildContext screenContext;
+    await tester.pumpWidget(
+      wrapWithStyle(
+        WidgetsApp(
+          color: const Color(0xFF000000),
+          pageRouteBuilder: <T>(RouteSettings settings, WidgetBuilder builder) =>
+              PageRouteBuilder<T>(
+            settings: settings,
+            pageBuilder: (context, animation, secondaryAnimation) =>
+                builder(context),
+          ),
+          home: Builder(
+            builder: (context) {
+              screenContext = context;
+              return const SizedBox.shrink();
+            },
+          ),
+        ),
+      ),
+    );
+
+    // The real sheet helper, opened with the SCREEN's context — the trap the
+    // tile's dartdoc warns about is passing the sheet builder's instead.
+    showPrysmSheet<void>(
+      context: screenContext,
+      builder: (_) => copyMessageTile(
+        context: screenContext,
+        text: 'axolotl dossier',
+      ),
+    );
+    await tester.pumpAndSettle();
+    expect(find.text('Copy'), findsOneWidget);
+
+    await tester.tap(find.text('Copy'));
+    await tester.pumpAndSettle();
+
+    expect(find.text('Copy'), findsNothing, reason: 'the sheet must close');
+    expect(find.text('Copied to clipboard'), findsOneWidget);
+    await tester.pump(const Duration(seconds: 4));
   });
 }


### PR DESCRIPTION
Found while verifying the text-selection fix on a real device: long-pressing a bubble in the self-chat offered **only Delete**. The same was true in group chats. Only the 1:1 chat had a Copy row.

The row was written inline in `chat.dart`. Duplicating it twice more would have repeated the defect that caused this, so it is collapsed into `lib/screens/widgets/message_copy_action.dart` (`messageCopyText` + `copyMessageTile`) and wired into all three screens.

`chat.dart` keeps its own branch for call messages: their label is built from direction, status and duration by helpers private to that screen, and moving those would be a wider refactor than this fix needs. Its behaviour is unchanged — same row position, same guard, same context, same pop/copy/toast order.

**Verification.** `flutter analyze` 0, full suite green, unit + widget tests for the shared seam. Driven live over real Tor on two peers: long-press a bubble in the self-chat and in a real group -> sheet shows Copy, tapping it closes the sheet and raises the "Copied to clipboard" toast on both.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a Copy action to standard, group, and self-chat message menus.
  - Supports copying text, file names, and image descriptions when available.
  - Shows confirmation feedback after copying.

- **Bug Fixes**
  - Prevents unsupported call messages and sensitive source paths from being copied.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->