### PR TITLE
fix(transfer): agree on the file envelope scheme so chunked sends can start

### DIFF
--- a/lib/services/file_transfer_handler.dart
+++ b/lib/services/file_transfer_handler.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 import 'dart:convert';
 
 import 'package:flutter/foundation.dart';
+import 'package:prysm/crypto/constants.dart';
 import 'package:prysm/crypto/envelope.dart';
 import 'package:prysm/server/inbound_limits.dart';
 import 'package:prysm/server/inbound_message_router.dart';
@@ -27,6 +28,7 @@ class _InboundTransfer {
     required this.ciphertextSize,
     required this.totalChunks,
     required this.chunkSize,
+    required this.scheme,
     this.replyTo,
     this.viewOnce = false,
   }) : buffer = Uint8List(ciphertextSize),
@@ -45,6 +47,7 @@ class _InboundTransfer {
   final int ciphertextSize;
   final int totalChunks;
   final int chunkSize;
+  final String scheme;
   final String? replyTo;
   final bool viewOnce;
 
@@ -215,6 +218,14 @@ class FileTransferHandler {
     final transferId = payload['transferId'] as String;
     final nonce = base64Decode(payload['nonce'] as String);
 
+    // Peers predating the scheme field send no scheme; anything that is not a
+    // clean `file-signed-1` is treated exactly like today's legacy
+    // `file-aead-1` transfer, and only the two known constants are ever
+    // stored or handed to the crypto layer.
+    final scheme = payload['scheme'] == CryptoConstants.schemeFileSigned1
+        ? CryptoConstants.schemeFileSigned1
+        : CryptoConstants.schemeFileAead1;
+
     _active[transferId] = _InboundTransfer(
       messageId: payload['messageId'] as String,
       senderId: payload['senderId'] as String,
@@ -230,6 +241,7 @@ class FileTransferHandler {
       ciphertextSize: payload['ciphertextSize'] as int,
       totalChunks: payload['totalChunks'] as int,
       chunkSize: payload['chunkSize'] as int,
+      scheme: scheme,
       replyTo: payload['replyTo'] as String?,
       viewOnce: payload['viewOnce'] == true,
     );
@@ -318,11 +330,17 @@ class FileTransferHandler {
       return {'error': 'Incomplete transfer'};
     }
 
-    final envelope = CryptoEnvelope.fileAead1(
-      wrappedKey: session.wrappedKey,
-      nonce: session.nonce,
-      ciphertext: session.buffer,
-    );
+    final envelope = session.scheme == CryptoConstants.schemeFileSigned1
+        ? CryptoEnvelope.fileSigned1(
+            wrappedKey: session.wrappedKey,
+            nonce: session.nonce,
+            ciphertext: session.buffer,
+          )
+        : CryptoEnvelope.fileAead1(
+            wrappedKey: session.wrappedKey,
+            nonce: session.nonce,
+            ciphertext: session.buffer,
+          );
     final wire = CryptoEnvelope.encode(envelope);
 
     final router = _router;

--- a/lib/services/file_transfer_handler.dart
+++ b/lib/services/file_transfer_handler.dart
@@ -222,7 +222,17 @@ class FileTransferHandler {
     // clean `file-signed-1` is treated exactly like today's legacy
     // `file-aead-1` transfer, and only the two known constants are ever
     // stored or handed to the crypto layer.
-    final scheme = payload['scheme'] == CryptoConstants.schemeFileSigned1
+    final declaredScheme = payload['scheme'];
+    if (declaredScheme != null &&
+        declaredScheme != CryptoConstants.schemeFileSigned1 &&
+        declaredScheme != CryptoConstants.schemeFileAead1) {
+      Logging.debug(
+        'begin unknown scheme=$declaredScheme transfer=$transferId '
+        'message=${payload['messageId']} falling back to file-aead-1',
+        'FileTransferHandler',
+      );
+    }
+    final scheme = declaredScheme == CryptoConstants.schemeFileSigned1
         ? CryptoConstants.schemeFileSigned1
         : CryptoConstants.schemeFileAead1;
 

--- a/lib/services/file_transfer_sender.dart
+++ b/lib/services/file_transfer_sender.dart
@@ -13,11 +13,13 @@ import 'package:uuid/uuid.dart';
 
 class FileTransferParts {
   const FileTransferParts({
+    required this.scheme,
     required this.wrappedKey,
     required this.nonce,
     required this.ciphertext,
   });
 
+  final String scheme;
   final Map<String, dynamic> wrappedKey;
   final Uint8List nonce;
   final Uint8List ciphertext;
@@ -25,8 +27,10 @@ class FileTransferParts {
 
 FileTransferParts parseFileTransferParts(String peerPayload) {
   final envelope = CryptoEnvelope.tryParse(peerPayload);
+  final scheme = envelope?['scheme'];
   if (envelope == null ||
-      envelope['scheme'] != CryptoConstants.schemeFileAead1) {
+      (scheme != CryptoConstants.schemeFileAead1 &&
+          scheme != CryptoConstants.schemeFileSigned1)) {
     throw const FormatException('Invalid file envelope');
   }
   final wrappedKey = envelope['wrappedKey'];
@@ -34,6 +38,7 @@ FileTransferParts parseFileTransferParts(String peerPayload) {
     throw const FormatException('Invalid wrappedKey');
   }
   return FileTransferParts(
+    scheme: scheme as String,
     wrappedKey: Map<String, dynamic>.from(wrappedKey),
     nonce: base64Decode(envelope['nonce'] as String),
     ciphertext: base64Decode(envelope['ciphertext'] as String),
@@ -143,6 +148,7 @@ class FileTransferSender {
           'timestamp': timestamp ?? DateTime.now().millisecondsSinceEpoch,
           'wrappedKey': parts.wrappedKey,
           'nonce': base64Encode(parts.nonce),
+          'scheme': parts.scheme,
           'ciphertextSize': ciphertext.length,
           'totalChunks': totalChunks,
           'chunkSize': chunkSize,

--- a/test/file_transfer_sender_test.dart
+++ b/test/file_transfer_sender_test.dart
@@ -415,4 +415,48 @@ void main() {
     expect(envelope, isNotNull);
     expect(envelope!['scheme'], CryptoConstants.schemeFileAead1);
   });
+
+  test(
+      'handleEnd rebuilds file-aead-1 when begin carries an unrecognized '
+      'scheme',
+      () async {
+    final handler = FileTransferHandler.instance;
+    const transferId = '550e8400-e29b-41d4-a716-4466554400cc';
+    final ciphertext =
+        Uint8List.fromList(List<int>.generate(300, (i) => i % 251));
+
+    final beginResult = await handler.handleBegin(
+      _beginPayload(
+        transferId: transferId,
+        messageId: 'msg-rebuild-unknown',
+        senderId: 'peer.onion',
+        receiverId: 'local.onion',
+        ciphertext: ciphertext,
+        scheme: 'file-signed-99',
+      ),
+      peerOnion: 'peer.onion',
+      localOnion: 'local.onion',
+    );
+    expect(beginResult['ok'], isTrue);
+
+    await _deliverChunks(
+      handler,
+      transferId,
+      ciphertext,
+      peerOnion: 'peer.onion',
+    );
+
+    final testRouter = _TestRouter();
+    handler.routerOverride = testRouter;
+    final endResult = await handler.handleEnd(
+      {'transferId': transferId},
+      peerOnion: 'peer.onion',
+    );
+    expect(endResult['ok'], isTrue);
+
+    final wire = testRouter.lastProcessed?['message'] as String;
+    final envelope = CryptoEnvelope.tryParse(wire);
+    expect(envelope, isNotNull);
+    expect(envelope!['scheme'], CryptoConstants.schemeFileAead1);
+  });
 }

--- a/test/file_transfer_sender_test.dart
+++ b/test/file_transfer_sender_test.dart
@@ -1,14 +1,22 @@
 import 'dart:async';
+import 'dart:convert';
 import 'dart:typed_data';
 
 import 'package:flutter_test/flutter_test.dart';
+import 'package:prysm/crypto/constants.dart';
 import 'package:prysm/crypto/envelope.dart';
+import 'package:prysm/crypto/identity.dart';
+import 'package:prysm/crypto/wire.dart';
+import 'package:prysm/server/inbound_message_router.dart';
+import 'package:prysm/services/file_transfer_handler.dart';
 import 'package:prysm/services/file_transfer_progress.dart';
 import 'package:prysm/services/file_transfer_sender.dart';
+import 'package:prysm/services/settings_service.dart';
 import 'package:prysm/services/ws_connection_manager.dart';
 import 'package:prysm/transport/ws_peer_link.dart';
 import 'package:prysm/transport/ws_protocol.dart';
 import 'package:prysm/util/file_transfer_policy.dart';
+import 'package:prysm/util/key_manager.dart';
 import 'package:prysm/util/tor_lifecycle_state.dart';
 import 'package:prysm/util/tor_runtime_gate.dart';
 import 'package:prysm/util/tor_service.dart';
@@ -84,10 +92,94 @@ class _ChunkAckLink implements WsPeerLink {
   Future<void> sendPing() async {}
 }
 
+Future<IdentityPublicKeys> _publicKeys(IdentityKeyPair id) async {
+  final sign = await id.signPublicKey;
+  final agree = await id.agreePublicKey;
+  return IdentityPublicKeys(
+    signPublic: sign,
+    agreePublic: agree,
+    fingerprint: IdentityKeyPair.fingerprintFromPublicJson(
+      await id.toPublicJson(),
+    ),
+  );
+}
+
+class _TestRouter extends InboundMessageRouter {
+  _TestRouter()
+      : super(
+          keyManager: KeyManager(),
+          settings: SettingsService(),
+          localOnionAddress: () => 'local.onion',
+        );
+
+  Map<String, dynamic>? lastProcessed;
+
+  @override
+  Future<InboundHandleResult> processMessage(
+    Map<String, dynamic> data,
+  ) async {
+    lastProcessed = data;
+    return InboundHandleResult.ok({'ok': true});
+  }
+}
+
+Map<String, dynamic> _beginPayload({
+  required String transferId,
+  required String messageId,
+  required String senderId,
+  required String receiverId,
+  required Uint8List ciphertext,
+  String? scheme,
+  Map<String, dynamic>? wrappedKey,
+}) {
+  return {
+    'transferId': transferId,
+    'messageId': messageId,
+    'senderId': senderId,
+    'receiverId': receiverId,
+    'type': 'file',
+    'fileName': 'test.bin',
+    'fileSize': 300,
+    'timestamp': 1,
+    'scheme': ?scheme,
+    'wrappedKey': wrappedKey ?? {'ephemeralPub': 'abc'},
+    'nonce': base64Encode(Uint8List(12)),
+    'ciphertextSize': ciphertext.length,
+    'totalChunks': FileTransferPolicy.chunkCountForSize(ciphertext.length),
+    'chunkSize': FileTransferPolicy.chunkSizeBytes,
+  };
+}
+
+Future<void> _deliverChunks(
+  FileTransferHandler handler,
+  String transferId,
+  Uint8List ciphertext, {
+  required String peerOnion,
+}) async {
+  final chunkSize = FileTransferPolicy.chunkSizeBytes;
+  for (var i = 0; i < FileTransferPolicy.chunkCountForSize(ciphertext.length); i++) {
+    final offset = i * chunkSize;
+    final end = offset + chunkSize > ciphertext.length
+        ? ciphertext.length
+        : offset + chunkSize;
+    final frame = FileTransferChunkFrame(
+      transferId: transferId,
+      chunkIndex: i,
+      payload: ciphertext.sublist(offset, end),
+    );
+    await handler.handleChunk(
+      frame,
+      peerOnion: peerOnion,
+      sendAck: (_, {payload}) async {},
+    );
+  }
+}
+
 void main() {
   setUp(() {
     TorRuntimeGate.resetForTest();
     TorLifecycleNotifier.instance.update(TorLifecycleState.ready);
+    FileTransferHandler.instance.resetForTest();
   });
 
   test('sender splits ciphertext and reports progress', () async {
@@ -130,5 +222,197 @@ void main() {
     expect(FileTransferProgress.uploadFor('msg-1')?.value, 1.0);
 
     manager.dispose();
+  });
+
+  test(
+    'parseFileTransferParts accepts the real encryptFile signed payload',
+    () async {
+      final alice = await IdentityKeyPair.generate();
+      final bob = await IdentityKeyPair.generate();
+      final bobPub = await bob.agreePublicKey;
+      final bytes =
+          Uint8List.fromList(List<int>.generate(300, (i) => i % 251));
+
+      final payloads = await CryptoWire.encryptFile(bytes, alice, bobPub);
+
+      final parts = parseFileTransferParts(payloads.peerPayload);
+      expect(parts.scheme, CryptoConstants.schemeFileSigned1);
+      expect(parts.wrappedKey['sig'], isA<String>());
+      expect(parts.ciphertext.length, greaterThan(0));
+    },
+  );
+
+  test(
+    'sender sends a real signed payload and its reassembly decrypts '
+    'like the monolithic envelope',
+    () async {
+      FileTransferProgress.resetForTest();
+
+      final alice = await IdentityKeyPair.generate();
+      final bob = await IdentityKeyPair.generate();
+      final bobPub = await bob.agreePublicKey;
+      final alicePub = await _publicKeys(alice);
+      final bytes =
+          Uint8List.fromList(List<int>.generate(300, (i) => i % 251));
+
+      final payloads = await CryptoWire.encryptFile(bytes, alice, bobPub);
+
+      final manager = WsConnectionManager(
+        TorManager(torPath: '/bin/false', dataDir: '/tmp/file-transfer-sender', controlPassword: 'test-password'),
+      );
+      final link = _ChunkAckLink('peer.onion');
+      manager.registerLinkForTest('peer.onion', link);
+
+      final sender = FileTransferSender(manager);
+      final ok = await sender.send(
+        peerOnion: 'peer.onion',
+        messageId: 'msg-signed-1',
+        senderId: 'me.onion',
+        receiverId: 'peer.onion',
+        type: 'file',
+        fileName: 'signed.bin',
+        fileSize: bytes.length,
+        peerPayload: payloads.peerPayload,
+      );
+      expect(ok, isTrue);
+
+      final beginIndex = link.sentOps.indexOf('file_transfer_begin');
+      expect(beginIndex, isNonNegative);
+      final beginPayload = link.sentPayloads[beginIndex]!;
+      expect(beginPayload['scheme'], CryptoConstants.schemeFileSigned1);
+      expect(
+        (beginPayload['wrappedKey'] as Map<String, dynamic>)['sig'],
+        isA<String>(),
+      );
+
+      // Feed the sender's exact wire output into the receiver path; the
+      // reassembled transfer must be rebuilt as file-signed-1 and decrypt
+      // exactly like the monolithic peer payload.
+      final handler = FileTransferHandler.instance;
+      final beginResult = await handler.handleBegin(
+        beginPayload,
+        peerOnion: 'me.onion',
+        localOnion: 'peer.onion',
+      );
+      expect(beginResult['ok'], isTrue);
+
+      for (final raw in link.sentBinary) {
+        final frame = FileTransferChunkFrame.decode(raw);
+        await handler.handleChunk(
+          frame,
+          peerOnion: 'me.onion',
+          sendAck: (_, {payload}) async {},
+        );
+      }
+
+      final testRouter = _TestRouter();
+      handler.routerOverride = testRouter;
+      final endResult = await handler.handleEnd(
+        {'transferId': beginPayload['transferId'] as String},
+        peerOnion: 'me.onion',
+      );
+      expect(endResult['ok'], isTrue);
+
+      final wire = testRouter.lastProcessed?['message'] as String;
+      final envelope = CryptoEnvelope.tryParse(wire);
+      expect(envelope, isNotNull);
+      expect(envelope!['scheme'], CryptoConstants.schemeFileSigned1);
+
+      final dec = await CryptoWire.decryptFileFromPeer(wire, bob, alicePub);
+      expect(dec, bytes);
+
+      manager.dispose();
+    },
+  );
+
+  test('handleEnd rebuilds file-signed-1 when begin carries the scheme',
+      () async {
+    final handler = FileTransferHandler.instance;
+    const transferId = '550e8400-e29b-41d4-a716-4466554400aa';
+    final ciphertext =
+        Uint8List.fromList(List<int>.generate(300, (i) => i % 251));
+
+    final beginResult = await handler.handleBegin(
+      _beginPayload(
+        transferId: transferId,
+        messageId: 'msg-rebuild-signed',
+        senderId: 'peer.onion',
+        receiverId: 'local.onion',
+        ciphertext: ciphertext,
+        scheme: CryptoConstants.schemeFileSigned1,
+        wrappedKey: {
+          'crypto': CryptoConstants.cryptoVersion,
+          'scheme': CryptoConstants.schemeDmSigned2,
+          'ephemeralPub': 'abc',
+          'nonce': base64Encode(Uint8List(12)),
+          'ciphertext': base64Encode(Uint8List(16)),
+          'sig': 'c2ln',
+        },
+      ),
+      peerOnion: 'peer.onion',
+      localOnion: 'local.onion',
+    );
+    expect(beginResult['ok'], isTrue);
+
+    await _deliverChunks(
+      handler,
+      transferId,
+      ciphertext,
+      peerOnion: 'peer.onion',
+    );
+
+    final testRouter = _TestRouter();
+    handler.routerOverride = testRouter;
+    final endResult = await handler.handleEnd(
+      {'transferId': transferId},
+      peerOnion: 'peer.onion',
+    );
+    expect(endResult['ok'], isTrue);
+
+    final wire = testRouter.lastProcessed?['message'] as String;
+    final envelope = CryptoEnvelope.tryParse(wire);
+    expect(envelope, isNotNull);
+    expect(envelope!['scheme'], CryptoConstants.schemeFileSigned1);
+  });
+
+  test('handleEnd rebuilds file-aead-1 when begin has no scheme (legacy peer)',
+      () async {
+    final handler = FileTransferHandler.instance;
+    const transferId = '550e8400-e29b-41d4-a716-4466554400bb';
+    final ciphertext =
+        Uint8List.fromList(List<int>.generate(300, (i) => i % 251));
+
+    final beginResult = await handler.handleBegin(
+      _beginPayload(
+        transferId: transferId,
+        messageId: 'msg-rebuild-legacy',
+        senderId: 'peer.onion',
+        receiverId: 'local.onion',
+        ciphertext: ciphertext,
+      ),
+      peerOnion: 'peer.onion',
+      localOnion: 'local.onion',
+    );
+    expect(beginResult['ok'], isTrue);
+
+    await _deliverChunks(
+      handler,
+      transferId,
+      ciphertext,
+      peerOnion: 'peer.onion',
+    );
+
+    final testRouter = _TestRouter();
+    handler.routerOverride = testRouter;
+    final endResult = await handler.handleEnd(
+      {'transferId': transferId},
+      peerOnion: 'peer.onion',
+    );
+    expect(endResult['ok'], isTrue);
+
+    final wire = testRouter.lastProcessed?['message'] as String;
+    final envelope = CryptoEnvelope.tryParse(wire);
+    expect(envelope, isNotNull);
+    expect(envelope!['scheme'], CryptoConstants.schemeFileAead1);
   });
 }


### PR DESCRIPTION
Found by measuring, not by reading: a two-peer transmission campaign over real Tor reported `path=mono` for every attachment, including an 8 MiB one. The sender's log said why, identically on every attempt:

```
ERROR [ChatService]: Chunked file send failed: FormatException: Invalid file envelope
ERROR [ChatService]: Chunked file transfer failed for cf291efe-…, falling back to HTTP send
```

**Cause.** `parseFileTransferParts` (`file_transfer_sender.dart:28`) accepted only `file-aead-1`, but `792d98f` (2026-08-04) changed `CryptoWire.encryptFile` to hand the peer a **`file-signed-1`** envelope whose `wrappedKey` is a signed `dm-signed-2` map. The two shapes are otherwise identical — `crypto: v2`, `wrappedKey` map, base64 `nonce`, base64 `ciphertext` — so the whole defect is one string, and it throws on the first line of `FileTransferSender.send`, before a byte moves. `file-aead-1` survives only as the *self* payload, which never leaves the device. At `4922f28` all three sides agreed; `792d98f` changed the producer and touched neither the parser nor the receiver. **The chunked path has been dead for eight days.**

A second, independent disagreement sat behind it: `handleEnd` (`file_transfer_handler.dart:321`) rebuilt every transfer as `file-aead-1`, so a signed wrap re-tagged unsigned would have been refused by the inbound auth gate (`direct_message_auth.dart:191`) and then by `decryptLegacyFromPeer`, which knows only `dh-aead-1/2`. Fixing only the parser would have moved the failure, not removed it.

**Fix.** The parser accepts both schemes; the sender puts the one it parsed into `file_transfer_begin`; `handleEnd` rebuilds with that scheme. A begin frame from a peer predating the field — or carrying anything other than the two known constants — is treated exactly as before, `file-aead-1`, so an older peer still interoperates and no attacker-chosen string reaches the crypto layer. `encryptFile` keeps signing peer payloads and `allowLegacyUnsignedFile` stays off: authentication is not relaxed to make the transport agree.

**Why the suite was green.** `file_transfer_sender_test.dart` hand-built a `file-aead-1` envelope instead of calling `encryptFile`, so it asserted the parser's own stale assumption and never crossed the seam. The new tests build the payload the way production does and carry it end to end: real `encryptFile` output → `FileTransferSender.send` → the captured begin payload → real `handleBegin` → real chunk frames → `handleEnd` → `decryptFileFromPeer` returns the original bytes. Plus the receiver rebuild in both directions (scheme present → `file-signed-1`, scheme absent → `file-aead-1`). Each was checked mordant: parser reverted → only the real-payload tests fail; `handleEnd` hardcoded again → only the rebuild test fails; legacy fallback dropped → only the legacy test fails.

**Verification.** `flutter analyze` 0, full suite 1062 + 1 skip green on this branch in isolation. Live between two containers with their own identities and Tor, 1:1 chat, same rig before and after:

| payload | before | after |
|---|---|---|
| 2 MiB | `path=mono`, 13.4 s, 1255 kbps, fallback error | `path=chunked`, **9 chunks**, 23.0 s, 729 kbps |
| 8 MiB | `path=mono`, 45.9 s, 1462 kbps, fallback error | `path=chunked`, **33 chunks**, 112.0 s, 599 kbps |
| 200 KiB | `path=mono`, 3.4 s | unchanged (below the 1 MiB threshold) |
| 997-char text | recv 0.68 s | recv 0.71 s, unchanged |

Sender now logs `chunk 33/33 sent bytes=16` then `transfer complete message=…`; receiver logs `begin accepted transfer=… chunks=33` and `Received file from …`. No fallback line, no failure signatures on either peer.

**One thing this fix exposes, and deliberately does not change.** Now that chunking actually runs, it is **1.7–2.4× slower** than the monolithic POST at these sizes: each 256 KiB chunk waits for its own ack, so 8 MiB is 33 sequential Tor round trips (measured inter-chunk gaps 1.7–2.7 s, with occasional 8–41 s stalls). What chunking buys is per-chunk retry (3×), progress reporting, and no 33% base64 inflation on the wire. Two follow-ups worth deciding separately, with numbers rather than opinion:

1. **Pipeline the chunk sends.** A window of N chunks in flight would remove the serialization; the ack correlation is already per-chunk index. This is the change that would make chunked strictly better than monolithic.
2. **`FileTransferSender.send`'s `timeout` parameter (`:67`, default 5 minutes) is dead.** It is passed from `ChatService._sendOverTor` and never used: begin/end use a hardcoded 30 s and each chunk ack 60 s. So there is no whole-transfer deadline on this path — which is why this fix does *not* introduce a cliff for large files, but the parameter currently lies about a bound that does not exist.

Until (1) lands, a maintainer may reasonably prefer to raise `chunkThresholdBytes` (`file_transfer_policy.dart:6`) above 1 MiB so the slower path is used only where its resilience is worth it. That is a product knob, so it is not in this PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * File transfers now support cryptographically signed envelopes alongside existing encrypted transfers.
  * Transfer security information is preserved throughout sending and receiving.
* **Bug Fixes**
  * Improved processing and reassembly of completed signed file transfers.
  * Transfers without explicit security information remain compatible with the legacy encryption path.
* **Tests**
  * Added coverage for signed transfers, legacy transfers, payload handling, and end-to-end reassembly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->