### PR TITLE
fix(ui): size the PIN keypad to the screen and stop onChanged firing twice

### DIFF
--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -12,15 +12,10 @@ concurrency:
   group: build-pr-${{ github.event.issue.number }}
   cancel-in-progress: true
 
+# Pinned, not tracked: an unpinned `stable` moved 3.44.9 -> 3.47.0 under an
+# unchanged main and broke it. Matches both Containerfiles. Bump deliberately.
 env:
   PR_NUMBER: ${{ github.event.issue.number }}
-
-# The toolchain is pinned, not tracked. `channel: stable` alone put CI on
-# whatever Flutter shipped that week: 3.44.9 was green on d18d384 and 3.47.0
-# failed the identical commit hours later, on a new lint plus a dart:io
-# signature change. Both Containerfiles already pin 3.44.8 (host toolchain);
-# this is the environment that was drifting away from them. Bump deliberately.
-env:
   FLUTTER_VERSION: "3.44.8"
 
 jobs:

--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -15,6 +15,14 @@ concurrency:
 env:
   PR_NUMBER: ${{ github.event.issue.number }}
 
+# The toolchain is pinned, not tracked. `channel: stable` alone put CI on
+# whatever Flutter shipped that week: 3.44.9 was green on d18d384 and 3.47.0
+# failed the identical commit hours later, on a new lint plus a dart:io
+# signature change. Both Containerfiles already pin 3.44.8 (host toolchain);
+# this is the environment that was drifting away from them. Bump deliberately.
+env:
+  FLUTTER_VERSION: "3.44.8"
+
 jobs:
   authorize:
     if: ${{ github.event.issue.pull_request && github.event.comment.body == 'build:test' }}
@@ -77,6 +85,7 @@ jobs:
 
       - uses: subosito/flutter-action@v2
         with:
+          flutter-version: ${{ env.FLUTTER_VERSION }}
           channel: stable
           cache: true
 
@@ -112,6 +121,7 @@ jobs:
 
       - uses: subosito/flutter-action@v2
         with:
+          flutter-version: ${{ env.FLUTTER_VERSION }}
           channel: stable
           cache: true
 
@@ -156,6 +166,7 @@ jobs:
 
       - uses: subosito/flutter-action@v2
         with:
+          flutter-version: ${{ env.FLUTTER_VERSION }}
           channel: stable
           cache: true
 
@@ -198,6 +209,7 @@ jobs:
 
       - uses: subosito/flutter-action@v2
         with:
+          flutter-version: ${{ env.FLUTTER_VERSION }}
           channel: stable
           cache: true
 
@@ -242,6 +254,7 @@ jobs:
 
       - uses: subosito/flutter-action@v2
         with:
+          flutter-version: ${{ env.FLUTTER_VERSION }}
           channel: stable
           cache: true
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,11 +5,8 @@ on:
     tags:
       - 'v*'
     
-# The toolchain is pinned, not tracked. `channel: stable` alone put CI on
-# whatever Flutter shipped that week: 3.44.9 was green on d18d384 and 3.47.0
-# failed the identical commit hours later, on a new lint plus a dart:io
-# signature change. Both Containerfiles already pin 3.44.8 (host toolchain);
-# this is the environment that was drifting away from them. Bump deliberately.
+# Pinned, not tracked: an unpinned `stable` moved 3.44.9 -> 3.47.0 under an
+# unchanged main and broke it. Matches both Containerfiles. Bump deliberately.
 env:
   FLUTTER_VERSION: "3.44.8"
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,6 +5,14 @@ on:
     tags:
       - 'v*'
     
+# The toolchain is pinned, not tracked. `channel: stable` alone put CI on
+# whatever Flutter shipped that week: 3.44.9 was green on d18d384 and 3.47.0
+# failed the identical commit hours later, on a new lint plus a dart:io
+# signature change. Both Containerfiles already pin 3.44.8 (host toolchain);
+# this is the environment that was drifting away from them. Bump deliberately.
+env:
+  FLUTTER_VERSION: "3.44.8"
+
 jobs:
 
   # ----------------------------
@@ -18,6 +26,7 @@ jobs:
 
       - uses: subosito/flutter-action@v2
         with:
+          flutter-version: ${{ env.FLUTTER_VERSION }}
           channel: stable
           cache: true
 
@@ -44,6 +53,7 @@ jobs:
 
       - uses: subosito/flutter-action@v2
         with:
