### PR TITLE
perf(transfer): keep eight chunks in flight instead of one

### DIFF
--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -12,15 +12,10 @@ concurrency:
   group: build-pr-${{ github.event.issue.number }}
   cancel-in-progress: true
 
+# Pinned, not tracked: an unpinned `stable` moved 3.44.9 -> 3.47.0 under an
+# unchanged main and broke it. Matches both Containerfiles. Bump deliberately.
 env:
   PR_NUMBER: ${{ github.event.issue.number }}
-
-# The toolchain is pinned, not tracked. `channel: stable` alone put CI on
-# whatever Flutter shipped that week: 3.44.9 was green on d18d384 and 3.47.0
-# failed the identical commit hours later, on a new lint plus a dart:io
-# signature change. Both Containerfiles already pin 3.44.8 (host toolchain);
-# this is the environment that was drifting away from them. Bump deliberately.
-env:
   FLUTTER_VERSION: "3.44.8"
 
 jobs:

--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -15,6 +15,14 @@ concurrency:
 env:
   PR_NUMBER: ${{ github.event.issue.number }}
 
+# The toolchain is pinned, not tracked. `channel: stable` alone put CI on
+# whatever Flutter shipped that week: 3.44.9 was green on d18d384 and 3.47.0
+# failed the identical commit hours later, on a new lint plus a dart:io
+# signature change. Both Containerfiles already pin 3.44.8 (host toolchain);
+# this is the environment that was drifting away from them. Bump deliberately.
+env:
+  FLUTTER_VERSION: "3.44.8"
+
 jobs:
   authorize:
     if: ${{ github.event.issue.pull_request && github.event.comment.body == 'build:test' }}
@@ -77,6 +85,7 @@ jobs:
 
       - uses: subosito/flutter-action@v2
         with:
+          flutter-version: ${{ env.FLUTTER_VERSION }}
           channel: stable
           cache: true
 
@@ -112,6 +121,7 @@ jobs:
 
       - uses: subosito/flutter-action@v2
         with:
+          flutter-version: ${{ env.FLUTTER_VERSION }}
           channel: stable
           cache: true
 
@@ -156,6 +166,7 @@ jobs:
 
       - uses: subosito/flutter-action@v2
         with:
+          flutter-version: ${{ env.FLUTTER_VERSION }}
           channel: stable
           cache: true
 
@@ -198,6 +209,7 @@ jobs:
 
       - uses: subosito/flutter-action@v2
         with:
+          flutter-version: ${{ env.FLUTTER_VERSION }}
           channel: stable
           cache: true
 
@@ -242,6 +254,7 @@ jobs:
 
       - uses: subosito/flutter-action@v2
         with:
+          flutter-version: ${{ env.FLUTTER_VERSION }}
           channel: stable
           cache: true
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,11 +5,8 @@ on:
     tags:
       - 'v*'
     
-# The toolchain is pinned, not tracked. `channel: stable` alone put CI on
-# whatever Flutter shipped that week: 3.44.9 was green on d18d384 and 3.47.0
-# failed the identical commit hours later, on a new lint plus a dart:io
-# signature change. Both Containerfiles already pin 3.44.8 (host toolchain);
-# this is the environment that was drifting away from them. Bump deliberately.
+# Pinned, not tracked: an unpinned `stable` moved 3.44.9 -> 3.47.0 under an
+# unchanged main and broke it. Matches both Containerfiles. Bump deliberately.
 env:
   FLUTTER_VERSION: "3.44.8"
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,6 +5,14 @@ on:
     tags:
       - 'v*'
     
+# The toolchain is pinned, not tracked. `channel: stable` alone put CI on
+# whatever Flutter shipped that week: 3.44.9 was green on d18d384 and 3.47.0
+# failed the identical commit hours later, on a new lint plus a dart:io
+# signature change. Both Containerfiles already pin 3.44.8 (host toolchain);
+# this is the environment that was drifting away from them. Bump deliberately.
+env:
+  FLUTTER_VERSION: "3.44.8"
+
 jobs:
 
   # ----------------------------
@@ -18,6 +26,7 @@ jobs:
 
       - uses: subosito/flutter-action@v2
         with:
+          flutter-version: ${{ env.FLUTTER_VERSION }}
           channel: stable
           cache: true
 
@@ -44,6 +53,7 @@ jobs:
 
       - uses: subosito/flutter-action@v2
         with:
+          flutter-version: ${{ env.FLUTTER_VERSION }}
           channel: stable
           cache: true
 
@@ -84,6 +94,7 @@ jobs:
 
       - uses: subosito/flutter-action@v2
         with:
+          flutter-version: ${{ env.FLUTTER_VERSION }}
           channel: stable
           cache: true
 
@@ -123,6 +134,7 @@ jobs:
 
       - uses: subosito/flutter-action@v2
         with:
+          flutter-version: ${{ env.FLUTTER_VERSION }}
           channel: stable
           cache: true
 
@@ -163,6 +175,7 @@ jobs:
 
       - uses: subosito/flutter-action@v2
         with:
+          flutter-version: ${{ env.FLUTTER_VERSION }}
           channel: stable
           cache: true
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,14 @@ on:
     branches: [main, master]
   pull_request:
 
+# The toolchain is pinned, not tracked. `channel: stable` alone put CI on
+# whatever Flutter shipped that week: 3.44.9 was green on d18d384 and 3.47.0
+# failed the identical commit hours later, on a new lint plus a dart:io
+# signature change. Both Containerfiles already pin 3.44.8 (host toolchain);
+# this is the environment that was drifting away from them. Bump deliberately.
+env:
+  FLUTTER_VERSION: "3.44.8"
+
 jobs:
   analyze-and-test:
     runs-on: ubuntu-latest
