### PR TITLE
fix(transport): bound a stale WS send and let an undialable peer's link form

### DIFF
--- a/lib/app/app_composition.dart
+++ b/lib/app/app_composition.dart
@@ -6,6 +6,7 @@ import 'package:prysm/services/block_service.dart';
 import 'package:prysm/services/call/call_manager.dart';
 import 'package:prysm/services/file_transfer_handler.dart';
 import 'package:prysm/services/message_search_backfill_service.dart';
+import 'package:prysm/services/peer_identity_resolver.dart';
 import 'package:prysm/services/read_receipt_service.dart';
 import 'package:prysm/services/sync_coordinator.dart';
 import 'package:prysm/services/wake_hint_service.dart';
@@ -13,6 +14,7 @@ import 'package:prysm/transport/transport_provider.dart';
 import 'package:prysm/util/key_manager.dart';
 import 'package:prysm/util/local_onion_address.dart';
 import 'package:prysm/util/logging.dart';
+import 'package:prysm/util/peer_identity_loader.dart';
 import 'package:prysm/util/tor_runtime_gate.dart';
 import 'package:prysm/util/tor_service.dart';
 
@@ -53,6 +55,15 @@ class AppComposition {
       } catch (_) {
         return null;
       }
+    };
+    // Cache-miss only: a hit means the hello gate can already resolve them.
+    TransportProvider.learnPeerIdentity = (peerOnion) async {
+      if (!keyManager.isUnlocked) return;
+      if (await loadPeerIdentityFromDb(keyManager, peerOnion) != null) return;
+      await PeerIdentityResolver(
+        peerId: peerOnion,
+        keyManager: keyManager,
+      ).fetchOverTor();
     };
     CallManager.configure(keyManager: keyManager);
     CallManager.instance.start();

--- a/lib/transport/tor_websocket_transport.dart
+++ b/lib/transport/tor_websocket_transport.dart
@@ -60,6 +60,10 @@ class TorWebSocketTransport implements OutboundTransport {
     });
   }
 