+          flutter-version: ${{ env.FLUTTER_VERSION }}
           channel: stable
           cache: true
 
@@ -84,6 +94,7 @@ jobs:
 
       - uses: subosito/flutter-action@v2
         with:
+          flutter-version: ${{ env.FLUTTER_VERSION }}
           channel: stable
           cache: true
 
@@ -123,6 +134,7 @@ jobs:
 
       - uses: subosito/flutter-action@v2
         with:
+          flutter-version: ${{ env.FLUTTER_VERSION }}
           channel: stable
           cache: true
 
@@ -163,6 +175,7 @@ jobs:
 
       - uses: subosito/flutter-action@v2
         with:
+          flutter-version: ${{ env.FLUTTER_VERSION }}
           channel: stable
           cache: true
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,14 @@ on:
     branches: [main, master]
   pull_request:
 
+# The toolchain is pinned, not tracked. `channel: stable` alone put CI on
+# whatever Flutter shipped that week: 3.44.9 was green on d18d384 and 3.47.0
+# failed the identical commit hours later, on a new lint plus a dart:io
+# signature change. Both Containerfiles already pin 3.44.8 (host toolchain);
+# this is the environment that was drifting away from them. Bump deliberately.
+env:
+  FLUTTER_VERSION: "3.44.8"
+
 jobs:
   analyze-and-test:
     runs-on: ubuntu-latest
@@ -13,6 +21,7 @@ jobs:
 
       - uses: subosito/flutter-action@v2
         with:
+          flutter-version: ${{ env.FLUTTER_VERSION }}
           channel: stable
 
       - name: Install Linux dependencies

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,11 +5,8 @@ on:
     branches: [main, master]
   pull_request:
 
-# The toolchain is pinned, not tracked. `channel: stable` alone put CI on
-# whatever Flutter shipped that week: 3.44.9 was green on d18d384 and 3.47.0
-# failed the identical commit hours later, on a new lint plus a dart:io
-# signature change. Both Containerfiles already pin 3.44.8 (host toolchain);
-# this is the environment that was drifting away from them. Bump deliberately.
+# Pinned, not tracked: an unpinned `stable` moved 3.44.9 -> 3.47.0 under an
+# unchanged main and broke it. Matches both Containerfiles. Bump deliberately.
 env:
   FLUTTER_VERSION: "3.44.8"
 

