### PR TITLE
feat(lab): Android platform, long-press, and a two-peer transmission harness

### DIFF
--- a/.agents/skills/live-app-testing/SKILL.md
+++ b/.agents/skills/live-app-testing/SKILL.md
@@ -1,14 +1,25 @@
 ---
 name: live-app-testing
-description: "Use when you need to prove UI<->state integration on the real, running Prysm desktop app: screens render what the stores contain, taps land, routes open and close. Proves the app's own wiring end to end. It does NOT prove pixels, does NOT prove the compositor's input path, and does NOT run in CI."
+description: "Use when you need to prove UI<->state integration on the real, running Prysm app — Linux desktop or Android — : screens render what the stores contain, taps and long presses land, routes open and close. Proves the app's own wiring end to end. It does NOT prove pixels by itself, does NOT prove the compositor's input path, and does NOT run in CI."
 ---
 
 # Live App Testing
 
-Drive the real Prysm Linux desktop app with `tool/live/prysmlab` — observation (Dart VM
-Service widget trees), control (in-app pointer events via `evaluate`), and data injection
-(HTTP against the app's loopback server). The app runs in a throwaway container under Xvfb
-with a private D-Bus session and keyring.
+Drive the real Prysm app with `tool/live/prysmlab` — observation (Dart VM Service widget
+trees), control (in-app pointer events via `evaluate`), and data injection (HTTP against the
+app's loopback server). Two platforms, one CLI:
+
+| | command | what runs |
+|---|---|---|
+| Linux desktop | `prysmlab …` (default) | the GTK app under Xvfb, private D-Bus session + keyring |
+| Android | `prysmlab -p android …` | the real APK on an in-container x86_64 emulator (KVM), AVD `pixel_5` |
+
+Everything downstream of the VM Service is identical on both; only the lifecycle differs.
+**Pick the platform the report came from.** A layout or gesture complaint from a phone is not
+refuted by the desktop build: `defaultTargetPlatform` changes the gesture branch that runs
+(on Linux a long press inside a focused field moves the caret, on Android it selects a word),
+and the two builds do not even render the same navigation surfaces.
+The Android lab has its own handoff: `HANDOFF-android-lab.md`.
 
 ## When to use it — and when not
 
@@ -18,10 +29,15 @@ close, a store whose change the UI never reflects. That is where this method fou
 
 Do NOT use it for:
 
-- **Pixels.** The dump is text: what is in the tree, not how it looks. Alignment, contrast,
-  truncation, overlap are invisible here. `prysmlab shot` writes a PNG of the Xvfb framebuffer
-  (verified: 1440x900), but producing an image is not reading one: with no vision-capable tool
-  available, the PNG proves nothing on its own.
+- **Pixels, by default.** The dump is text: what is in the tree, not how it looks.
+  `prysmlab shot` writes a PNG (Xvfb framebuffer on Linux, `adb exec-out screencap` on
+  Android) — and on a harness with an image-inspection tool that PNG *is* readable, which is
+  how the selection handles were caught pointing the wrong way:
+  `SHOT=$(prysmlab -p android shot | tail -1) && docker cp prysm-lab-android:"$SHOT" /tmp/x.png`,
+  then inspect `/tmp/x.png`. Use it for **geometry and presence**, never for values: the
+  reading is a description, not a measurement, and it has already mistaken the app's own light
+  theme for "a Material toolbar" and a system dialog's scrim for "a dark app". For colours,
+  read the live token with an `eval`; for rects, read the `RenderBox` with an `eval`.
 - **The compositor's input path.** `prysmlab tap` delivers `PointerDown/UpEvent` through
   Flutter's own hit test and gesture recognizers. It proves the app's wiring, not that a real
   click (window focus, display scaling, layered windows) arrives the same way.
@@ -58,7 +74,12 @@ prysmlab tap "Settings"   # act
 prysmlab down --purge     # teardown is part of the method — always
 ```
 
-`up` prints progress; the first run compiles the Linux bundle (minutes). `up --fresh` destroys
+The Android lab is the same seven lines with `-p android`; `doctor` there checks `/dev/kvm`
+instead of the repo tor binary, and `up` budgets ~6-7 min from cold (image from the Docker
+cache, emulator boot, gradle build). On the narrow Android home the sidebar is behind a
+button: `prysmlab -p android tap-widget --type Semantics --contains "Open menu"`.
+
+`up` prints progress; the first run compiles the app (minutes). `up --fresh` destroys
 the container first (loses the test identity) and re-stages; `prysmlab sync` re-stages without
 relaunching (a running app keeps the old code); `prysmlab restart [--sync]` relaunches the app
 in the running container — the way to pick up code changes (hot restart over stdin is not an
@@ -179,6 +200,82 @@ are forwarded into the container.
     `prysmlab type "<text>" [-n IDX] [--submit]` (verified working) finds an `EditableText` and
     feeds the text through `updateEditingValue` — the real platform-input entry point — so input
     formatters run and `onChanged` fires. Assigning to `controller.text` instead fires neither.
+
+13. **`tap` can never open a long-press menu; use `longpress`.**
+    `tap` sends down and up in the same turn, far below any
+    `LongPressGestureRecognizer` deadline, so the whole class of "hold down and nothing
+    happens" defects was invisible to this lab until `longpress` existed.
+    `prysmlab longpress "<text>" | --type <Widget> [--contains …] [-n IDX] [--hold MS]`
+    holds the pointer and schedules the release on the app's own event loop (`evaluate` is
+    synchronous, so it cannot wait). **Read the result with the next `screen`/`count`, not
+    from the command's output** — the command returns while the gesture is still in flight.
+    Message bubbles carry their text in `RichText`, not `Text`, so target them with
+    `--type RichText --contains "<word>"`; a composer is `--type PrysmEditableText`.
+
+14. **A long press does different things per platform, and both are correct.**
+    `TextSelectionGestureDetectorBuilder.onSingleLongTapStart` branches on
+    `defaultTargetPlatform`: on Android it selects the word under the finger, on Linux/Windows
+    it only moves the caret when the field already has focus. So an empty-looking Linux result
+    (`sel=105..105`, menu with just "Select all") is not a bug and does not refute an Android
+    report. The desktop gesture for the same menu is a **secondary tap**: fire a
+    `PointerDownEvent(buttons: kSecondaryButton)` through `eval`. It calls `toggleToolbar()`,
+    so if the menu is already open the first right-click closes it.
+
+15. **The emulator's clipboard is dead; assert on `Cut`, not `Copy`.**
+    On the headless AVD `Clipboard.setData` followed by `Clipboard.getData` returns `<null>`
+    even with no UI involved, and `adb shell cmd clipboard` does not exist on the android-34
+    image: Android denies clipboard access to an app without window focus, and `-no-window`
+    never has it. A missing "Paste" entry in the selection menu is this, not a defect. What is
+    observable in-app is `Cut` — it mutates the field — and the app's own
+    "Copied to clipboard" toast.
+    The **soft keyboard has the same cause and the same answer**: `show_ime_with_hard_keyboard
+    1` is accepted, the IME binds (`mHaveConnection=true`), and it still never shows
+    (`mInputShown=false`) even for an explicit `TextInput.show` — a windowless app cannot raise
+    it, so `viewInsets.bottom` is always 0 and no amount of tapping produces a keyboard-open
+    layout. To exercise what a keyboard actually does to layout, shrink the display instead:
+    `adb shell wm size 1080x1600` moves every bottom-anchored widget up by ~270 dp and forces
+    the same relayout, `adb shell wm size reset` restores it.
+
+16. **A group chat is reachable without a second peer — create it with an `eval`.**
+    Adding a contact through the UI needs the peer online (it fetches their public key over
+    Tor), so the group screens look untestable. They are not: `GroupService.createGroup` only
+    needs a member *string*. Take the live `HomeScreen` widget's `onionAddress` and `keyManager`
+    (walk the element tree; the field is `onionAddress`, not `userId`), then
+    `GroupService(userId: home.onionAddress, keyManager: home.keyManager).createGroup('name',
+    ['<56 base32 chars>.onion'])` from `--lib package:prysm/screens/group_chat.dart`, which is
+    where both `GroupService` and the widget types are visible. Print the id from `.then()` and
+    read it with `logs --grep` (rule 3). The invite delivery fails against the fake onion and
+    that is fine — the group, its key and its membership are already committed locally.
+    `restart` once: HomeScreen caches the "N contacts · N groups" counts and will not show the
+    group until it re-reads the DB. After that the group chat is a normal screen — compose,
+    send, `longpress --type RichText --contains "<word>"` on the bubble.
+
+17. **Two peers, real Tor: the lab can test transmission, not just UI.**
+    The Linux lab is a second identity in a second container: every host resource is
+    env-overridable, including the pub-cache volume (`VOLUME = os.environ.get("PRYSMLAB_VOLUME", …)`,
+    `tool/live/prysmlab:148`), so a second peer is `PRYSMLAB_CONTAINER=prysm-lab-b
+    PRYSMLAB_HOST_LAB=/tmp/prysm-lab-b PRYSMLAB_VOLUME=prysm-lab-b-pub tool/live/prysmlab up`. Identity
+    lives in the container's writable layer, so each container IS a new identity; the image is shared,
+    so build once and `up` both. Peers talk over the real Tor network — no host ports are published and
+    there is no LAN/direct transport. Pairing is a real Tor round trip: "Add contact" fetches the peer's
+    public key, so the peer must be ONLINE. Measured: Linux→Linux 2.5 s and 7.1 s, Linux→Android 9.6 s,
+    Android→Linux 21.8 s (a cold phone Tor sits near the 2×12 s ContactAddService ceiling). A real-member
+    group is `GroupService(userId: home.onionAddress, keyManager: home.keyManager).createGroup('name',
+    ['<peer onion>'])` from `--lib package:prysm/screens/group_chat.dart`, with `onionAddress`/`keyManager`
+    off the live `HomeScreen` widget (rule 16); invite delivery is a sequential fan-out, measured
+    0.58-1.22 s per member. `tool/live/txlab` runs the measurement: host clock for the tap, app-log
+    timestamps for arrival and ack (UTC — parse with `calendar.timegm`, never `time.mktime`), widget-tree
+    poll for render. Baseline, 1:1 Linux↔Linux over an established WS link: median wire 0.43 s, ack
+    0.22 s, bubble on screen 1.47 s, 0 lost in 36 messages; serialized outbound ceiling ~1.4 msg/s
+    (20-message programmatic burst, median inter-arrival 0.71 s, all in order); a peer that was offline
+    drains its backlog 8-11 s after it returns. Re-check, don't re-discover: (1) a stale WS link costs
+    the full 30 s `_wsSendBudget` before HTTP fallback — 1 send in 10 to the Android peer took ~50 s,
+    zero occurrences Linux↔Linux; (2) a group invite applies to the DB in ~1 s but the receiver's
+    conversation list does not refresh — invisible on Android until an app restart, ~15.6 s on Linux;
+    (3) two members of the same group who are not mutual contacts cannot form a WS link at all
+    (`rejecting hello from unknown peer`; identity resolution is cache-only by design at
+    lib/transport/inbound_ws_peer_link.dart:229-237), so their first group message took 134 s and later
+    ones still ran 19-22 s against 0.6 s for a contact pair.
 
 ## Worked example
 

--- a/tool/live/android/Containerfile
+++ b/tool/live/android/Containerfile
@@ -1,0 +1,161 @@
+# Prysm — live app testing environment (Android emulator)
+#
+# Same containment argument as tool/live/Containerfile: TorManager._killOrphanTorForce
+# runs a bare `pkill -9 tor` (lib/util/tor_service.dart:497) and the container's
+# PID namespace is what keeps that away from the host's tor. The Android emulator
+# runs inside this container too, so the app's loopback server (127.0.0.1:12345)
+# lives inside the emulator and is reachable only through the `adb forward` that
+# the launcher (tool/live/android/labd.sh) sets up — the host never sees it.
+#
+# Layers 1-5 are byte-identical to .l3e2e/Containerfile and tool/live/Containerfile
+# so Docker reuses their cache — in particular the ~1 GB Flutter SDK download.
+# Keep them in sync. If one of the three files changes, change all three.
+FROM ubuntu:24.04
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+# Last group: runtime libraries for the bundled tor binary (ldd on
+# tor_executable/tor — it is NOT statically linked). Kept byte-identical to the
+# sibling Containerfiles for cache reuse; the Android app ignores this binary
+# (tor comes from the info.guardianproject:tor-android AAR at build time), but
+# splitting the layer would cost the shared cache.
+RUN apt-get update && apt-get install -y --no-install-recommends \
+      bash ca-certificates curl git xz-utils unzip \
+      build-essential \
+      psmisc procps \
+      libevent-2.1-7t64 libssl3t64 liblzma5 libzstd1 zlib1g \
+      libcap2 libseccomp2 libsystemd0 libbrotli1 \
+    && rm -rf /var/lib/apt/lists/*
+
+# Official Flutter SDK, same version as the host toolchain and .dart_tool/version.
+# SHA-256 from Google's releases_linux.json for this exact archive — verified
+# against storage.googleapis.com so a tampered or truncated download aborts the
+# build before extraction.
+ARG FLUTTER_VERSION=3.44.8
+ARG FLUTTER_SHA256=672089e001571a9fbb209a495c583580c0c6c73ef98999264ba07fa93ace332d
+RUN curl -fsSL -o /tmp/flutter.tar.xz \
+      "https://storage.googleapis.com/flutter_infra_release/releases/stable/linux/flutter_linux_${FLUTTER_VERSION}-stable.tar.xz" \
+    && echo "${FLUTTER_SHA256}  /tmp/flutter.tar.xz" | sha256sum -c - \
+    && tar -xJf /tmp/flutter.tar.xz -C /opt \
+    && rm /tmp/flutter.tar.xz
+
+ENV PATH="/opt/flutter/bin:${PATH}"
+RUN git config --global --add safe.directory /opt/flutter \
+    && flutter --disable-analytics \
+    && flutter precache --linux
+
+# --- everything below is specific to running the Android app on an emulator ---
+#
+# JDK 17: AGP 8.x requires it; the cmdline-tools' sdkmanager needs it too.
+# Emulator runtime libraries: the set below is what an ubuntu:24.04 container
+# needs for the emulator's qemu binary — verified by a transitive ldd scan of
+# the emulator package (with the emulator's own lib64 dir on LD_LIBRARY_PATH,
+# so bundled libs resolve) plus `emulator -version`, which also caught two
+# dlopen-only deps that ldd cannot see: libpng16-16 and libxkbfile1.
+RUN apt-get update && apt-get install -y --no-install-recommends \
+      openjdk-17-jdk-headless \
+      libpulse0 libnss3 libxcursor1 libxdamage1 libxcomposite1 libxi6 libxtst6 \
+      libasound2t64 libgl1 libglu1-mesa libpng16-16 libxkbfile1 \
+    && rm -rf /var/lib/apt/lists/*
+
+# Android commandline-tools, pinned and SHA-256-verified (same discipline as the
+# Flutter tarball above: a silently truncated download must abort the build).
+ARG CMDLINE_TOOLS_SHA256=2d2d50857e4eb553af5a6dc3ad507a17adf43d115264b1afc116f95c92e5e258
+RUN curl -fsSL -o /tmp/cmdline-tools.zip \
+      "https://dl.google.com/android/repository/commandlinetools-linux-11076708_latest.zip" \
+    && echo "${CMDLINE_TOOLS_SHA256}  /tmp/cmdline-tools.zip" | sha256sum -c - \
+    && mkdir -p /opt/android-sdk/cmdline-tools \
+    && unzip -q /tmp/cmdline-tools.zip -d /tmp/cmdtools-unzip \
+    && mv /tmp/cmdtools-unzip/cmdline-tools /opt/android-sdk/cmdline-tools/latest \
+    && rm -rf /tmp/cmdline-tools.zip /tmp/cmdtools-unzip
+
+ENV ANDROID_HOME=/opt/android-sdk \
+    ANDROID_SDK_ROOT=/opt/android-sdk \
+    JAVA_HOME=/usr/lib/jvm/java-17-openjdk-amd64 \
+    PATH="/opt/android-sdk/cmdline-tools/latest/bin:/opt/android-sdk/platform-tools:/opt/android-sdk/emulator:${PATH}"
+
+# Pinned SDK packages (versions verified against Google's repository XML before
+# writing this file):
+#   platforms;android-35      decided minimum; the app's compileSdk is
+#                             flutter.compileSdkVersion = 36 (Flutter 3.44.8),
+#                             so android-36 is installed as well — AGP uses it
+#                             for the real compile and auto-downloads anything
+#                             else when the licences are accepted (they are).
+#   ndk;28.2.13676358         flutter.ndkVersion; the opus_flutter_android
+#                             plugin builds libopus from source with ndkBuild,
+#                             so the NDK is a hard build requirement.
+#   build-tools;35.0.0        AGP 8.11.1's default Build Tools version.
+#   system-images;android-34;default;x86_64  x86_64 host; the app packages the
+#                             x86_64 engine ABI (FlutterPlugin clears
+#                             abiFilters and adds PLATFORM_ABI_LIST).
+# Accept every licence non-interactively so AGP can auto-install anything a
+# plugin needs beyond this set. `flutter precache --android` pulls the engine
+# artifacts into /opt/flutter/bin/cache so the first gradle build does not
+# download them.
+RUN yes | sdkmanager --licenses >/dev/null \
+    && sdkmanager --install \
+         "platform-tools" \
+         "emulator" \
+         "platforms;android-35" \
+         "platforms;android-36" \
+         "build-tools;35.0.0" \
+         "ndk;28.2.13676358" \
+         "system-images;android-34;default;x86_64" \
+    && flutter precache --android \
+    && test -x /opt/android-sdk/emulator/qemu/linux-x86_64/qemu-system-x86_64-headless \
+    && miss=$(LD_LIBRARY_PATH=/opt/android-sdk/emulator/lib64 \
+         ldd /opt/android-sdk/emulator/qemu/linux-x86_64/qemu-system-x86_64-headless 2>&1 | grep "not found" || true) \
+    && if [ -n "$miss" ]; then echo "emulator runtime deps missing:"; echo "$miss"; exit 1; fi \
+    && /opt/android-sdk/emulator/emulator -version
+
+# receive_sharing_intent (^1.9.0, in pubspec.lock) declares compileSdk 37, but
+# Google ships android-37.0 — there is no plain android-37 — and AGP asks for
+# the exact directory name. Install 37.0 and provide the android-37 dir AGP
+# wants: AGP reads the ApiLevel from source.properties, so the copy satisfies
+# it without touching the shipped app config or the plugin. (AGP prints a
+# harmless "inconsistent location" warning for the duplicate.)
+RUN sdkmanager --install "platforms;android-37.0" >/dev/null \
+    && cp -a /opt/android-sdk/platforms/android-37.0 /opt/android-sdk/platforms/android-37
+
+# The CLI forwards itself into the container as `python3 /opt/lab/prysmlab`
+# (forward()), so the container needs a python3 interpreter even though the
+# Android image has no other use for one. In a separate layer so the ~1 GB SDK
+# layer above stays shared with the Linux lab.
+RUN apt-get update && apt-get install -y --no-install-recommends python3 \
+    && rm -rf /var/lib/apt/lists/*
+
+# Bind-mount ownership: ubuntu:24.04 ships a default uid-1000 user
+# 'ubuntu', but the host user may be any uid. tool/live/prysmlab passes the host
+# uid/gid as build args, and this step remaps 'ubuntu' to match, so the
+# bind-mounted /work stays readable/writable for the container user.
+ARG HOST_UID=1000
+ARG HOST_GID=1000
+#
+# --non-unique is required, not defensive: ubuntu:24.04 already owns gid 20
+# (dialout) and gid 100 (users), and plain `groupmod -g` refuses a gid another
+# group holds ("GID '20' already exists"), which aborts the whole build for any
+# host user on one of those gids. Sharing the id is harmless here — `chown
+# ubuntu:ubuntu` still resolves by name, and the container is single-user.
+# The Android SDK is chowned too: the emulator and AGP (running as `ubuntu`)
+# write into it at runtime — a root-owned SDK would make AGP's auto-download of
+# a missing package fail with a permission error instead of working.
+RUN if [ "${HOST_UID}" != "1000" ] || [ "${HOST_GID}" != "1000" ]; then \
+      groupmod --non-unique -g "${HOST_GID}" ubuntu \
+      && usermod --non-unique -u "${HOST_UID}" -g "${HOST_GID}" ubuntu; \
+    fi \
+    && chown -R ubuntu:ubuntu /opt/flutter \
+    && chown -R ubuntu:ubuntu /opt/android-sdk \
+    && mkdir -p /home/ubuntu/.pub-cache /home/ubuntu/lab \
+    && chown -R ubuntu:ubuntu /home/ubuntu
+
+# The pub cache is a named Docker volume so nothing lands in the host's HOME and
+# `prysmlab down --purge` can drop it. Docker seeds a fresh volume from the image
+# path, so that path must already exist and belong to `ubuntu` — otherwise the
+# volume comes up root-owned and `flutter pub get` dies on hosted-hashes.
+
+USER ubuntu
+ENV HOME=/home/ubuntu \
+    PUB_CACHE=/home/ubuntu/.pub-cache \
+    XDG_RUNTIME_DIR=/tmp/xdg-runtime
+
+WORKDIR /work

--- a/tool/live/android/labd.sh
+++ b/tool/live/android/labd.sh
@@ -1,0 +1,120 @@
+#!/bin/sh
+# prysmlab — in-container launcher for the real Prysm Android app on an emulator.
+# Started by `prysmlab up` as: sh -lc '/opt/lab/android/labd.sh > ~/lab/app.log 2>&1'
+#
+# The Android sibling of tool/live/labd.sh: create the AVD, boot the emulator
+# headless, PROVE it booted (a running qemu process is not a booted device —
+# same lesson as PRYSMLAB_UPOWER_FAILED on Linux), forward the app's loopback
+# port, regenerate android/local.properties (the host's copy points at host
+# paths), then `flutter run`. Every failure mode emits an explicit token that
+# `prysmlab up` recognises and reports with the actual cause.
+set -e
+
+LAB="$HOME/lab"
+ANDROID_HOME="${ANDROID_HOME:-/opt/android-sdk}"
+AVD="prysmlab"
+EMU="$ANDROID_HOME/emulator/emulator"
+mkdir -p "$LAB" "$HOME/.android/avd" /tmp/android-unknown
+export ANDROID_HOME ANDROID_SDK_ROOT="$ANDROID_HOME"
+
+# KVM is a hard requirement for the x86_64 system image: without it the emulator
+# refuses to start. `prysmlab up` passes --device /dev/kvm on docker run; confirm
+# it here with an explicit failure token instead of a bare emulator error later.
+if [ ! -r /dev/kvm ] || [ ! -w /dev/kvm ]; then
+  echo "PRYSMLAB_KVM_FAILED: /dev/kvm is not usable inside the container" >&2
+  exit 1
+fi
+
+# Create or refresh the AVD. `echo no` answers the "custom hardware profile"
+# prompt; --force keeps repeated container starts idempotent.
+#
+# -d pixel_5 is not cosmetic: without a device profile avdmanager falls back to
+# a 320x640 screen, which is smaller than any shipping phone. Layout defects
+# that only a real phone shows (and layout *reports* from users) cannot be
+# reproduced or refuted on a screen no user has. pixel_5 is 1080x2340 @440dpi,
+# i.e. 393x851 logical pixels — an ordinary modern phone.
+if ! "$EMU" -list-avds | grep -qx "$AVD"; then
+  echo no | "$ANDROID_HOME/cmdline-tools/latest/bin/avdmanager" create avd \
+    --force -n "$AVD" -d pixel_5 -k "system-images;android-34;default;x86_64" \
+    >"$LAB/avd.log" 2>&1
+fi
+
+# Headless boot. -no-snapshot keeps every boot honest instead of restoring a
+# possibly half-booted snapshot; -accel on makes a missing KVM fail loudly.
+# If an emulator for this AVD is already running (e.g. after `prysmlab restart`,
+# which re-runs this launcher), reuse it instead of starting a second one.
+EMU_PID=""
+if ! pgrep -f "qemu-system.*-avd $AVD" >/dev/null 2>&1; then
+  "$EMU" -avd "$AVD" -no-window -no-audio -no-boot-anim -no-snapshot \
+    -gpu swiftshader_indirect -accel on >"$LAB/emulator.log" 2>&1 &
+  EMU_PID=$!
+fi
+
+adb start-server >/dev/null 2>&1 || true
+
+# 1) the device must appear in `adb devices` as "device" ...
+i=0
+while [ $i -lt 300 ]; do
+  if adb devices 2>/dev/null | sed -n 's/^emulator-[0-9]*[[:space:]]*device$/device/p' \
+       | grep -q device; then
+    break
+  fi
+  if [ -n "$EMU_PID" ] && ! kill -0 "$EMU_PID" 2>/dev/null; then
+    echo "PRYSMLAB_EMULATOR_FAILED: emulator exited before adb saw the device" >&2
+    tail -40 "$LAB/emulator.log" >&2
+    exit 1
+  fi
+  i=$((i + 1)); sleep 1
+done
+
+# ... and 2) Android must finish booting. sys.boot_completed=1 is the contract;
+# an online adb device is not proof the system is up.
+i=0
+while [ $i -lt 300 ]; do
+  if [ "$(adb shell getprop sys.boot_completed 2>/dev/null | tr -d '\r')" = "1" ]; then
+    break
+  fi
+  if [ -n "$EMU_PID" ] && ! kill -0 "$EMU_PID" 2>/dev/null; then
+    echo "PRYSMLAB_EMULATOR_FAILED: emulator died during boot" >&2
+    tail -40 "$LAB/emulator.log" >&2
+    exit 1
+  fi
+  i=$((i + 1)); sleep 2
+done
+if [ "$(adb shell getprop sys.boot_completed 2>/dev/null | tr -d '\r')" != "1" ]; then
+  echo "PRYSMLAB_BOOT_TIMEOUT: sys.boot_completed never reached 1" >&2
+  tail -40 "$LAB/emulator.log" >&2
+  exit 1
+fi
+echo "PRYSMLAB_EMULATOR_UP"
+
+# The app's loopback server binds 127.0.0.1:12345 inside the emulator; forward it
+# so `prysmlab peer` keeps talking to 127.0.0.1:12345 unchanged.
+adb forward tcp:12345 tcp:12345 >/dev/null
+echo "PRYSMLAB_ADB_FORWARD_UP"
+
+# android/local.properties must not come from the host (it points at the host's
+# SDK paths); regenerate it for the in-container toolchain.
+printf 'sdk.dir=%s\nflutter.sdk=/opt/flutter\n' "$ANDROID_HOME" \
+  > /work/android/local.properties
+
+cd /work
+[ -f .dart_tool/package_config.json ] || flutter pub get
+
+# Deterministic device id: the first emulator in a fresh container is
+# emulator-5554; resolve it from adb rather than assuming.
+DEVICE=$(adb devices 2>/dev/null | awk '/emulator-[0-9]+[ \t]+device/{print $1; exit}')
+if [ -z "$DEVICE" ]; then
+  echo "PRYSMLAB_EMULATOR_FAILED: no emulator device in adb" >&2
+  exit 1
+fi
+
+# flutter run treats stdin EOF as quit, so it needs a stdin that never ends.
+# A FIFO opened read-write is exactly that (same reasoning as the Linux lab).
+FIFO="$HOME/lab/app-stdin"
+rm -f "$FIFO"
+mkfifo "$FIFO"
+flutter run -d "$DEVICE" --debug --no-pub --disable-service-auth-codes <> "$FIFO"
+rc=$?
+rm -f "$FIFO"
+exit "$rc"

--- a/tool/live/prysmlab
+++ b/tool/live/prysmlab
@@ -49,18 +49,115 @@ import urllib.request
 
 IN_CONTAINER = os.environ.get("PRYSMLAB_IN_CONTAINER") == "1"
 
-# ---- host side -------------------------------------------------------------
-IMAGE = os.environ.get("PRYSMLAB_IMAGE", "prysm-lab")
-CONTAINER = os.environ.get("PRYSMLAB_CONTAINER", "prysm-lab")
-VOLUME = "prysm-lab-pub"
-HOST_LAB = os.environ.get("PRYSMLAB_HOST_LAB", "/tmp/prysm-lab")
-WORK = os.path.join(HOST_LAB, "work")
+# ---- platform config -------------------------------------------------------
+# The same CLI drives two labs; only the lifecycle differs. Everything that
+# differs lives in this table: the Linux desktop app under Xvfb, and the Android
+# app on an in-container emulator. Everything downstream of the Dart VM Service
+# (WebSocket JSON-RPC, widget-tree walking, pointer injection, `type` via
+# updateEditingValue) is platform-independent and shared. The Linux values are
+# byte-identical to the pre-platform version of this file — that lab is in
+# production and must not regress.
+PLATFORM_DEFAULTS = {
+    "linux": {
+        "image": "prysm-lab",
+        "container": "prysm-lab",
+        "volume": "prysm-lab-pub",
+        "host_lab": "/tmp/prysm-lab",
+        "containerfile": "tool/live/Containerfile",
+        "build_context": "tool/live",
+        "launcher": "/opt/lab/labd.sh",
+        "root_script": "/opt/lab/labroot.sh",
+        "run_args": [],
+        "vm_ready": "Dart VM Service on Linux is available at:",
+        "fail_tokens": {
+            "PRYSMLAB_XVFB_FAILED":
+                "Xvfb never came up inside the container; see `prysmlab logs`",
+        },
+        "stage_paths": [
+            "lib", "test", "assets", "linux", "packages", "tor_executable",
+            "pubspec.yaml", "pubspec.lock", "analysis_options.yaml",
+            "devtools_options.yaml",
+        ],
+        "stage_excludes": [".dart_tool", "linux/flutter/ephemeral", "build"],
+    },
+    "android": {
+        "image": "prysm-lab-android",
+        "container": "prysm-lab-android",
+        "volume": "prysm-lab-android-pub",
+        "host_lab": "/tmp/prysm-lab-android",
+        "containerfile": "tool/live/android/Containerfile",
+        "build_context": "tool/live/android",
+        "launcher": "/opt/lab/android/labd.sh",
+        "root_script": None,
+        "run_args": ["--device", "/dev/kvm"],
+        "vm_ready": "Dart VM Service on",
+        "fail_tokens": {
+            "PRYSMLAB_KVM_FAILED":
+                "/dev/kvm is not usable inside the container; the Android "
+                "emulator needs KVM. Check that docker passes --device /dev/kvm "
+                "and that KVM is enabled on the host.",
+            "PRYSMLAB_EMULATOR_FAILED":
+                "the emulator died before the device came online; "
+                "see `prysmlab logs` for the emulator log tail",
+            "PRYSMLAB_BOOT_TIMEOUT":
+                "the emulator never finished booting (sys.boot_completed); "
+                "see `prysmlab logs` for the emulator log tail",
+        },
+        "stage_paths": [
+            "lib", "test", "assets", "packages", "android",
+            "pubspec.yaml", "pubspec.lock", "analysis_options.yaml",
+            "devtools_options.yaml",
+        ],
+        "stage_excludes": [
+            ".dart_tool", "build",
+            "android/.gradle", "android/app/build", "android/local.properties",
+        ],
+    },
+}
 
-# ---- container side --------------------------------------------------------
-LAB = "/home/ubuntu/lab"
-LOG_PATH = f"{LAB}/app.log"
-STATE_PATH = f"{LAB}/state.json"
+# ---- host side -------------------------------------------------------------
+PLATFORM = "linux"
+IMAGE = CONTAINER = VOLUME = HOST_LAB = WORK = ""
+LAB = LOG_PATH = STATE_PATH = ""
+LAUNCHER = ""
+ROOT_SCRIPT: str | None = None
+RUN_ARGS: list[str] = []
+VM_READY = ""
+FAIL_TOKENS: dict[str, str] = {}
+STAGE_PATHS: list[str] = []
+STAGE_EXCLUDES: list[str] = []
 APP_PORT = 12345
+
+
+def init_platform(name: str) -> None:
+    """Bind the module-level lab constants for the active platform.
+
+    Called from main() before dispatch, so the same globals keep working for
+    every command; the in-container side picks the same platform because
+    dexec()/forward() propagate PRYSMLAB_PLATFORM on every docker exec.
+    """
+    global PLATFORM, IMAGE, CONTAINER, VOLUME, HOST_LAB, WORK
+    global LAB, LOG_PATH, STATE_PATH, LAUNCHER, ROOT_SCRIPT, RUN_ARGS
+    global VM_READY, FAIL_TOKENS, STAGE_PATHS, STAGE_EXCLUDES
+    if name not in PLATFORM_DEFAULTS:
+        die(f"unknown platform {name!r} (choose from {', '.join(PLATFORM_DEFAULTS)})")
+    cfg = PLATFORM_DEFAULTS[name]
+    PLATFORM = name
+    IMAGE = os.environ.get("PRYSMLAB_IMAGE", cfg["image"])
+    CONTAINER = os.environ.get("PRYSMLAB_CONTAINER", cfg["container"])
+    VOLUME = cfg["volume"]
+    HOST_LAB = os.environ.get("PRYSMLAB_HOST_LAB", cfg["host_lab"])
+    WORK = os.path.join(HOST_LAB, "work")
+    LAB = "/home/ubuntu/lab"
+    LOG_PATH = f"{LAB}/app.log"
+    STATE_PATH = f"{LAB}/state.json"
+    LAUNCHER = cfg["launcher"]
+    ROOT_SCRIPT = cfg["root_script"]
+    RUN_ARGS = cfg["run_args"]
+    VM_READY = cfg["vm_ready"]
+    FAIL_TOKENS = cfg["fail_tokens"]
+    STAGE_PATHS = cfg["stage_paths"]
+    STAGE_EXCLUDES = cfg["stage_excludes"]
 
 # Evaluation context. Flutter's own widgets/binding.dart imports foundation,
 # gestures, rendering, scheduler and services, so WidgetsBinding, Element,
@@ -70,13 +167,6 @@ APP_PORT = 12345
 PREFERRED_LIB = "package:flutter/src/widgets/binding.dart"
 
 HOST_COMMANDS = {"up", "down", "doctor", "sync", "shell", "build-image", "restart"}
-
-# Staged into /work. Excludes .dart_tool and linux/flutter/ephemeral so the
-# container regenerates them for its own toolchain.
-STAGE_PATHS = [
-    "lib", "test", "assets", "linux", "packages", "tor_executable",
-    "pubspec.yaml", "pubspec.lock", "analysis_options.yaml", "devtools_options.yaml",
-]
 
 
 class Fail(Exception):
@@ -114,7 +204,8 @@ def image_exists() -> bool:
 
 def dexec(argv: list[str], capture: bool = True, timeout: float | None = None,
           stdin_data: str | None = None) -> subprocess.CompletedProcess:
-    cmd = ["docker", "exec", "-i", "-e", "PRYSMLAB_IN_CONTAINER=1", CONTAINER] + argv
+    cmd = ["docker", "exec", "-i", "-e", "PRYSMLAB_IN_CONTAINER=1",
+           "-e", f"PRYSMLAB_PLATFORM={PLATFORM}", CONTAINER] + argv
     if capture:
         return subprocess.run(cmd, capture_output=True, text=True, timeout=timeout,
                               input=stdin_data)
@@ -125,7 +216,8 @@ def forward(argv: list[str]) -> int:
     """Re-run this same CLI inside the container with the same arguments."""
     if container_state() != "running":
         die("no lab container is running — start it with `prysmlab up`")
-    cmd = ["docker", "exec", "-i", "-e", "PRYSMLAB_IN_CONTAINER=1", CONTAINER,
+    cmd = ["docker", "exec", "-i", "-e", "PRYSMLAB_IN_CONTAINER=1",
+           "-e", f"PRYSMLAB_PLATFORM={PLATFORM}", CONTAINER,
            "python3", "/opt/lab/prysmlab"] + argv
     return subprocess.run(cmd).returncode
 
@@ -144,7 +236,7 @@ def vm_base() -> str:
             text = fh.read()
     except OSError as exc:
         raise Fail(f"no app log at {LOG_PATH} ({exc}); run `prysmlab up`") from exc
-    hits = re.findall(r"Dart VM Service on Linux is available at:\s*(\S+)", text)
+    hits = re.findall(r"Dart VM Service on .*? is available at:\s*(\S+)", text)
     if not hits:
         raise Fail("the app has not published a VM Service yet — see `prysmlab logs`")
     return hits[-1]
@@ -433,6 +525,31 @@ def tap_expr(pred: str, idx: int, pointer: int = 7, force: bool = False) -> str:
     )
 
 
+def longpress_expr(pred: str, idx: int, hold_ms: int = 900,
+                   force: bool = False) -> str:
+    """Hold a pointer down on the target, then release it after `hold_ms`.
+
+    `tap_expr` releases in the same turn, which is below every LongPressGestureRecognizer's
+    deadline, so it can never open a long-press menu. The release is scheduled on the
+    app's own event loop because `evaluate` returns synchronously: the expression
+    reports the press, and the gesture completes a moment later. Read the result
+    with a follow-up `screen`/`count`, not from this call's output.
+    """
+    # A fresh id per call; a never-released down (stuck press) must not collide
+    # with the next invocation's press.
+    pointer = 1000 + (time.time_ns() // 1000000) % 100000
+    guard = "" if force else (
+        "if (hit == 'no') " + _REPORT.format(tag="OCCLUDED") + " "
+    )
+    return (
+        "(() { " + _WALK.format(pred=pred, idx=idx) + guard
+        + f"b.handlePointerEvent(PointerDownEvent(position: c, pointer: {pointer}, viewId: vid)); "
+        + f"Future.delayed(const Duration(milliseconds: {hold_ms}), () {{ "
+        + f"b.handlePointerEvent(PointerUpEvent(position: c, pointer: {pointer}, viewId: vid)); }}); "
+        + _REPORT.format(tag="LONGPRESSED") + " })()"
+    )
+
+
 SCROLL_EXPR = (
     "(() {{ final b = WidgetsBinding.instance; dynamic best; double bestExtent = -1; "
     "void walk(Element e) {{ if (e is StatefulElement && "
@@ -536,10 +653,9 @@ def count_text(tree: str, needle: str) -> int:
 
 def stage_repo(repo: str) -> None:
     os.makedirs(WORK, exist_ok=True)
-    cmd = ["rsync", "-a", "--delete",
-           "--exclude", ".dart_tool",
-           "--exclude", "linux/flutter/ephemeral",
-           "--exclude", "build"]
+    cmd = ["rsync", "-a", "--delete"]
+    for ex in STAGE_EXCLUDES:
+        cmd += ["--exclude", ex]
     cmd += [os.path.join(repo, p) for p in STAGE_PATHS if os.path.exists(os.path.join(repo, p))]
     cmd.append(WORK + "/")
     res = run(cmd)
@@ -549,11 +665,12 @@ def stage_repo(repo: str) -> None:
 
 def cmd_build_image(args) -> int:
     repo = repo_root()
-    cmd = ["docker", "build", "-f", os.path.join(repo, "tool/live/Containerfile"),
+    cfg = PLATFORM_DEFAULTS[PLATFORM]
+    cmd = ["docker", "build", "-f", os.path.join(repo, cfg["containerfile"]),
            "-t", IMAGE,
            "--build-arg", f"HOST_UID={os.getuid()}",
            "--build-arg", f"HOST_GID={os.getgid()}",
-           os.path.join(repo, "tool/live")]
+           os.path.join(repo, cfg["build_context"])]
     print(" ".join(cmd))
     return subprocess.run(cmd).returncode
 
@@ -562,6 +679,10 @@ def cmd_up(args) -> int:
     repo = repo_root()
     if run(["docker", "version"]).returncode != 0:
         die("docker is not usable")
+    if PLATFORM == "android" and not (
+            os.path.exists("/dev/kvm") and os.access("/dev/kvm", os.R_OK | os.W_OK)):
+        die("the Android lab needs /dev/kvm (present and writable); "
+            "`prysmlab -p android doctor` explains what to install")
     if not image_exists():
         print(f"image {IMAGE} missing — building it")
         if cmd_build_image(args) != 0:
@@ -580,6 +701,7 @@ def cmd_up(args) -> int:
         res = run([
             "docker", "run", "-d", "--name", CONTAINER,
             "--init", "--shm-size=512m",
+        ] + RUN_ARGS + [
             "-v", f"{WORK}:/work",
             "-v", f"{os.path.join(repo, 'tool/live')}:/opt/lab:ro",
             "-v", f"{VOLUME}:/home/ubuntu/.pub-cache",
@@ -589,15 +711,18 @@ def cmd_up(args) -> int:
             die(f"docker run failed: {res.stderr.strip()}")
         print(f"container {CONTAINER} up ({res.stdout.strip()[:12]})")
 
-    root = run(["docker", "exec", "-u", "0", CONTAINER, "/opt/lab/labroot.sh"])
-    if "PRYSMLAB_UPOWER_FAILED" in root.stdout:
-        die("system D-Bus is up but nothing claimed org.freedesktop.UPower. "
-            "battery_plus would hang AppBootstrap.initializeServices and "
-            "runApp would never be reached, so the app would open a window "
-            "and render nothing. Check /var/log/upowerd.log in the container.")
-    if "PRYSMLAB_SYSTEM_BUS_UP" not in root.stdout:
-        die("could not bring up the container's system D-Bus: "
-            + (root.stderr or root.stdout).strip())
+    if ROOT_SCRIPT is not None:
+        root = run(["docker", "exec", "-u", "0",
+                    "-e", f"PRYSMLAB_PLATFORM={PLATFORM}",
+                    CONTAINER, ROOT_SCRIPT])
+        if "PRYSMLAB_UPOWER_FAILED" in root.stdout:
+            die("system D-Bus is up but nothing claimed org.freedesktop.UPower. "
+                "battery_plus would hang AppBootstrap.initializeServices and "
+                "runApp would never be reached, so the app would open a window "
+                "and render nothing. Check /var/log/upowerd.log in the container.")
+        if "PRYSMLAB_SYSTEM_BUS_UP" not in root.stdout:
+            die("could not bring up the container's system D-Bus: "
+                + (root.stderr or root.stdout).strip())
 
     # The bracket keeps the pattern from matching the `sh -lc` that carries it.
     running = dexec(["sh", "-lc", "pgrep -f '[f]lutter_tools.snapshot run' >/dev/null && echo yes"])
@@ -614,22 +739,23 @@ def start_app():
     dexec(["sh", "-lc", f"pkill -f '[f]lutter_tools.snapshot run'; sleep 1; "
                         f"mkdir -p {LAB} && rm -f {LOG_PATH} {STATE_PATH}"])
     subprocess.run([
-        "docker", "exec", "-d", "-e", "PRYSMLAB_IN_CONTAINER=1", CONTAINER,
-        "sh", "-lc", f"/opt/lab/labd.sh > {LOG_PATH} 2>&1",
+        "docker", "exec", "-d", "-e", "PRYSMLAB_IN_CONTAINER=1",
+        "-e", f"PRYSMLAB_PLATFORM={PLATFORM}", CONTAINER,
+        "sh", "-lc", f"{LAUNCHER} > {LOG_PATH} 2>&1",
     ], check=False)
-    print("app starting (the first run compiles the Linux bundle, a few minutes)")
+    print("app starting (the first run compiles the bundle, a few minutes)")
 
 
 def wait_for_vm(timeout: float):
     deadline = time.time() + timeout
-    pattern = "Dart VM Service on Linux is available at:"
     last = ""
     while time.time() < deadline:
         log = dexec(["sh", "-lc", f"cat {LOG_PATH} 2>/dev/null"]).stdout
-        if pattern in log:
+        if VM_READY in log:
             return
-        if "PRYSMLAB_XVFB_FAILED" in log:
-            die("Xvfb never came up inside the container; see `prysmlab logs`")
+        for token, msg in FAIL_TOKENS.items():
+            if token in log:
+                die(msg)
         tail = (log.strip().splitlines() or [""])[-1]
         if tail != last:
             last = tail
@@ -665,7 +791,9 @@ def cmd_sync(args) -> int:
 
 
 def cmd_shell(args) -> int:
-    return subprocess.run(["docker", "exec", "-it", CONTAINER, "bash", "-l"]).returncode
+    return subprocess.run(
+        ["docker", "exec", "-it", "-e", f"PRYSMLAB_PLATFORM={PLATFORM}",
+         CONTAINER, "bash", "-l"]).returncode
 
 
 def cmd_doctor(args) -> int:
@@ -684,8 +812,16 @@ def cmd_doctor(args) -> int:
           "rootless docker must be running")
     check(image_exists(), f"image {IMAGE} present", "run `prysmlab build-image`")
     check(shutil.which("rsync") is not None, "rsync present", "needed to stage the repo")
-    check(os.path.exists(os.path.join(repo, "tor_executable/tor")),
-          "repo tor binary present", "the app would download ~14 MB inside the container")
+    if PLATFORM == "linux":
+        check(os.path.exists(os.path.join(repo, "tor_executable/tor")),
+              "repo tor binary present",
+              "the app would download ~14 MB inside the container")
+    else:
+        kvm = os.path.exists("/dev/kvm")
+        check(kvm and os.access("/dev/kvm", os.R_OK | os.W_OK),
+              "/dev/kvm present and writable",
+              "the Android emulator needs KVM; install qemu-kvm or enable "
+              "nested virtualization")
 
     status = container_state()
     print(f"  info  container {CONTAINER}: {status}")
@@ -738,6 +874,11 @@ def cmd_down(args) -> int:
                IMAGE]).stdout.strip()
     print(f"  image {IMAGE}: " + (img or "removed"))
     print("  host tor: " + (run(["pgrep", "-a", "tor"]).stdout.strip() or "none"))
+    if PLATFORM == "android":
+        qemu = run(["pgrep", "-a", "-f", "[q]emu-system"]).stdout.strip()
+        print("  host qemu/emulator: " + (qemu or "none")
+              + "  (the emulator ran inside the container; nothing may remain "
+                "on the host)")
     repo = repo_root()
     dirty = run(["git", "-C", repo, "status", "--porcelain"]).stdout.strip()
     print("  repo working tree: " + (dirty.replace("\n", " | ") if dirty else "clean"))
@@ -852,6 +993,27 @@ def cmd_tap_widget(args) -> int:
     return 0 if out.startswith("TAPPED") else 2
 
 
+def cmd_longpress(args) -> int:
+    if args.hold < 500:
+        die("--hold must clear kLongPressTimeout (500 ms) or no gesture fires")
+    if args.type:
+        # `--contains` doubles as a flag for texts and as a value for widget
+        # types; a bare flag means "no substring" on the widget path.
+        needle = args.contains if isinstance(args.contains, str) else None
+        pred = pred_widget(args.type, needle)
+    elif args.text:
+        pred = pred_text(args.text, not args.contains)
+    else:
+        die("longpress needs a text or --type")
+    out = eval_dart(longpress_expr(pred, args.index, hold_ms=args.hold,
+                                   force=args.force))
+    print(out)
+    # The release is scheduled inside the app; wait past it plus the settle so
+    # the next `screen` sees whatever the gesture opened.
+    time.sleep(args.hold / 1000.0 + args.settle)
+    return 0 if out.startswith("LONGPRESSED") else 2
+
+
 def cmd_scroll(args) -> int:
     print(scroll_by(args.dy))
     return 0
@@ -964,13 +1126,22 @@ def cmd_onboard(args) -> int:
         if digits <= texts:
             entries += 1
             print(f"[{step}] pin pad (entry {entries}) -> {args.pin}")
+            entered = True
             for digit in args.pin:
                 out = eval_dart(tap_expr(pred_text(digit), 0, force=True))
                 if not out.startswith("TAPPED"):
-                    print(f"       digit {digit}: {out}", file=sys.stderr)
-                    return 2
+                    # A pad can vanish mid-entry: after a successful confirm the
+                    # route pops, and during the pop transition both the pad and
+                    # the next screen are in the tree. The pad read was stale —
+                    # that is a transient, not a failed onboarding. Re-evaluate
+                    # the screen instead of aborting.
+                    print(f"       digit {digit}: {out} (screen moved on)",
+                          file=sys.stderr)
+                    entered = False
+                    break
                 time.sleep(0.25)
-            time.sleep(args.settle)
+            if entered:
+                time.sleep(args.settle)
             continue
         target = next((t for t in advance if t in texts), None)
         if target:
@@ -989,9 +1160,14 @@ def cmd_onboard(args) -> int:
 
 def cmd_shot(args) -> int:
     out = args.out or f"{LAB}/shot-{int(time.time())}.png"
-    display = os.environ.get("DISPLAY", ":99")
-    res = run(["sh", "-lc",
-               f"xwd -root -display {display} | xwdtopnm 2>/dev/null | pnmtopng > {out}"])
+    if PLATFORM == "android":
+        # adb exec-out writes the raw PNG to stdout; the emulator is reachable
+        # because adb runs in this container against the lab emulator.
+        res = run(["sh", "-lc", f"adb exec-out screencap -p > {out}"])
+    else:
+        display = os.environ.get("DISPLAY", ":99")
+        res = run(["sh", "-lc",
+                   f"xwd -root -display {display} | xwdtopnm 2>/dev/null | pnmtopng > {out}"])
     if res.returncode != 0 or not os.path.exists(out) or os.path.getsize(out) == 0:
         die(f"screenshot failed: {res.stderr.strip()}")
     print(out)
@@ -1008,6 +1184,10 @@ def build_parser() -> argparse.ArgumentParser:
         epilog="lifecycle commands run on the host; all others are forwarded into "
                "the container automatically",
         formatter_class=argparse.RawDescriptionHelpFormatter)
+    p.add_argument("-p", "--platform", choices=sorted(PLATFORM_DEFAULTS),
+                   default=None,
+                   help="linux (Xvfb desktop app) or android (in-container "
+                        "emulator); default from $PRYSMLAB_PLATFORM, else linux")
     sub = p.add_subparsers(dest="cmd", required=True)
 
     s = sub.add_parser("doctor", help="preflight checks, host and container")
@@ -1084,6 +1264,22 @@ def build_parser() -> argparse.ArgumentParser:
                        help="tap even if the hit test says something covers it")
         s.add_argument("--settle", type=float, default=1.2)
 
+    s = sub.add_parser("longpress",
+                       help="hold a widget down long enough for a long-press "
+                            "gesture (text selection menus, message menus)")
+    s.add_argument("text", nargs="?", help="text of the target; omit when using --type")
+    s.add_argument("--type", help="widget type instead of a text, e.g. PrysmEditableText")
+    s.add_argument("--contains", nargs="?", const=True, default=None,
+                   help="with a text: match a substring; with --type: substring of "
+                        "the widget's toString")
+    s.add_argument("-n", "--index", type=int, default=0)
+    s.add_argument("--hold", type=int, default=900,
+                   help="milliseconds to hold; must clear the recogniser deadline (500ms)")
+    s.add_argument("--force", action="store_true",
+                   help="press even if the hit test says something covers it")
+    s.add_argument("--settle", type=float, default=1.2)
+    s.set_defaults(func=cmd_longpress)
+
     s = sub.add_parser("scroll", help="jump the longest scrollable by dy pixels")
     s.add_argument("dy", type=int)
     s.set_defaults(func=cmd_scroll)
@@ -1139,10 +1335,45 @@ def build_parser() -> argparse.ArgumentParser:
     return p
 
 
+def resolve_platform(argv: list[str]) -> str:
+    """The -p/--platform flag wins over $PRYSMLAB_PLATFORM, then linux.
+
+    Scanned manually before argparse so the choice is known before subcommand
+    dispatch and can steer the forward()/host-command decision in main().
+    """
+    for i, a in enumerate(argv):
+        if a == "--":  # after it, -p is a literal arg, not the flag
+            break
+        if a in ("-p", "--platform") and i + 1 < len(argv):
+            return argv[i + 1]
+        if a.startswith("--platform="):
+            return a.split("=", 1)[1]
+    return os.environ.get("PRYSMLAB_PLATFORM", "linux")
+
+
+def strip_platform_args(argv: list[str]) -> list[str]:
+    """argv minus the -p/--platform pair, for the HOST_COMMANDS check."""
+    out: list[str] = []
+    i = 0
+    while i < len(argv):
+        a = argv[i]
+        if a in ("-p", "--platform"):
+            i += 2
+            continue
+        if a.startswith("--platform="):
+            i += 1
+            continue
+        out.append(a)
+        i += 1
+    return out
+
+
 def main(argv: list[str]) -> int:
-    if not IN_CONTAINER and argv and argv[0] not in HOST_COMMANDS \
-            and not argv[0].startswith("-"):
-        return forward(argv)
+    init_platform(resolve_platform(argv))
+    if not IN_CONTAINER:
+        rest = strip_platform_args(argv)
+        if rest and rest[0] not in HOST_COMMANDS and not rest[0].startswith("-"):
+            return forward(argv)
     args = build_parser().parse_args(argv)
     try:
         return args.func(args)

--- a/tool/live/prysmlab
+++ b/tool/live/prysmlab
@@ -145,7 +145,7 @@ def init_platform(name: str) -> None:
     PLATFORM = name
     IMAGE = os.environ.get("PRYSMLAB_IMAGE", cfg["image"])
     CONTAINER = os.environ.get("PRYSMLAB_CONTAINER", cfg["container"])
-    VOLUME = cfg["volume"]
+    VOLUME = os.environ.get("PRYSMLAB_VOLUME", cfg["volume"])
     HOST_LAB = os.environ.get("PRYSMLAB_HOST_LAB", cfg["host_lab"])
     WORK = os.path.join(HOST_LAB, "work")
     LAB = "/home/ubuntu/lab"

--- a/tool/live/txlab
+++ b/tool/live/txlab
@@ -1,0 +1,302 @@
+#!/usr/bin/env python3
+"""txlab — measure real P2P transmission between two live Prysm labs.
+
+A THIN driver over tool/live/prysmlab: it shells out, it never reimplements.
+Each peer is a prysmlab instance in its own container with its own Tor and
+identity; peers talk over the REAL Tor network (no host ports, no LAN
+transport). Two-peer transmission found defects a one-peer UI lab cannot see —
+stale WS links, group lists that never refresh, WS links that never form.
+
+    tool/live/txlab onion a            # onion + base58 contact id
+    tool/live/txlab send a b --reps 10
+    tool/live/txlab watch droid --secs 60
+
+`send` needs both apps up, the sender's composer empty, and BOTH peers on the
+chat screen. A second Linux peer — identity is per-container, image shared:
+
+    PRYSMLAB_CONTAINER=prysm-lab-b PRYSMLAB_HOST_LAB=/tmp/prysm-lab-b \
+      PRYSMLAB_VOLUME=prysm-lab-b-pub tool/live/prysmlab up
+"""
+
+from __future__ import annotations
+
+import argparse
+import calendar
+import json
+import os
+import re
+import statistics
+import subprocess
+import sys
+import time
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+PRYSMLAB = os.path.join(HERE, "prysmlab")
+
+# ---- the only configuration -------------------------------------------------
+# Each peer is a full prysmlab identity: own container, staging dir, tor and
+# pub-cache volume. Identity lives in the container's writable layer, so a
+# second container IS a second identity. `droid` (Android) has no hostname
+# file, so its onion is read off the live HomeScreen widget (cmd_onion).
+PEERS = {
+    "a":     {"platform": "linux",   "container": "prysm-lab-a",
+              "host_lab": "/tmp/prysm-lab-a",       "volume": "prysm-lab-a-pub"},
+    "b":     {"platform": "linux",   "container": "prysm-lab-b",
+              "host_lab": "/tmp/prysm-lab-b",       "volume": "prysm-lab-b-pub"},
+    # A third Linux peer: the group scenario needs two members who are both
+    # contacts of the admin but not of each other.
+    "c":     {"platform": "linux",   "container": "prysm-lab-c",
+              "host_lab": "/tmp/prysm-lab-c",       "volume": "prysm-lab-c-pub"},
+    "droid": {"platform": "android", "container": "prysm-lab-android",
+              "host_lab": "/tmp/prysm-lab-android", "volume": "prysm-lab-android-pub"},
+}
+
+# Failure signatures worth counting on a live peer (cmd_watch).
+SIGNATURES = [
+    r"WS failed .*TimeoutException",      # stale WS link, full send budget burned
+    r"rejecting hello from unknown peer", # group member with no contact identity
+    r"hostUnreachable",                   # SOCKS says the peer's onion is dead
+    r"sync-hint to .* failed",            # wake hint did not reach a peer
+    r"Quarantin",                         # peer put in the 10-min dial quarantine
+]
+
+# Base58 alphabet as lib/util/onion_id_codec.dart uses it (package:bs58).
+BASE58 = "123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz"
+# Not anchored: Android lines arrive through logcat as
+# `I/flutter ( 2617): [2026-08-11 13:00:24.856] INFO …`, so the bracket is not
+# at column 0 and an `^` here makes every Android read come back empty.
+LOG_TS = re.compile(r"\[(\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2})\.(\d{3})\]")
+
+def die(msg: str, code: int = 1):
+    print(f"txlab: {msg}", file=sys.stderr)
+    sys.exit(code)
+
+def plab(peer: str, argv: list[str], check: bool = True) -> str:
+    """Run a prysmlab subcommand for a peer, with that peer's identity env."""
+    cfg = PEERS[peer]
+    env = dict(os.environ, PRYSMLAB_CONTAINER=cfg["container"],
+               PRYSMLAB_HOST_LAB=cfg["host_lab"], PRYSMLAB_VOLUME=cfg["volume"],
+               PRYSMLAB_PLATFORM=cfg["platform"])
+    res = subprocess.run([PRYSMLAB, *argv], capture_output=True, text=True, env=env)
+    if res.returncode != 0 and check:
+        die(f"{peer}: prysmlab {' '.join(argv)} failed: "
+            f"{(res.stderr or res.stdout).strip()}")
+    return res.stdout
+
+def parse_log_ts(line: str) -> float | None:
+    # App timestamps are UTC; the host may not be. timegm treats them as UTC;
+    # time.mktime would apply the host's local offset and skew every
+    # cross-side delta by it.
+    m = LOG_TS.search(line)   # search, not match: the bracket is not at column 0 on Android
+    if not m:
+        return None
+    return calendar.timegm(time.strptime(m.group(1), "%Y-%m-%d %H:%M:%S")) \
+        + int(m.group(2)) / 1000.0
+
+def newest_match(peer: str, regex: str, after: float) -> tuple[float, str] | None:
+    # Log lines carry no message id, so correlation is by ordering: keep ONE
+    # message in flight per rep, anchored on a mark taken just before the send.
+    # `prysmlab logs` takes `--tail`, not `--lines` — the wrong flag returns
+    # nothing and every message silently looks lost.
+    out = plab(peer, ["logs", "--grep", regex, "--tail", "4000"])
+    best = None
+    for line in out.splitlines():
+        ts = parse_log_ts(line)
+        if ts is not None and ts > after and (best is None or ts > best[0]):
+            best = (ts, line)
+    return best
+
+def cmd_onion(args) -> int:
+    if PEERS[args.peer]["platform"] == "android":
+        # Android has no hostname file; read the live HomeScreen widget. The
+        # eval stays in the default widgets/binding.dart library: `eval --lib`
+        # is STICKY, and after a --lib package:prysm/... eval plain tap/where
+        # break until `eval --lib package:flutter/src/widgets/binding.dart 1`
+        # resets it — txlab must never leave that behind.
+        expr = ("(() { final b = WidgetsBinding.instance; final hits = <Element>[]; "
+                "void walk(Element e) { final dynamic w = e.widget; "
+                "if (w.runtimeType.toString() == 'HomeScreen') { hits.add(e); } "
+                "e.visitChildren(walk); } final r = b.rootElement; "
+                "if (r == null) return 'ERR no-root'; walk(r); "
+                "if (hits.isEmpty) return 'NOTFOUND HomeScreen'; "
+                "final dynamic home = hits.first.widget; return home.onionAddress; })()")
+        onion = plab(args.peer, ["eval", expr]).strip()
+    else:
+        onion = plab(args.peer, ["peer", "onion"]).strip()
+    # Base58 of the utf8 bytes, `.onion` stripped — mirrors onion_id_codec.dart.
+    raw = (onion[:-6] if onion.endswith(".onion") else onion).encode()
+    n = int.from_bytes(raw, "big")
+    b58 = ""
+    while n:
+        n, digit = divmod(n, 58)
+        b58 = BASE58[digit] + b58
+    pad = 0
+    for byte in raw:
+        if byte:
+            break
+        pad += 1
+    print(onion)
+    print("1" * pad + (b58 or ""))
+    return 0
+
+def wait_for_render(peer: str, mark: str, timeout: float) -> float | None:
+    # A delivered bubble is one Text + one RichText at the same y — exactly 2
+    # hits is ONE bubble, not a duplicate (both carry the text in toString).
+    expr = ("(() { final b = WidgetsBinding.instance; int n = 0; "
+            "void walk(Element e) { final dynamic w = e.widget; "
+            "final String t = w.runtimeType.toString(); "
+            "if ((t == 'RichText' || t == 'Text') && "
+            f"w.toString().contains({json.dumps(mark)}))" + " { n++; } "
+            "e.visitChildren(walk); } final r = b.rootElement; "
+            "if (r == null) return 'ERR no-root'; walk(r); "
+            "return 'HITS ' + n.toString(); })()")
+    deadline = time.time() + timeout
+    while True:
+        m = re.search(r"HITS (\d+)", plab(peer, ["eval", expr]).strip())
+        if m and int(m.group(1)) >= 2:
+            return time.time()
+        if time.time() >= deadline:
+            return None
+        time.sleep(0.4)
+
+def cmd_send(args) -> int:
+    if args.frm == args.to:
+        die("sender and receiver must be different peers")
+    # Receiver arrival line per chat kind: 1:1 logs `Received text from`,
+    # group logs `Received group_text from`; --group selects it.
+    recv_re = r"Received group_text from" if args.group else r"Received text from"
+    rows = []
+    lost = skipped = 0
+    for rep in range(1, args.reps + 1):
+        mark = f"txlab{args.frm}{rep}-{time.time_ns()}"
+        # Count real EditableText ELEMENTS, not occurrences of the string in the
+        # dump: the raw tree names the type on every ancestor line too, which
+        # over-counts wildly (27 vs the 2 widgets `type -n` actually indexes).
+        walk = ("(() { final b = WidgetsBinding.instance; var n = 0; "
+                "void walk(Element e) { if (e.widget.runtimeType.toString() == 'EditableText') n++; "
+                "e.visitChildren(walk); } b.rootElement!.visitChildren(walk); return 'N=$n'; })()")
+        m = re.search(r"N=(\d+)", plab(args.frm, ["eval", walk]))
+        n = int(m.group(1)) if m else 0
+        if n == 0:
+            die(f"{args.frm}: no EditableText in the tree — is the chat screen open?")
+        typed = plab(args.frm, ["type", mark, "-n", str(n - 1)])  # composer = LAST field
+        m = re.search(r"now=(.*)", typed)
+        if not m or m.group(1) != mark:
+            skipped += 1
+            print(f"rep {rep}: SKIPPED — composer not clean (now={m.group(1) if m else '?'})")
+            continue
+        # Pre-send marks, newest matching line per side just before the tap,
+        # so the post-send read takes "newest strictly newer than the mark".
+        before_s = newest_match(args.frm, r"send ok", 0.0)
+        before_r = newest_match(args.to, recv_re, 0.0)
+        t0 = time.time()  # host wall clock right before the tap
+        # A non-TAPPED result (OCCLUDED / NOTFOUND) is a normal harness outcome,
+        # not a crash: prysmlab exits 2, so tolerate it and count the rep lost.
+        tapped = plab(args.frm, ["tap-widget", "--type", "PrysmIconButton",
+                                 "--contains", "send", "--settle", "0"], check=False)
+        if not tapped.startswith("TAPPED"):
+            lost += 1
+            print(f"rep {rep}: LOST — tap failed ({tapped.strip()})")
+            continue
+        # Both containers share the host kernel clock (measured skew 1 ms), so
+        # host wall-clock times and UTC log timestamps are one clock; do not
+        # "fix" the deltas with an NTP dance.
+        t_render = wait_for_render(args.to, mark, args.timeout)
+        sent = newest_match(args.frm, r"send ok", before_s[0] if before_s else 0.0)
+        recv = newest_match(args.to, recv_re, before_r[0] if before_r else 0.0)
+        if recv is None:
+            lost += 1
+            # wait_for_render returns as soon as the bubble shows, so the poll may
+            # have lasted far less than --timeout; say what actually happened.
+            waited = time.time() - t0
+            why = ("bubble rendered but no log line — wrong chat kind? "
+                   "1:1 logs 'Received text from', a group logs 'Received group_text from'"
+                   if t_render else "nothing rendered either")
+            print(f"rep {rep}: LOST — no receiver '{recv_re}' line after "
+                  f"{waited:.1f}s ({why})")
+            continue
+        recv_ts, _ = recv
+        if sent is None:
+            path, ack = "?", None
+        else:
+            sent_ts, sent_line = sent
+            # Only `HTTP send ok` names its transport for certain. The
+            # ws-preferred line cannot: withPeer may have fallen back to HTTP
+            # inside the same call, so report it as unknown rather than "WS".
+            path = "HTTP" if "HTTP send ok" in sent_line else "ws-pref?"
+            ack = sent_ts - recv_ts
+        render = None if t_render is None else t_render - recv_ts
+        rows.append((recv_ts - t0, ack, render, path))
+        print(f"rep {rep}: wire={rows[-1][0]:.3f}s "
+              f"ack={'n/a' if ack is None else f'{ack:.3f}s'} "
+              f"render={'n/a' if render is None else f'{render:.3f}s'} path={path}")
+    for key, idx in (("wire", 0), ("ack", 1), ("render", 2)):
+        vals = sorted(r[idx] for r in rows if r[idx] is not None)
+        if vals:
+            print(f"summary {key}: median={statistics.median(vals):.3f}s "
+                  f"min={vals[0]:.3f}s max={vals[-1]:.3f}s (n={len(vals)})")
+    paths = {}
+    for _, _, _, path in rows:
+        if path != "?":
+            paths[path] = paths.get(path, 0) + 1
+    if paths:
+        print("summary path: " + " ".join(f"{k}={v}" for k, v in paths.items()))
+    print(f"summary lost: {lost}/{args.reps}" + (f"  skipped: {skipped}" if skipped else ""))
+    return 1 if lost else 0
+
+def cmd_watch(args) -> int:
+    # One combined grep per sample keeps the docker execs down; the per-
+    # signature split happens here on the host. `logs --grep` filters the
+    # whole log then tails 4000 matching lines, so only a >4000-match burst
+    # could undercount.
+    combined = "|".join(f"({s})" for s in SIGNATURES)
+
+    def sample() -> dict:
+        out = plab(args.peer, ["logs", "--grep", combined, "--tail", "4000"])
+        return {s: sum(1 for ln in out.splitlines() if re.search(s, ln))
+                for s in SIGNATURES}
+
+    first = sample()
+    last = first
+    deadline = time.time() + args.secs
+    while time.time() < deadline:
+        time.sleep(2)
+        last = sample()
+    print(f"watch {args.peer} over {args.secs:g}s: new occurrences per signature")
+    for sig in SIGNATURES:
+        print(f"  {last[sig] - first[sig]:5d}  {sig}")
+    return 0
+
+def build_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(
+        prog="txlab", description=__doc__.split("\n\n")[0],
+        formatter_class=argparse.RawDescriptionHelpFormatter)
+    sub = p.add_subparsers(dest="cmd", required=True)
+    s = sub.add_parser("onion", help="print a peer's onion and base58 contact id")
+    s.add_argument("peer", choices=sorted(PEERS))
+    s.set_defaults(func=cmd_onion)
+    s = sub.add_parser("send", help="measure sends between two peers, rep by rep")
+    s.add_argument("frm", metavar="FROM", choices=sorted(PEERS))
+    s.add_argument("to", metavar="TO", choices=sorted(PEERS))
+    s.add_argument("--reps", type=int, default=5)
+    s.add_argument("--group", action="store_true",
+                   help="group chat: receiver logs 'Received group_text from'")
+    s.add_argument("--timeout", type=float, default=120.0,
+                   help="per-rep wait for the bubble to render, seconds")
+    s.set_defaults(func=cmd_send)
+    s = sub.add_parser("watch", help="count failure signatures in a peer's log")
+    s.add_argument("peer", choices=sorted(PEERS))
+    s.add_argument("--secs", type=float, default=30.0,
+                   help="watch window in seconds")
+    s.set_defaults(func=cmd_watch)
+    return p
+
+def main(argv: list[str]) -> int:
+    args = build_parser().parse_args(argv)
+    try:
+        return args.func(args)
+    except KeyboardInterrupt:
+        return 130
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))