@@ -13,6 +21,7 @@ jobs:
 
       - uses: subosito/flutter-action@v2
         with:
+          flutter-version: ${{ env.FLUTTER_VERSION }}
           channel: stable
 
       - name: Install Linux dependencies

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,11 +5,8 @@ on:
     branches: [main, master]
   pull_request:
 
-# The toolchain is pinned, not tracked. `channel: stable` alone put CI on
-# whatever Flutter shipped that week: 3.44.9 was green on d18d384 and 3.47.0
-# failed the identical commit hours later, on a new lint plus a dart:io
-# signature change. Both Containerfiles already pin 3.44.8 (host toolchain);
-# this is the environment that was drifting away from them. Bump deliberately.
+# Pinned, not tracked: an unpinned `stable` moved 3.44.9 -> 3.47.0 under an
+# unchanged main and broke it. Matches both Containerfiles. Bump deliberately.
 env:
   FLUTTER_VERSION: "3.44.8"
 

--- a/lib/services/chat_service.dart
+++ b/lib/services/chat_service.dart
@@ -633,7 +633,6 @@ class ChatService {
         fileSize: fileSize,
         replyToId: replyToId,
         viewOnce: viewOnce,
-        timeout: timeout,
         expiresAt: expiresAt,
         timestamp: wireTimestamp,
       );