--- a/lib/screens/widgets/pin_keypad.dart
+++ b/lib/screens/widgets/pin_keypad.dart
@@ -351,6 +351,15 @@ class PinKeypad extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    // LayoutBuilder sees only the incoming constraint, which inside the
+    // onboarding step's SingleChildScrollView is unbounded on the main axis;
+    // MediaQuery carries the real screen height in every host instead, so
+    // derive the key from it: 80dp (gap 10) fits a 1152dp screen, below that
+    // shrink to the 52dp floor so short phones still see the whole keypad.
+    final keySize = (MediaQuery.sizeOf(context).height * 80 / 1152)
+        .clamp(52.0, 80.0)
+        .toDouble();
+    final gap = keySize / 8;
     const keys = [
       ['1', '2', '3'],
       ['4', '5', '6'],
@@ -362,32 +371,33 @@ class PinKeypad extends StatelessWidget {
       mainAxisSize: MainAxisSize.min,
       children: keys.map((row) {
         return Padding(
-          padding: const EdgeInsets.symmetric(vertical: 10),
+          padding: EdgeInsets.symmetric(vertical: gap),
           child: Row(
             mainAxisAlignment: MainAxisAlignment.spaceEvenly,
             children: row.map((key) {
               if (key.isEmpty) {
-                return const SizedBox(width: 80);
+                return SizedBox(width: keySize);
               } else if (key == 'back') {
                 return GestureDetector(
                   onTap: () => onKeyPress('back'),
                   behavior: HitTestBehavior.opaque,
                   child: SizedBox(
-                    width: 80,
-                    height: 80,
+                    width: keySize,
+                    height: keySize,
                     child: Icon(
                       PrysmIcons.backspaceOutlined,
-                      size: 28,
+                      size: keySize * 0.35,
                       color: context.prysmStyle.tokens.textPrimary,
                     ),
                   ),
                 );
               }
               return SizedBox(
-                width: 80,
-                height: 80,
+                width: keySize,
+                height: keySize,
                 child: _KeyButton(
                   value: key,
+                  keySize: keySize,
                   onPressed: () => onKeyPress(key),
                 ),
               );
@@ -401,9 +411,14 @@ class PinKeypad extends StatelessWidget {
 
 class _KeyButton extends StatelessWidget {
   final String value;
+  final double keySize;
   final VoidCallback onPressed;
 
-  const _KeyButton({required this.value, required this.onPressed});
+  const _KeyButton({
+    required this.value,
+    required this.keySize,
+    required this.onPressed,
+  });
 
   @override
   Widget build(BuildContext context) {
@@ -420,7 +435,9 @@ class _KeyButton extends StatelessWidget {
           value,
           style: TextStyle(
             color: context.prysmStyle.tokens.textPrimary,
-            fontSize: 32,
+            // 32dp digit on an 80dp key (0.4x), so a shrunken key is not
+            // mostly padding.
+            fontSize: keySize * 0.4,
             fontWeight: FontWeight.w400,
           ),
         ),

--- a/lib/ui/core/prysm_text_field.dart
+++ b/lib/ui/core/prysm_text_field.dart
@@ -89,7 +89,6 @@ class _PrysmTextFieldState extends State<PrysmTextField> {
 
   void _onTextChanged() {
     if (mounted) setState(() {});
-    widget.onChanged?.call(widget.controller.text);
   }
 
   void _onFocusChanged() {

--- a/test/prysm_text_selection_test.dart
+++ b/test/prysm_text_selection_test.dart
@@ -882,4 +882,94 @@ void main() {
           reason: 'the tap must not be stolen by the field caret placement');
     });
   });
+
+  // --- onChanged fires exactly once per keystroke --------------------------
+  //
+  // The reported defect: PrysmTextField listened to its controller AND
+  // forwarded onChanged into PrysmEditableText, so a single keystroke fired
+  // the callback twice. The listener half was unguarded: the controller is a
+  // ValueNotifier that also notifies on selection-only changes, so merely
+  // moving the caret called onChanged — and in the composer that sends the
+  // peer a typing indicator with zero text typed. EditableText's own
+  // forwarding is guarded by a real text change; the listener must not call
+  // onChanged at all. The listener's setState stays: build reads the
+  // controller's text for showHint, and no other rebuild path covers it.
+  group('onChanged fires exactly once per keystroke', () {
+    testWidgets('typing one character invokes onChanged exactly once',
+        (tester) async {
+      final controller = TextEditingController();
+      addTearDown(controller.dispose);
+      var calls = 0;
+
+      await pumpInPrysmApp(
+        tester,
+        PrysmTextField(
+          controller: controller,
+          onChanged: (_) => calls++,
+        ),
+      );
+
+      await tester.enterText(find.byType(EditableText), 'a');
+      await tester.pump();
+
+      expect(calls, 1,
+          reason: 'one keystroke must report exactly one text change');
+      expect(controller.text, 'a');
+    });
+
+    testWidgets('moving the caret invokes onChanged zero times',
+        (tester) async {
+      final controller = TextEditingController(text: 'abc');
+      addTearDown(controller.dispose);
+      var calls = 0;
+
+      await pumpInPrysmApp(
+        tester,
+        PrysmTextField(
+          controller: controller,
+          onChanged: (_) => calls++,
+        ),
+      );
+
+      // Establish the IME connection, then move the caret with the text
+      // untouched — both via the platform and via a direct controller write.
+      // Either used to trip the unguarded listener.
+      await tester.tap(find.byType(EditableText));
+      await tester.pump();
+      tester.testTextInput.updateEditingValue(
+        const TextEditingValue(
+          text: 'abc',
+          selection: TextSelection.collapsed(offset: 0),
+        ),
+      );
+      await tester.pump();
+      controller.selection = const TextSelection.collapsed(offset: 2);
+      await tester.pump();
+
+      expect(calls, 0,
+          reason: 'a caret move must not be reported as typing');
+    });
+
+    testWidgets('the hint disappears on the first typed character',
+        (tester) async {
+      final controller = TextEditingController();
+      addTearDown(controller.dispose);
+
+      await pumpInPrysmApp(
+        tester,
+        PrysmTextField(
+          controller: controller,
+          hintText: 'Type here',
+        ),
+      );
+
+      expect(find.text('Type here'), findsOneWidget);
+
+      await tester.enterText(find.byType(EditableText), 'a');
+      await tester.pump();
+
+      expect(find.text('Type here'), findsNothing,
+          reason: 'the retained listener setState must repaint the hint away');
+    });
+  });
 }

--- a/test/renderflex_overflow_test.dart
+++ b/test/renderflex_overflow_test.dart
@@ -32,7 +32,9 @@ import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:prysm/models/appearance_settings.dart';
 import 'package:prysm/models/reply_preview_data.dart';
+import 'package:prysm/screens/onboarding/onboarding_screen.dart';
 import 'package:prysm/screens/pin_entry.dart';
+import 'package:prysm/screens/widgets/pin_keypad.dart';
 import 'package:prysm/screens/widgets/quoted_reply_preview.dart';
 import 'package:prysm/services/unlock_lockout_service.dart';
 import 'package:prysm/theme/prysm_style_resolver.dart';
@@ -215,6 +217,114 @@ void main() {
 
       expect(tester.takeException(), isNull,
           reason: 'PIN screen column must fit on a small phone screen');
+    },
+  );
+
+  testWidgets(
+    'onboarding unlock setup step (2/7) fits 1080x2340: the 0 key is fully '
+    'visible at scroll offset 0',
+    (tester) async {
+      // 1080x2340 @3x — the device the step cut the bottom row on. The step's
+      // SingleChildScrollView swallows any overflow, so the assertion is
+      // geometry, not an exception.
+      tester.view.physicalSize = const Size(1080, 2340);
+      tester.view.devicePixelRatio = 3.0;
+      addTearDown(tester.view.reset);
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: wrapWithStyle(
+            OnboardingScreen(
+              onionAddress: 'abc',
+              torReady: true,
+              onComplete: () {},
+              isInitialSetup: true,
+            ),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('Next'));
+      await tester.pumpAndSettle();
+
+      final scrollView = find.ancestor(
+        of: find.text('0'),
+        matching: find.byType(SingleChildScrollView),
+      );
+      expect(scrollView, findsOneWidget);
+      expect(
+        tester.getRect(find.text('0')).bottom,
+        lessThanOrEqualTo(tester.getRect(scrollView).bottom),
+        reason: 'the 0 key must sit above the fold at scroll offset 0',
+      );
+      // The digit font scales down with the key so a shrunken key is not
+      // mostly padding.
+      expect(tester.widget<Text>(find.text('1')).style?.fontSize,
+          lessThan(32));
+    },
+  );
+
+  testWidgets(
+    'PinPadScreen does not overflow its non-scrollable column on a short '
+    'phone (1080x1800 @3x)',
+    (tester) async {
+      // The 1080x2340 surface never overflowed even before the fix, so it
+      // cannot catch a regression; 1080x1800 @3x is the shortest real phone
+      // class where the fixed 400dp keypad overflowed the centered column.
+      tester.view.physicalSize = const Size(1080, 1800);
+      tester.view.devicePixelRatio = 3.0;
+      addTearDown(tester.view.reset);
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: wrapWithStyle(
+            PinPadScreen(
+              title: 'Current PIN',
+              subtitle: 'Enter your current unlock PIN.',
+              validatePin: (_) async => null,
+            ),
+          ),
+        ),
+      );
+      await tester.pump();
+
+      expect(tester.takeException(), isNull,
+          reason: 'PIN pad column must fit on a short phone screen');
+    },
+  );
+
+  testWidgets(
+    'PinKeypad keeps the exact 80px keys / 10px gaps on a tall surface '
+    '(no-op where it already fit)',
+    (tester) async {
+      tester.view.physicalSize = const Size(1080, 3600);
+      tester.view.devicePixelRatio = 3.0;
+      addTearDown(tester.view.reset);
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: wrapWithStyle(
+            Center(
+              child: PinKeypad(onKeyPress: (_) {}),
+            ),
+          ),
+        ),
+      );
+      await tester.pump();
+
+      final key1 = find
+          .ancestor(of: find.text('1'), matching: find.byType(SizedBox))
+          .first;
+      final key4 = find
+          .ancestor(of: find.text('4'), matching: find.byType(SizedBox))
+          .first;
+      expect(tester.getSize(key1), const Size(80, 80));
+      expect(tester.getSize(key4), const Size(80, 80));
+      // Each row carries 10 of vertical padding above and below.
+      expect(tester.getRect(key4).top - tester.getRect(key1).bottom, 20);
+      expect(tester.getSize(find.byType(PinKeypad)), const Size(360, 400));
+      // 80dp key keeps the original 32dp digit.
+      expect(tester.widget<Text>(find.text('1')).style?.fontSize, 32);
     },
   );
 }


### PR DESCRIPTION

Two defects carried in the handoff's open list, both in widgets #145 had to leave alone. They land together because #145 is now in `main`.

## The `0` key is cut off, and no exception says so

`PinKeypad` is a hard **400 dp** block: four rows of 80 dp keys with 10 dp padding, no `LayoutBuilder`, no `AspectRatio`, nothing flexible. It cannot shrink. In onboarding step 2/7 the step viewport measures ~631 dp against ~736 dp of content, so the last row `['', '0', 'back']` falls below the fold.

The existing `renderflex_overflow_test.dart` style — `expect(tester.takeException(), isNull)` — is **blind to this**: the onboarding step scrolls, so nothing throws. The regression test asserts geometry instead, the `0` key's bottom edge against the viewport at scroll offset 0.

The key size now derives from `MediaQuery.sizeOf(context).height`, clamped to `[52, 80]`, `gap = keySize / 8`. `LayoutBuilder` will not work here: inside the step's `SingleChildScrollView` the incoming main-axis constraint is unbounded. At >= 1152 dp it reproduces 80 dp / 10 dp exactly, so the widget is byte-identical where it already fit; the 52 dp floor keeps every key above the 48 dp touch-target minimum. Fonts scale with the key.

**It also fixes a site nobody had looked at.** `PinPadScreen` (Settings -> Change passcode, Panic PIN) hosts the same keypad in a plain **non-scrollable** `Column` and throws a real `RenderFlex overflowed by 29 pixels` on a 360x600 phone. #144 fixed `pin_entry.dart` and never touched it. One file, three hosts, zero call-site churn.

One correction to the handoff: `PinPadScreen` does **not** overflow at 1080x2340 (content ~572 dp in ~724 dp available). It starts overflowing at logical heights <= ~615 dp, so that test uses 1080x1800 @3x — the shortest real phone class that fails before the fix.

## `onChanged` fires twice per keystroke, and once for a caret move

`_onTextChanged` is registered as a controller listener **and** `onChanged` is passed down to the `EditableText`. Inside `_formatAndSetValue`, `_value = value` writes `widget.controller.value`, and the controller is a `ValueNotifier` — the listener fires, then fourteen lines later the `EditableText` callback fires. Deleting the listener's call leaves `PrysmTextField` matching `PrysmSearchField`, which already only calls `setState`.

The doubling is the smaller half. The listener path is **unguarded**, where the `EditableText` path is gated on `oldValue.text != currentText`. A `TextEditingController` also notifies on **selection** changes — so moving the caret in the composer invoked `onChanged` -> `_notifyTypingFromText` and told the peer we were typing with **nothing typed**. The sharper of the two new tests pins that at zero.

The `setState` stays: `build` reads `controller.text.isEmpty` for the hint.

## Verification

`flutter analyze` 0, full suite **1095 + 1 skip** green on this branch in isolation (`main` is 1089 + 1).

Every new test checked mordant, with the production fix reverted:

| test | failure with the fix removed |
|---|---|
| `0` key above the fold | `Expected: a value less than or equal to <712.0>` / `Actual: <759.0>` |
| `PinPadScreen` no overflow | `Actual: FlutterError:<A RenderFlex overflowed by 29 pixels on the bottom.>` |
| one keystroke -> one `onChanged` | `Expected: <1>` / `Actual: <3>` |
| caret move -> zero `onChanged` | `Expected: <0>` / `Actual: <3>` |

The third test pins the no-op: 80 px keys / 10 px gaps / 400 dp / 32 pt digits on a tall surface.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * PIN keypads now adapt key sizes and spacing to available screen height.
  * Key labels and controls scale consistently across screen sizes.

* **Bug Fixes**
  * Prevented duplicate text-change notifications when only the caret moves.
  * Improved short-screen PIN layouts to keep controls visible and avoid overflow.
  * Text field hints now disappear correctly after text entry.

* **Tests**
  * Added coverage for responsive keypad dimensions, short-screen layouts, PIN visibility, and text-field change behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->