### PR DESCRIPTION
Tooling only — no `lib/` change.

**Android.** `prysmlab -p android` runs the real APK on an in-container x86_64 emulator (KVM, AVD `pixel_5`). Everything downstream of the Dart VM Service is shared with the Linux lab; only the lifecycle differs, so the platform table is the whole difference and the Linux values are unchanged. A phone report cannot be refuted on the desktop build: `defaultTargetPlatform` picks a different gesture branch, and the two builds do not even render the same navigation surfaces. The AVD carries a device profile on purpose — without one `avdmanager` builds a 320x640 screen no phone has, and every layout observation is worthless.

**`longpress`.** `tap` sends down and up in the same turn, below every `LongPressGestureRecognizer` deadline, so the entire class of "hold down and nothing happens" defects was invisible to the tool that exists to see it. The release is scheduled on the app's own event loop, so the result is read from the next `screen`, not from the command's output.

**Two peers.** Every host resource was already env-overridable except the pub-cache volume; one line fixes that, and a second peer is then just three environment variables. Each container is a new identity with its own Tor and its own onion, and they talk over the real Tor network.

**`txlab`.** A thin driver over `prysmlab` that measures transmission between two peers: wire time from the send tap to the receiver's router log, ack, render, and transport, with medians and a loss count. It bakes in the traps that cost time: app log timestamps are UTC (`timegm`, not `mktime`), `logs` takes `--tail`, the receiver's line differs between 1:1 and group, and no log line carries a message id so correlation is one message in flight at a time.

The skill doc gains the two-peer recipe with the measured baselines, so the next session starts from numbers instead of rediscovering them.