@@ -685,7 +684,6 @@ class ChatService {
     required int fileSize,
     String? replyToId,
     bool viewOnce = false,
-    required Duration timeout,
     int? expiresAt,
     int? timestamp,
   }) async {
@@ -716,7 +714,6 @@ class ChatService {
         peerPayload: encrypted,
         replyToId: replyToId,
         viewOnce: viewOnce,
-        timeout: timeout,
         expiresAt: expiresAt,
         timestamp: timestamp,
       );

--- a/lib/services/file_transfer_sender.dart
+++ b/lib/services/file_transfer_sender.dart
@@ -83,6 +83,12 @@ class FileTransferSender {
     StreamSubscription<Map<String, dynamic>>? controlSub;
     final pendingChunkAcks = <String, Completer<void>>{};
 
+    // Set once send() unwinds: a retry loop that was between attempts (its
+    // ack key already dropped) must not re-register a completer and resend
+    // frames after controlSub is cancelled. Local to send(), never a field:
+    // a field would leak one send's abandonment into a concurrent one.
+    var abandoned = false;
+
     void completeChunkAck(String key) {
       pendingChunkAcks.remove(key)?.complete();
     }
@@ -199,6 +205,11 @@ class FileTransferSender {
           for (var attempt = 0;
               attempt < FileTransferPolicy.maxChunkRetries;
               attempt++) {
+            // send() may have finished while this chunk sat between
+            // attempts: its old ack key is already gone, so continuing
+            // would strand a fresh completer and send frames on a
+            // subscription that will never ack them.
+            if (abandoned || transferFailed.isCompleted) return;
             final ackKey = '$transferId:$index';
             final ackCompleter = Completer<void>();
             pendingChunkAcks[ackKey] = ackCompleter;
@@ -316,6 +327,9 @@ class FileTransferSender {
       Logging.error('file transfer failed: $e\n$stack', 'FileTransferSender');
       return false;
     } finally {
+      // Stop any chunk still looping through retries from sending more
+      // frames once the ack subscription is gone.
+      abandoned = true;
       await controlSub.cancel();
       for (final completer in pendingChunkAcks.values) {
         if (!completer.isCompleted) {

--- a/lib/services/file_transfer_sender.dart
+++ b/lib/services/file_transfer_sender.dart
@@ -47,9 +47,14 @@ FileTransferParts parseFileTransferParts(String peerPayload) {
 
 /// Sends encrypted file ciphertext in WebSocket chunks with per-chunk acks.
 class FileTransferSender {
-  FileTransferSender(this._manager);
+  FileTransferSender(this._manager,
+      {this.ackTimeout = const Duration(seconds: 60)});
 
   final WsConnectionManager _manager;
+
+  /// Per-chunk ack wait before a retry. Injectable so tests can drive the
+  /// retry/abort paths without a real 60 s delay; production keeps 60 s.
+  final Duration ackTimeout;
 
   Future<bool> send({
     required String peerOnion,
@@ -64,7 +69,6 @@ class FileTransferSender {
     bool viewOnce = false,
     int? expiresAt,
     int? timestamp,
-    Duration timeout = const Duration(minutes: 5),
   }) async {
     final parts = parseFileTransferParts(peerPayload);
     final ciphertext = parts.ciphertext;
@@ -172,58 +176,111 @@ class FileTransferSender {
       );
 
       var ackedChunks = 0;
-      for (var index = 0; index < totalChunks; index++) {
-        final offset = index * chunkSize;
-        final end = offset + chunkSize > ciphertext.length
-            ? ciphertext.length
-            : offset + chunkSize;
-        final chunkBytes = ciphertext.sublist(offset, end);
-        final frame = FileTransferChunkFrame(
-          transferId: transferId,
-          chunkIndex: index,
-          payload: chunkBytes,
-        );
+      var nextIndex = 0;
+      var inFlight = 0;
+      final allChunksAcked = Completer<void>();
+      final transferFailed = Completer<void>();
+      Completer<void>? refill;
 
-        var sent = false;
-        for (var attempt = 0;
-            attempt < FileTransferPolicy.maxChunkRetries;
-            attempt++) {
-          final ackKey = '$transferId:$index';
-          final ackCompleter = Completer<void>();
-          pendingChunkAcks[ackKey] = ackCompleter;
+      void kickRefill() {
+        final pending = refill;
+        refill = null;
+        if (pending != null && !pending.isCompleted) {
+          pending.complete();
+        }
+      }
 
-          await _manager.sendBytes(peerOnion, frame.encode());
-          Logging.debug(
-            'chunk ${index + 1}/$totalChunks sent bytes=${chunkBytes.length} '
-            'transfer=$transferId',
-            'FileTransferSender',
-          );
+      // Sends one chunk (with per-index retries) and waits for its ack. The
+      // frame is built lazily at send time so the window never holds W × 256
+      // KiB of pre-sliced copies; only the sink buffers the in-flight frames.
+      Future<void> sendChunkWithRetries(int index) async {
+        try {
+          var sent = false;
+          for (var attempt = 0;
+              attempt < FileTransferPolicy.maxChunkRetries;
+              attempt++) {
+            final ackKey = '$transferId:$index';
+            final ackCompleter = Completer<void>();
+            pendingChunkAcks[ackKey] = ackCompleter;
 
-          try {
-            await ackCompleter.future.timeout(const Duration(seconds: 60));
-            sent = true;
-            break;
-          } on TimeoutException {
-            pendingChunkAcks.remove(ackKey);
+            final offset = index * chunkSize;
+            final end = offset + chunkSize > ciphertext.length
+                ? ciphertext.length
+                : offset + chunkSize;
+            final chunkBytes = ciphertext.sublist(offset, end);
+            final frame = FileTransferChunkFrame(
+              transferId: transferId,
+              chunkIndex: index,
+              payload: chunkBytes,
+            );
+
+            await _manager.sendBytes(peerOnion, frame.encode());
             Logging.debug(
-              'chunk $index/$totalChunks ack timeout attempt=${attempt + 1} '
+              'chunk ${index + 1}/$totalChunks sent bytes=${chunkBytes.length} '
               'transfer=$transferId',
               'FileTransferSender',
             );
+
+            try {
+              await ackCompleter.future.timeout(ackTimeout);
+              sent = true;
+              break;
+            } on TimeoutException {
+              pendingChunkAcks.remove(ackKey);
+              Logging.debug(
+                'chunk $index/$totalChunks ack timeout attempt=${attempt + 1} '
+                'transfer=$transferId',
+                'FileTransferSender',
+              );
+            }
           }
-        }
 
-        if (!sent) {
-          Logging.error(
-            'chunk $index/$totalChunks ack timeout transfer=$transferId',
-            'FileTransferSender',
-          );
-          return false;
-        }
+          if (!sent) {
+            Logging.error(
+              'chunk $index/$totalChunks ack timeout transfer=$transferId',
+              'FileTransferSender',
+            );
+            if (!transferFailed.isCompleted) transferFailed.complete();
+            return;
+          }
 
-        ackedChunks++;
-        progress.value = ackedChunks / totalChunks;
+          ackedChunks++;
+          progress.value = ackedChunks / totalChunks;
+          if (ackedChunks == totalChunks && !allChunksAcked.isCompleted) {
+            allChunksAcked.complete();
+          }
+        } catch (e, stack) {
+          if (!transferFailed.isCompleted) {
+            transferFailed.completeError(e, stack);
+          }
+        } finally {
+          inFlight--;
+          kickRefill();
+        }
       }
+
+      // Keeps at most chunkWindowSize chunks in flight; refills the window as
+      // acks drain it. All indices must be acked (not just an in-order
+      // prefix) before the transfer is allowed to finish.
+      Future<void> pumpWindow() async {
+        while (nextIndex < totalChunks &&
+            !transferFailed.isCompleted &&
+            !allChunksAcked.isCompleted) {
+          while (nextIndex < totalChunks &&
+              inFlight < FileTransferPolicy.chunkWindowSize) {
+            final index = nextIndex++;
+            inFlight++;
+            unawaited(sendChunkWithRetries(index));
+          }
+          if (nextIndex >= totalChunks) break;
+          refill = Completer<void>();
+          await refill!.future;
+        }
+      }
+
+      unawaited(pumpWindow());
+      await Future.any([allChunksAcked.future, transferFailed.future]);
+      if (transferFailed.isCompleted) return false;
 
       final endResult = await _manager.request(
         peerOnion,

--- a/lib/services/file_transfer_sender.dart
+++ b/lib/services/file_transfer_sender.dart
@@ -214,7 +214,17 @@ class FileTransferSender {
               payload: chunkBytes,
             );
 
-            await _manager.sendBytes(peerOnion, frame.encode());
+            // The completer must be registered before sendBytes so an ack
+            // racing ahead of the send future can still complete it; if the
+            // send itself fails no ack will ever arrive, so drop the entry
+            // here rather than leave it for send()'s finally to completeError
+            // on a future nobody listens to (an uncaught async error).
+            try {
+              await _manager.sendBytes(peerOnion, frame.encode());
+            } catch (_) {
+              pendingChunkAcks.remove(ackKey);
+              rethrow;
+            }
             Logging.debug(
               'chunk ${index + 1}/$totalChunks sent bytes=${chunkBytes.length} '
               'transfer=$transferId',

--- a/lib/util/file_transfer_policy.dart
+++ b/lib/util/file_transfer_policy.dart
@@ -24,6 +24,9 @@ class FileTransferPolicy {
   /// Per-chunk send retries before failing the transfer.
   static const int maxChunkRetries = 3;
 
+  /// Chunks in flight at once: 8 × 256 KiB buffered in the WS sink while acks travel, cutting measured stall waves from 33 to ceil(33/8).
+  static const int chunkWindowSize = 8;
+
   static bool shouldUseChunkedTransfer({
     required int fileSizeBytes,
     required bool wsConnected,

--- a/test/file_transfer_sender_test.dart
+++ b/test/file_transfer_sender_test.dart
@@ -21,8 +21,10 @@ import 'package:prysm/util/tor_lifecycle_state.dart';
 import 'package:prysm/util/tor_runtime_gate.dart';
 import 'package:prysm/util/tor_service.dart';
 
-class _ChunkAckLink implements WsPeerLink {
-  _ChunkAckLink(this.peerOnion);
+/// Records every frame the sender pushes; only the chunk-ack policy differs
+/// between [_ChunkAckLink] (immediate) and [_GatedAckLink] (queued).
+abstract class _AckLinkBase implements WsPeerLink {
+  _AckLinkBase(this.peerOnion);
 
   @override
   final String peerOnion;
@@ -74,6 +76,16 @@ class _ChunkAckLink implements WsPeerLink {
     sentOps.add(op);
     sentPayloads.add(payload);
   }
+
+  @override
+  Future<void> sendBytes(List<int> bytes);
+
+  @override
+  Future<void> sendPing() async {}
+}
+
+class _ChunkAckLink extends _AckLinkBase {
+  _ChunkAckLink(super.peerOnion);
 
   @override
   Future<void> sendBytes(List<int> bytes) async {
@@ -87,72 +99,19 @@ class _ChunkAckLink implements WsPeerLink {
       },
     });
   }
-
-  @override
-  Future<void> sendPing() async {}
 }
 
 /// A link that records every chunk frame but does NOT ack it until the test
 /// releases the ack, so a windowed sender can be observed mid-flight (unlike
 /// [_ChunkAckLink], whose synchronous acks hide any pipelining).
-class _GatedAckLink implements WsPeerLink {
-  _GatedAckLink(this.peerOnion, {this.throwOnSendIndex});
-
-  @override
-  final String peerOnion;
+class _GatedAckLink extends _AckLinkBase {
+  _GatedAckLink(super.peerOnion, {this.throwOnSendIndex});
 
   /// When set, [sendBytes] throws for the matching chunk index instead of
   /// delivering the frame, simulating a failed write mid-transfer.
   final int? throwOnSendIndex;
 
-  final pushController = StreamController<Map<String, dynamic>>.broadcast();
-  final sentBinary = <List<int>>[];
-  final sentOps = <String>[];
-  final sentPayloads = <Map<String, dynamic>?>[];
   final pendingAcks = <Map<String, dynamic>>[];
-
-  @override
-  bool isConnected = true;
-
-  @override
-  Stream<List<int>> get onBinaryFrames => const Stream.empty();
-
-  @override
-  Stream<Map<String, dynamic>> get onPushFrames => pushController.stream;
-
-  @override
-  Future<void> close() async {
-    isConnected = false;
-  }
-
-  @override
-  Future<Map<String, dynamic>> request(
-    String op, {
-    Map<String, dynamic>? payload,
-    Duration timeout = const Duration(seconds: 30),
-  }) async {
-    sentOps.add(op);
-    sentPayloads.add(payload);
-    if (op == 'file_transfer_begin' && payload != null) {
-      return {
-        'ok': true,
-        'transferId': payload['transferId'],
-      };
-    }
-    if (op == 'file_transfer_end' && payload != null) {
-      return {
-        'ok': true,
-        'transferId': payload['transferId'],
-      };
-    }
-    return {'ok': true};
-  }
-
-  @override
-  Future<void> send(String op, {Map<String, dynamic>? payload}) async {
-    sentOps.add(op);
-    sentPayloads.add(payload);
-  }
 
   @override
   Future<void> sendBytes(List<int> bytes) async {
@@ -197,9 +156,6 @@ class _GatedAckLink implements WsPeerLink {
       }
     }
   }
-
-  @override
-  Future<void> sendPing() async {}
 }
 
 Future<IdentityPublicKeys> _publicKeys(IdentityKeyPair id) async {

--- a/test/file_transfer_sender_test.dart
+++ b/test/file_transfer_sender_test.dart
@@ -96,10 +96,14 @@ class _ChunkAckLink implements WsPeerLink {
 /// releases the ack, so a windowed sender can be observed mid-flight (unlike
 /// [_ChunkAckLink], whose synchronous acks hide any pipelining).
 class _GatedAckLink implements WsPeerLink {
-  _GatedAckLink(this.peerOnion);
+  _GatedAckLink(this.peerOnion, {this.throwOnSendIndex});
 
   @override
   final String peerOnion;
+
+  /// When set, [sendBytes] throws for the matching chunk index instead of
+  /// delivering the frame, simulating a failed write mid-transfer.
+  final int? throwOnSendIndex;
 
   final pushController = StreamController<Map<String, dynamic>>.broadcast();
   final sentBinary = <List<int>>[];
@@ -152,8 +156,11 @@ class _GatedAckLink implements WsPeerLink {
 
   @override
   Future<void> sendBytes(List<int> bytes) async {
-    sentBinary.add(bytes);
     final frame = FileTransferChunkFrame.decode(bytes);
+    if (frame.chunkIndex == throwOnSendIndex) {
+      throw StateError('simulated send failure for chunk ${frame.chunkIndex}');
+    }
+    sentBinary.add(bytes);
     pendingAcks.add({
       'transferId': frame.transferId,
       'chunkIndex': frame.chunkIndex,
@@ -270,6 +277,7 @@ String _envelopePayload(Uint8List ciphertext) {
   Uint8List ciphertext, {
   required String messageId,
   Duration ackTimeout = const Duration(seconds: 60),
+  int? throwOnSendIndex,
 }) {
   final manager = WsConnectionManager(
     TorManager(
@@ -278,7 +286,7 @@ String _envelopePayload(Uint8List ciphertext) {
       controlPassword: 'test-password',
     ),
   );
-  final link = _GatedAckLink('peer.onion');
+  final link = _GatedAckLink('peer.onion', throwOnSendIndex: throwOnSendIndex);
   manager.registerLinkForTest('peer.onion', link);
   final sender = FileTransferSender(manager, ackTimeout: ackTimeout);
   final send = sender.send(
@@ -751,7 +759,14 @@ void main() {
       [3],
     );
 
-    // Releasing the withheld ack completes the transfer.
+    // Releasing the withheld ack completes the transfer. The sender drops
+    // the ack key on every timeout and re-registers it on the next attempt,
+    // and releaseAckFor silently no-ops when nothing is queued, so wait for
+    // a queued ack first instead of racing the retry (a release landing in
+    // the gap would be dropped and index 3 would exhaust maxChunkRetries).
+    await _waitFor(
+      () => started.link.pendingAcks.any((a) => a['chunkIndex'] == 3),
+    );
     started.link.releaseAckFor(3);
     await _waitFor(() => ok);
     expect(started.link.sentOps, contains('file_transfer_end'));
@@ -818,14 +833,58 @@ void main() {
           FileTransferPolicy.chunkWindowSize,
     );
 
-    // Never ack anything: each index is sent maxChunkRetries times, then the
-    // whole transfer fails and the send returns false.
+    // Never ack anything: each index is retried until it exhausts
+    // maxChunkRetries, then the whole transfer fails and send returns false.
     await _waitFor(() => ok == false, timeout: const Duration(seconds: 10));
+    // A bound, not an exact count: the first index to exhaust its retries
+    // completes transferFailed and send returns, so a slower chunk may never
+    // send its third attempt, and a chunk sitting between attempts at that
+    // moment can send one extra; with a 30 ms ackTimeout both are likely
+    // under load. The upper bound (each index is sent at most
+    // maxChunkRetries times) rules out retrying past the policy cap; the
+    // lower bound (every index's first frame plus the exhausting index's
+    // remaining attempts) rules out failing before one index has run
+    // through all of its retries.
     expect(
       started.link.sentBinary.length,
-      FileTransferPolicy.chunkWindowSize * FileTransferPolicy.maxChunkRetries,
+      inInclusiveRange(
+        FileTransferPolicy.chunkWindowSize +
+            FileTransferPolicy.maxChunkRetries -
+            1,
+        FileTransferPolicy.chunkWindowSize * FileTransferPolicy.maxChunkRetries,
+      ),
     );
     expect(started.link.sentOps, isNot(contains('file_transfer_end')));
+
+    started.manager.dispose();
+  });
+
+  test('a sendBytes failure fails the transfer with no unhandled async error',
+      () async {
+    FileTransferProgress.resetForTest();
+    final ciphertext = Uint8List.fromList(List<int>.generate(
+      FileTransferPolicy.chunkWindowSize * FileTransferPolicy.chunkSizeBytes,
+      (i) => i % 251,
+    ));
+
+    // Chunk 3's write fails on the wire. The ack completer for a chunk is
+    // registered before sendBytes so an ack racing ahead of the send future
+    // can still complete it; a throw used to leave that entry in the map for
+    // send()'s finally to completeError on a future nobody listens to, which
+    // the test zone reports as an uncaught async error. The transfer must
+    // still fail (send returns false) without that leak.
+    final started = _startGatedSend(
+      ciphertext,
+      messageId: 'msg-send-fails',
+      throwOnSendIndex: 3,
+    );
+
+    expect(await started.send, isFalse);
+    expect(started.link.sentOps, isNot(contains('file_transfer_end')));
+
+    // Let any late uncaught-async-error report land inside this test's zone
+    // so the leak fails the test instead of leaking past it.
+    await Future<void>.delayed(const Duration(milliseconds: 20));
 
     started.manager.dispose();
   });

--- a/test/file_transfer_sender_test.dart
+++ b/test/file_transfer_sender_test.dart
@@ -92,6 +92,109 @@ class _ChunkAckLink implements WsPeerLink {
   Future<void> sendPing() async {}
 }
 
+/// A link that records every chunk frame but does NOT ack it until the test
+/// releases the ack, so a windowed sender can be observed mid-flight (unlike
+/// [_ChunkAckLink], whose synchronous acks hide any pipelining).
+class _GatedAckLink implements WsPeerLink {
+  _GatedAckLink(this.peerOnion);
+
+  @override
+  final String peerOnion;
+
+  final pushController = StreamController<Map<String, dynamic>>.broadcast();
+  final sentBinary = <List<int>>[];
+  final sentOps = <String>[];
+  final sentPayloads = <Map<String, dynamic>?>[];
+  final pendingAcks = <Map<String, dynamic>>[];
+
+  @override
+  bool isConnected = true;
+
+  @override
+  Stream<List<int>> get onBinaryFrames => const Stream.empty();
+
+  @override
+  Stream<Map<String, dynamic>> get onPushFrames => pushController.stream;
+
+  @override
+  Future<void> close() async {
+    isConnected = false;
+  }
+
+  @override
+  Future<Map<String, dynamic>> request(
+    String op, {
+    Map<String, dynamic>? payload,
+    Duration timeout = const Duration(seconds: 30),
+  }) async {
+    sentOps.add(op);
+    sentPayloads.add(payload);
+    if (op == 'file_transfer_begin' && payload != null) {
+      return {
+        'ok': true,
+        'transferId': payload['transferId'],
+      };
+    }
+    if (op == 'file_transfer_end' && payload != null) {
+      return {
+        'ok': true,
+        'transferId': payload['transferId'],
+      };
+    }
+    return {'ok': true};
+  }
+
+  @override
+  Future<void> send(String op, {Map<String, dynamic>? payload}) async {
+    sentOps.add(op);
+    sentPayloads.add(payload);
+  }
+
+  @override
+  Future<void> sendBytes(List<int> bytes) async {
+    sentBinary.add(bytes);
+    final frame = FileTransferChunkFrame.decode(bytes);
+    pendingAcks.add({
+      'transferId': frame.transferId,
+      'chunkIndex': frame.chunkIndex,
+    });
+  }
+
+  List<int> sentChunkIndices() =>
+      sentBinary.map((b) => FileTransferChunkFrame.decode(b).chunkIndex).toList();
+
+  /// Pushes the first [count] queued acks (all of them when [count] is null).
+  void releaseAcks([int? count]) {
+    final acks = count == null
+        ? List<Map<String, dynamic>>.from(pendingAcks)
+        : pendingAcks.take(count).toList();
+    for (final ack in acks) {
+      pendingAcks.remove(ack);
+      pushController.add({
+        'op': 'file_transfer_chunk_ack',
+        'payload': ack,
+      });
+    }
+  }
+
+  /// Pushes the first queued ack for [chunkIndex], if any.
+  void releaseAckFor(int chunkIndex) {
+    for (final ack in pendingAcks.toList()) {
+      if (ack['chunkIndex'] == chunkIndex) {
+        pendingAcks.remove(ack);
+        pushController.add({
+          'op': 'file_transfer_chunk_ack',
+          'payload': ack,
+        });
+        return;
+      }
+    }
+  }
+
+  @override
+  Future<void> sendPing() async {}
+}
+
 Future<IdentityPublicKeys> _publicKeys(IdentityKeyPair id) async {
   final sign = await id.signPublicKey;
   final agree = await id.agreePublicKey;
@@ -148,6 +251,61 @@ Map<String, dynamic> _beginPayload({
     'totalChunks': FileTransferPolicy.chunkCountForSize(ciphertext.length),
     'chunkSize': FileTransferPolicy.chunkSizeBytes,
   };
+}
+
+String _envelopePayload(Uint8List ciphertext) {
+  final envelope = CryptoEnvelope.fileAead1(
+    wrappedKey: {'ephemeralPub': 'abc'},
+    nonce: Uint8List(12),
+    ciphertext: ciphertext,
+  );
+  return CryptoEnvelope.encode(envelope);
+}
+
+/// Starts a chunked send against a gated link whose acks the test releases
+/// manually, so a windowed driver can be observed mid-flight. [ackTimeout]
+/// shortens the per-chunk ack wait so retry/abort paths can be driven fast.
+({WsConnectionManager manager, _GatedAckLink link, Future<bool> send})
+    _startGatedSend(
+  Uint8List ciphertext, {
+  required String messageId,
+  Duration ackTimeout = const Duration(seconds: 60),
+}) {
+  final manager = WsConnectionManager(
+    TorManager(
+      torPath: '/bin/false',
+      dataDir: '/tmp/file-transfer-sender',
+      controlPassword: 'test-password',
+    ),
+  );
+  final link = _GatedAckLink('peer.onion');
+  manager.registerLinkForTest('peer.onion', link);
+  final sender = FileTransferSender(manager, ackTimeout: ackTimeout);
+  final send = sender.send(
+    peerOnion: 'peer.onion',
+    messageId: messageId,
+    senderId: 'me.onion',
+    receiverId: 'peer.onion',
+    type: 'file',
+    fileName: 'window.bin',
+    fileSize: ciphertext.length,
+    peerPayload: _envelopePayload(ciphertext),
+  );
+  return (manager: manager, link: link, send: send);
+}
+
+/// Polls [predicate] until it returns true or [timeout] elapses.
+Future<void> _waitFor(
+  bool Function() predicate, {
+  Duration timeout = const Duration(seconds: 30),
+}) async {
+  final end = DateTime.now().add(timeout);
+  while (!predicate()) {
+    if (DateTime.now().isAfter(end)) {
+      fail('Timed out waiting for condition');
+    }
+    await Future<void>.delayed(const Duration(milliseconds: 10));
+  }
 }
 
 Future<void> _deliverChunks(
@@ -458,5 +616,217 @@ void main() {
     final envelope = CryptoEnvelope.tryParse(wire);
     expect(envelope, isNotNull);
     expect(envelope!['scheme'], CryptoConstants.schemeFileAead1);
+  });
+
+  test('pipelines chunkWindowSize frames before any ack is released', () async {
+    FileTransferProgress.resetForTest();
+    final ciphertext = Uint8List.fromList(List<int>.generate(
+      (FileTransferPolicy.chunkWindowSize + 2) *
+          FileTransferPolicy.chunkSizeBytes,
+      (i) => i % 251,
+    ));
+    final totalChunks = FileTransferPolicy.chunkCountForSize(ciphertext.length);
+    expect(totalChunks, FileTransferPolicy.chunkWindowSize + 2);
+
+    final started = _startGatedSend(ciphertext, messageId: 'msg-window-1');
+    var ok = false;
+    started.send.then((v) => ok = v);
+
+    // The whole window is on the wire with no ack released.
+    await _waitFor(
+      () =>
+          started.link.sentBinary.length ==
+          FileTransferPolicy.chunkWindowSize,
+    );
+    expect(
+      started.link.pendingAcks.length,
+      FileTransferPolicy.chunkWindowSize,
+    );
+
+    // Releasing acks one at a time never leaves more than the window in
+    // flight: every release lets exactly one refill chunk out.
+    var released = 0;
+    var maxInFlight = started.link.sentBinary.length;
+    for (var i = 0; i < totalChunks; i++) {
+      started.link.releaseAcks(1);
+      released++;
+      final expectedSent =
+          totalChunks < FileTransferPolicy.chunkWindowSize + released
+              ? totalChunks
+              : FileTransferPolicy.chunkWindowSize + released;
+      await _waitFor(() => started.link.sentBinary.length >= expectedSent);
+      final inFlight = started.link.sentBinary.length - released;
+      if (inFlight > maxInFlight) maxInFlight = inFlight;
+    }
+    await _waitFor(() => ok);
+    expect(started.link.sentBinary.length, totalChunks);
+    expect(
+      maxInFlight,
+      lessThanOrEqualTo(FileTransferPolicy.chunkWindowSize),
+    );
+
+    started.manager.dispose();
+  });
+
+  test('releasing one ack lets exactly one more chunk go out', () async {
+    FileTransferProgress.resetForTest();
+    final ciphertext = Uint8List.fromList(List<int>.generate(
+      (FileTransferPolicy.chunkWindowSize + 2) *
+          FileTransferPolicy.chunkSizeBytes,
+      (i) => i % 251,
+    ));
+
+    final started = _startGatedSend(ciphertext, messageId: 'msg-window-2');
+    var ok = false;
+    started.send.then((v) => ok = v);
+
+    await _waitFor(
+      () =>
+          started.link.sentBinary.length ==
+          FileTransferPolicy.chunkWindowSize,
+    );
+
+    started.link.releaseAcks(1);
+    await _waitFor(
+      () =>
+          started.link.sentBinary.length ==
+          FileTransferPolicy.chunkWindowSize + 1,
+    );
+
+    started.link.releaseAcks(1);
+    await _waitFor(
+      () =>
+          started.link.sentBinary.length ==
+          FileTransferPolicy.chunkWindowSize + 2,
+    );
+
+    started.link.releaseAcks();
+    await _waitFor(() => ok);
+    expect(
+      started.link.sentBinary.length,
+      FileTransferPolicy.chunkCountForSize(ciphertext.length),
+    );
+
+    started.manager.dispose();
+  });
+
+  test('withheld ack makes the sender re-send only that index', () async {
+    FileTransferProgress.resetForTest();
+    final ciphertext = Uint8List.fromList(List<int>.generate(
+      FileTransferPolicy.chunkWindowSize * FileTransferPolicy.chunkSizeBytes,
+      (i) => i % 251,
+    ));
+
+    final started = _startGatedSend(
+      ciphertext,
+      messageId: 'msg-window-3',
+      ackTimeout: const Duration(milliseconds: 500),
+    );
+    var ok = false;
+    started.send.then((v) => ok = v);
+
+    await _waitFor(
+      () =>
+          started.link.sentBinary.length ==
+          FileTransferPolicy.chunkWindowSize,
+    );
+
+    // Ack every index except 3.
+    for (var i = 0; i < FileTransferPolicy.chunkWindowSize; i++) {
+      if (i != 3) started.link.releaseAckFor(i);
+    }
+    await _waitFor(() => started.link.pendingAcks.length == 1);
+
+    // After the ack timeout only index 3 is re-sent, not the whole window.
+    await _waitFor(
+      () =>
+          started.link.sentBinary.length ==
+          FileTransferPolicy.chunkWindowSize + 1,
+      timeout: const Duration(seconds: 5),
+    );
+    final indices = started.link.sentChunkIndices();
+    expect(indices.length, FileTransferPolicy.chunkWindowSize + 1);
+    expect(
+      indices.sublist(FileTransferPolicy.chunkWindowSize),
+      [3],
+    );
+
+    // Releasing the withheld ack completes the transfer.
+    started.link.releaseAckFor(3);
+    await _waitFor(() => ok);
+    expect(started.link.sentOps, contains('file_transfer_end'));
+
+    started.manager.dispose();
+  });
+
+  test('file_transfer_end waits for every index to be acked', () async {
+    FileTransferProgress.resetForTest();
+    final ciphertext = Uint8List.fromList(List<int>.generate(
+      FileTransferPolicy.chunkWindowSize * FileTransferPolicy.chunkSizeBytes,
+      (i) => i % 251,
+    ));
+
+    final started = _startGatedSend(ciphertext, messageId: 'msg-window-4');
+    var ok = false;
+    started.send.then((v) => ok = v);
+
+    await _waitFor(
+      () =>
+          started.link.sentBinary.length ==
+          FileTransferPolicy.chunkWindowSize,
+    );
+
+    // A full in-order prefix (indices 0..6) is acked while index 7 is not:
+    // the sender must not request the end frame yet. Wait until the sender
+    // has actually processed those acks (progress reaches 7/8) before
+    // asserting, so a buggy "end after in-order prefix" would be caught.
+    started.link.releaseAcks(FileTransferPolicy.chunkWindowSize - 1);
+    await _waitFor(
+      () =>
+          (FileTransferProgress.uploadFor('msg-window-4')?.value ?? 0) ==
+          (FileTransferPolicy.chunkWindowSize - 1) /
+              FileTransferPolicy.chunkWindowSize,
+    );
+    expect(started.link.sentOps, isNot(contains('file_transfer_end')));
+
+    // The final ack lets the end frame through.
+    started.link.releaseAcks(1);
+    await _waitFor(() => ok);
+    expect(started.link.sentOps, contains('file_transfer_end'));
+
+    started.manager.dispose();
+  });
+
+  test('an unacked index fails the transfer after maxChunkRetries', () async {
+    FileTransferProgress.resetForTest();
+    final ciphertext = Uint8List.fromList(List<int>.generate(
+      FileTransferPolicy.chunkWindowSize * FileTransferPolicy.chunkSizeBytes,
+      (i) => i % 251,
+    ));
+
+    final started = _startGatedSend(
+      ciphertext,
+      messageId: 'msg-window-5',
+      ackTimeout: const Duration(milliseconds: 30),
+    );
+    var ok = true;
+    started.send.then((v) => ok = v);
+
+    await _waitFor(
+      () =>
+          started.link.sentBinary.length ==
+          FileTransferPolicy.chunkWindowSize,
+    );
+
+    // Never ack anything: each index is sent maxChunkRetries times, then the
+    // whole transfer fails and the send returns false.
+    await _waitFor(() => ok == false, timeout: const Duration(seconds: 10));
+    expect(
+      started.link.sentBinary.length,
+      FileTransferPolicy.chunkWindowSize * FileTransferPolicy.maxChunkRetries,
+    );
+    expect(started.link.sentOps, isNot(contains('file_transfer_end')));
+
+    started.manager.dispose();
   });
 }


### PR DESCRIPTION
#150 made chunked transfers work again after eight days dead. Measuring the result showed the path was **slower than not using it**: 2 MiB took 23.0 s against 13.4 s monolithic, 8 MiB 112.0 s against 45.9 s. The sender awaited an ack after every 256 KiB, so 8 MiB was 33 sequential Tor round trips — measured inter-chunk gaps 1.7-2.7 s. The bytes were never the problem.

## The change

Eight chunks in flight instead of one. What is remarkable is how little had to move, because the pieces were already there:

- the ack frame already carries the chunk index (`file_transfer_chunk_ack` payload `{transferId, chunkIndex}`) and `pendingChunkAcks` was **already** keyed `transferId:index` — only the control flow serialised;
- the receiver already writes by index into a preallocated buffer, acks duplicates, and decides completeness by counting **distinct** indices, so out-of-order arrival needed no change at all;
- chunk acks mean "written to the in-memory buffer", not "persisted" — the single DB write stays in `handleEnd` — so a window does not change the disk pattern.

Per-index retries keep the old semantics: an ack timeout re-sends that index alone while the rest of the window keeps flying, and exhausting `maxChunkRetries` still fails the whole transfer with the same log line. `file_transfer_end` waits for **every** index rather than an in-order prefix, because `handleEnd` validates by count and would answer `Incomplete transfer`.

`send`'s `timeout` parameter also goes: it was passed from `ChatService._trySendChunkedFile` and never read in the body. The per-chunk 60 s × 3 retries plus the abort path are the real bound. Inventing a whole-transfer deadline to replace a dead one is a product decision, not a refactor — flagging it rather than deciding it.

## Measured, two containers, real Tor, same rig

| payload | sequential (#150) | windowed (this PR) |
|---|---|---|
| 2 MiB | 23.0 s · 729 kbps | **14.3 s · 1173 kbps** |
| 8 MiB | 112.0 s · 599 kbps | **41.2 s / 44.1 s · 1630 / 1523 kbps** |

41 s also beats the 45.9 s monolithic best for the same file, because chunks carry raw ciphertext where the monolithic envelope carries base64 (+33% on the wire). The window turns the slowest path into the fastest one.

**Why eight and not sixteen.** W=16 measured 79.5 s against 87.3 s for W=8 on a slow circuit — a 9% difference, while Tor circuit variance across today's runs was 1.7-9× (the same 8 MiB monolithic send took 45.9 s on one circuit and 416 s on another; 200 KiB took 3.4 s and 150 s). That difference is not distinguishable from noise, so the smaller window wins: it collapses the stall waves from 33 to 5 and buffers 2 MiB of unacked frames instead of 4. `WebSocket.add` gives no backpressure, so the window size *is* the sender's buffer bound.

## Tests

The existing suite could not see this change: its fake link acks **synchronously inside `sendBytes`**, so sequential and windowed behave identically under it. Five new tests use a gated link that records frames and acks only when released:

- eight frames on the wire before any ack is released, never more in flight;
- releasing one ack lets exactly one more chunk out;
- withholding one middle ack re-sends only that index and the transfer still completes;
- `file_transfer_end` is not requested until every index is acked;
- an index that is never acked fails the send after `maxChunkRetries`.

Each was checked mordant: reverting to the sequential driver fails the first, second and fourth; making a retry re-send the whole window fails the third; removing the all-acks-before-end wait fails the fourth.

`flutter analyze` 0, full suite **1094 + 1 skip** green on this branch in isolation.

## Two findings from the measurement, not fixed here

1. **The first attachment after a (re)connect always takes the monolithic path**, because `shouldUseChunkedTransfer` requires an already-established WS link. On a cold circuit that is the worst possible choice: measured 150 s for a 200 KiB file and 416 s for 8 MiB, immediately after a restart. Warming the link (or letting the chunked path bring it up, as `prepareForFileTransfer` already can) would matter more than any window tuning.
2. That 416 s monolithic send **exceeded the 5-minute cap** `ChatService` puts on `postDirect` and still arrived, which means it went through the pending-queue retry path. Worth a look on its own: the cap does not abort the delivery, it just re-runs it later.

One test seam was added: `FileTransferSender.ackTimeout`, a constructor field defaulting to the existing 60 s, because the retry and abort tests cannot use `fake_async` — it is only a transitive dependency of `flutter_test` (importing it would fail `depend_on_referenced_packages`, and adding it to the pubspec would break the no-new-dependencies rule), and the sender's `finally` awaits `controlSub.cancel()`, whose continuation is scheduled on the real microtask queue and never resumes under fake time.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * File transfers now send multiple chunks concurrently for improved throughput.
  * Transfers continue progressing as chunks are acknowledged, with bounded buffering for consistent performance.
  * Individual unacknowledged chunks are retried without restarting the entire transfer.
* **Reliability**
  * Transfers wait for all chunks to be confirmed before completing.
  * Failed transfers are reported clearly after retry limits are reached.
  * Send failures no longer leave transfers retrying after cancellation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->