+  // Healthy acks take 0.22-0.47 s, worst healthy wire 6.5 s: 8 s never bites
+  // a healthy link and bounds a wrong "connected" guess.
+  static const Duration _wsAckCap = Duration(seconds: 8);
+
   @override
   Future<void> postMessage({
     required String peerOnion,
@@ -72,7 +76,8 @@ class TorWebSocketTransport implements OutboundTransport {
         peerOnion,
         op,
         payload: payload,
-        timeout: timeout,
+        // WS leg only; the HTTP fallback keeps the full timeout for its own.
+        timeout: timeout < _wsAckCap ? timeout : _wsAckCap,
       );
       final error = ack['error'];
       if (error != null) {

--- a/lib/transport/transport_provider.dart
+++ b/lib/transport/transport_provider.dart
@@ -386,8 +386,6 @@ class TransportProvider implements OutboundTransport {
     );
   }
 
-  static const Duration _wsSendBudget = Duration(seconds: 30);
-
   static bool _shouldDisconnectWsAfterFailure(Object error) {
     if (error is TimeoutException) return false;
     if (error is StateError) {
@@ -396,11 +394,6 @@ class TransportProvider implements OutboundTransport {
           message.contains('disconnected');
     }
     return true;
-  }
-
-  static Duration _wsSendTimeoutFor(Duration requested) {
-    if (requested > _wsSendBudget) return requested;
-    return requested < _wsSendBudget ? requested : _wsSendBudget;
   }
 
   static Future<void> postMessageOrFallback({
@@ -431,17 +424,19 @@ class TransportProvider implements OutboundTransport {
         );
       }
       if (inst.isRealtimeConnected(peerOnion) && !skipWsForLargePayload) {
-        final wsTimeout = _wsSendTimeoutFor(timeout);
         Object? lastWsError;
         for (var attempt = 0; attempt < 2; attempt++) {
           try {
             await inst.postMessageWithPreference(
               peerOnion: peerOnion,
               payload: payload,
-              timeout: wsTimeout,
+              timeout: timeout,
               preference: TransportPreference.wsIfConnected,
             );
-            Logging.debug('WS send ok $peerOnion', 'TransportProvider');
+            Logging.debug(
+              'WS-preferred send ok $peerOnion (may have used HTTP)',
+              'TransportProvider',
+            );
             return;
           } catch (e) {
             lastWsError = e;

--- a/lib/transport/transport_provider.dart
+++ b/lib/transport/transport_provider.dart
@@ -61,6 +61,8 @@ class TransportProvider implements OutboundTransport {
   static void resetForTest() {
     _instance?.dispose();
     _instance = null;
+    // Static hook: without this it leaks into every later test in the file.
+    learnPeerIdentity = null;
     PeerTransportRegistry.instance.resetForTest();
   }
 
@@ -93,6 +95,13 @@ class TransportProvider implements OutboundTransport {
 
   void unpinPeer(String peerOnion) => _wsManager.unpinPeer(peerOnion);
 
+  /// Composition-time hook, not ambient global state: same reason as
+  /// [PeerProof.localIdentity] — this layer is built from a [TorManager]
+  /// alone and has no path to a [KeyManager] or to the user store. The
+  /// composition root sets it; the closure resolves and persists a peer's
+  /// public keys, and must swallow its own failures.
+  static Future<void> Function(String peerOnion)? learnPeerIdentity;
+
   /// Tries to restore a WebSocket after HTTP fallback or disconnect.
   Future<void> recoverWebSocket(String peerOnion) async {
     if (isRealtimeConnected(peerOnion)) return;
@@ -108,6 +117,15 @@ class TransportProvider implements OutboundTransport {
     } catch (_) {}
 
     if (isRealtimeConnected(peerOnion)) return;
+
+    // Reachable over HTTP but undialable is the signature of a peer whose
+    // keys we never learned — a group co-member we never added. The hello
+    // gate resolves cache-only by design, so their dial to us keeps getting
+    // rejected until their identity is in our store. Learn it here, off the
+    // send path, so the next dial in either direction can succeed.
+    try {
+      await learnPeerIdentity?.call(peerOnion);
+    } catch (_) {}
 
     try {
       await postSyncHint(peerOnion: peerOnion);

--- a/test/transport_provider_test.dart
+++ b/test/transport_provider_test.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter_test/flutter_test.dart';
 import 'package:prysm/services/ws_connection_manager.dart';
 import 'package:prysm/transport/peer_transport_registry.dart';
@@ -6,6 +8,7 @@ import 'package:prysm/transport/transport_preference.dart';
 import 'package:prysm/transport/transport_provider.dart';
 import 'package:prysm/transport/ws_peer_link.dart';
 import 'package:prysm/util/tor_delivery.dart';
+import 'package:prysm/util/tor_runtime_gate.dart';
 import 'package:prysm/util/tor_service.dart';
 
 void main() {
@@ -106,13 +109,75 @@ void main() {
     expect(usedWs, isTrue);
     expect(result, 'ok');
   });
+
+  test('WS ack wait is capped when a connected link never acks', () async {
+    TransportProvider.configure(
+      TorManager(
+        torPath: '/bin/false',
+        dataDir: '/tmp/transport-provider-ws-ack-cap',
+        controlPassword: 'test-password',
+      ),
+    );
+    // Open the gate: the default stopped state refuses before asking.
+    TorRuntimeGate.resetForTest();
+
+    final link = _FakeWsPeerLink('peer.onion', stallAck: true);
+    TransportProvider.instance.wsManager.registerLinkForTest(
+      'peer.onion',
+      link,
+    );
+
+    final stopwatch = Stopwatch()..start();
+    try {
+      await TransportProvider.instance.postMessageWithPreference(
+        peerOnion: 'peer.onion',
+        payload: {'type': 'text'},
+        preference: TransportPreference.wsIfConnected,
+      );
+    } catch (_) {
+      // WS leg timed out at its cap; the HTTP fallback cannot deliver.
+    }
+    stopwatch.stop();
+
+    // A stale-but-connected link must not eat the whole 30 s send budget.
+    expect(stopwatch.elapsed, lessThan(const Duration(seconds: 15)));
+    expect(link.lastRequestTimeout, lessThan(const Duration(seconds: 15)));
+  });
+
+  test('recoverWebSocket learns the identity of an undialable peer', () async {
+    TransportProvider.configure(
+      TorManager(
+        torPath: '/bin/false',
+        dataDir: '/tmp/transport-provider-learn-identity',
+        controlPassword: 'test-password',
+      ),
+    );
+
+    final learned = <String>[];
+    TransportProvider.learnPeerIdentity = (peerOnion) async {
+      learned.add(peerOnion);
+    };
+
+    // No link is registered, so the dial fails: this is the group co-member
+    // we can reach over HTTP but whose hello we keep rejecting because their
+    // keys were never stored. Recovery must go and learn them.
+    await TransportProvider.instance.recoverWebSocket('stranger.onion');
+
+    expect(learned, ['stranger.onion']);
+  });
 }
 
 class _FakeWsPeerLink implements WsPeerLink {
-  _FakeWsPeerLink(this.peerOnion);
+  _FakeWsPeerLink(this.peerOnion, {this.stallAck = false});
 
   @override
   final String peerOnion;
+
+  /// When true, [request] never answers; only its own timeout can fire.
+  final bool stallAck;
+
+  /// Last timeout handed to [request]; lets tests see the applied cap.
+  Duration? lastRequestTimeout;
 
   @override
   bool isConnected = true;
@@ -134,8 +199,15 @@ class _FakeWsPeerLink implements WsPeerLink {
     String op, {
     Map<String, dynamic>? payload,
     Duration timeout = const Duration(seconds: 30),
-  }) async =>
-      <String, dynamic>{};
+  }) {
+    lastRequestTimeout = timeout;
+    if (!stallAck) {
+      return Future<Map<String, dynamic>>.value(<String, dynamic>{});
+    }
+    // A half-dead socket reports connected but never acks: mirror the real
+    // link, where only the passed timeout can fire.
+    return Completer<Map<String, dynamic>>().future.timeout(timeout);
+  }
 
   @override
   Future<void> send(String op, {Map<String, dynamic>? payload}) async {}

--- a/test/transport_provider_test.dart
+++ b/test/transport_provider_test.dart
@@ -8,6 +8,7 @@ import 'package:prysm/transport/transport_preference.dart';
 import 'package:prysm/transport/transport_provider.dart';
 import 'package:prysm/transport/ws_peer_link.dart';
 import 'package:prysm/util/tor_delivery.dart';
+import 'package:prysm/util/tor_lifecycle_state.dart';
 import 'package:prysm/util/tor_runtime_gate.dart';
 import 'package:prysm/util/tor_service.dart';
 
@@ -118,8 +119,12 @@ void main() {
         controlPassword: 'test-password',
       ),
     );
-    // Open the gate: the default stopped state refuses before asking.
+    // Open the gate: the default stopped state refuses before asking. It is
+    // process-wide, so put it back or the next test inherits a ready gate.
     TorRuntimeGate.resetForTest();
+    addTearDown(
+      () => TorRuntimeGate.resetForTest(lifecycle: TorLifecycleState.stopped),
+    );
 
     final link = _FakeWsPeerLink('peer.onion', stallAck: true);
     TransportProvider.instance.wsManager.registerLinkForTest(
@@ -140,8 +145,9 @@ void main() {
     stopwatch.stop();
 
     // A stale-but-connected link must not eat the whole 30 s send budget.
+    // Pin the cap exactly: `lessThan(15s)` would accept a 14 s regression.
     expect(stopwatch.elapsed, lessThan(const Duration(seconds: 15)));
-    expect(link.lastRequestTimeout, lessThan(const Duration(seconds: 15)));
+    expect(link.lastRequestTimeout, const Duration(seconds: 8));
   });
 
   test('recoverWebSocket learns the identity of an undialable peer', () async {


### PR DESCRIPTION
Two delivery defects measured on a two-peer lab (two containers, real Tor, real onions, ~110 real messages, zero lost).

**1. A stale WebSocket link burns the whole send budget.** 2 of 16 sends to the second peer took **49.2 s and 54.8 s**; the same test between two Linux peers produced zero such stalls (median wire time 0.43 s). The sender logged `TimeoutException after 0:00:30` and only then delivered over HTTP.

The link cannot be known dead: `isRealtimeConnected` is a *handshake* flag, and the heartbeat ping is fire-and-forget (`sendPing` -> `socket.add`, no pong awaited, `pong` frames are swallowed), so `_maxPingFailures` can never trip. A half-dead link reports connected indefinitely. So the cost of guessing wrong is bounded instead: the WS ack wait is capped at 8 s — above every healthy ack measured (0.22-0.47 s) and above the worst healthy wire time seen (6.5 s), far below the 30 s budget. The cap sits at the WS transport boundary on purpose: the same timeout value is reused for `withPeer`'s internal HTTP fallback leg, which legitimately needs ~20 s.

While there: `_wsSendTimeoutFor` returned its argument on every branch, so `_wsSendBudget` was never applied — both deleted. And `WS send ok` was logged even when the internal HTTP leg delivered; it no longer claims a transport it cannot know.

**2. Two members of the same group who are not mutual contacts can never form a WS link.** The invite carries `{id, role}` and no keys, `ensureUserExist` seeds a row with `identityJson` NULL, and the hello gate resolves cache-only by design — so each side rejects the other's hello forever (`rejecting hello from unknown peer`). Measured: first group message between such a pair **134 s**, later ones still 19-22 s, against 0.6 s for a contact pair.

`recoverWebSocket` now learns the peer's identity after a failed dial. It uses a composition-time hook, for the reason already documented on `PeerProof.localIdentity`: this layer is built from a `TorManager` alone and has no path to a `KeyManager` or the user store. The fetch sits off the hello path, off inbound processing and off the send critical path, so the cache-only anti-flood property and the M2 no-oracle rule are untouched.

**Verification.** `flutter analyze` 0, full suite green. Both new tests were proved mordant by reverting the fix (30 s without the cap; hook never called without the call). Live on three Linux peers where two are strangers inside one group: B<->C converges from 41.7 s to a steady **0.77 s / 0.68 s** median, and `rejecting hello` stops (20 during convergence, 0 after).

Known limit: convergence needs traffic in both directions, and the first exchange is still slow. Putting member keys in the signed invite would fix the unidirectional case too — deliberately not done here.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved peer identity recovery when connecting through Tor.
  * Added automatic recovery for undialable peers before synchronization.
  * Capped WebSocket acknowledgment waits at 8 seconds to improve fallback responsiveness.
  * Preserved the full requested timeout for HTTP fallback requests.
  * Improved connection status reporting when HTTP fallback is used.

* **Tests**
  * Added coverage for WebSocket timeout handling and peer identity recovery.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->