### PR TITLE
ci: pin the Flutter toolchain instead of tracking whatever stable ships

### DIFF
--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -12,15 +12,10 @@ concurrency:
   group: build-pr-${{ github.event.issue.number }}
   cancel-in-progress: true
 
+# Pinned, not tracked: an unpinned `stable` moved 3.44.9 -> 3.47.0 under an
+# unchanged main and broke it. Matches both Containerfiles. Bump deliberately.
 env:
   PR_NUMBER: ${{ github.event.issue.number }}
-
-# The toolchain is pinned, not tracked. `channel: stable` alone put CI on
-# whatever Flutter shipped that week: 3.44.9 was green on d18d384 and 3.47.0
-# failed the identical commit hours later, on a new lint plus a dart:io
-# signature change. Both Containerfiles already pin 3.44.8 (host toolchain);
-# this is the environment that was drifting away from them. Bump deliberately.
-env:
   FLUTTER_VERSION: "3.44.8"
 
 jobs:

--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -15,6 +15,14 @@ concurrency:
 env:
   PR_NUMBER: ${{ github.event.issue.number }}
 
+# The toolchain is pinned, not tracked. `channel: stable` alone put CI on
+# whatever Flutter shipped that week: 3.44.9 was green on d18d384 and 3.47.0
+# failed the identical commit hours later, on a new lint plus a dart:io
+# signature change. Both Containerfiles already pin 3.44.8 (host toolchain);
+# this is the environment that was drifting away from them. Bump deliberately.
+env:
+  FLUTTER_VERSION: "3.44.8"
+
 jobs:
   authorize:
     if: ${{ github.event.issue.pull_request && github.event.comment.body == 'build:test' }}
@@ -77,6 +85,7 @@ jobs:
 
       - uses: subosito/flutter-action@v2
         with:
+          flutter-version: ${{ env.FLUTTER_VERSION }}
           channel: stable
           cache: true
 
@@ -112,6 +121,7 @@ jobs:
 
       - uses: subosito/flutter-action@v2
         with:
+          flutter-version: ${{ env.FLUTTER_VERSION }}
           channel: stable
           cache: true
 
@@ -156,6 +166,7 @@ jobs:
 
       - uses: subosito/flutter-action@v2
         with:
+          flutter-version: ${{ env.FLUTTER_VERSION }}
           channel: stable
           cache: true
 
@@ -198,6 +209,7 @@ jobs:
 
       - uses: subosito/flutter-action@v2
         with:
+          flutter-version: ${{ env.FLUTTER_VERSION }}
           channel: stable
           cache: true
 
@@ -242,6 +254,7 @@ jobs:
 
       - uses: subosito/flutter-action@v2
         with:
+          flutter-version: ${{ env.FLUTTER_VERSION }}
           channel: stable
           cache: true
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,11 +5,8 @@ on:
     tags:
       - 'v*'
     
-# The toolchain is pinned, not tracked. `channel: stable` alone put CI on
-# whatever Flutter shipped that week: 3.44.9 was green on d18d384 and 3.47.0
-# failed the identical commit hours later, on a new lint plus a dart:io
-# signature change. Both Containerfiles already pin 3.44.8 (host toolchain);
-# this is the environment that was drifting away from them. Bump deliberately.
+# Pinned, not tracked: an unpinned `stable` moved 3.44.9 -> 3.47.0 under an
+# unchanged main and broke it. Matches both Containerfiles. Bump deliberately.
 env:
   FLUTTER_VERSION: "3.44.8"
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,6 +5,14 @@ on:
     tags:
       - 'v*'
     
+# The toolchain is pinned, not tracked. `channel: stable` alone put CI on
+# whatever Flutter shipped that week: 3.44.9 was green on d18d384 and 3.47.0
+# failed the identical commit hours later, on a new lint plus a dart:io
+# signature change. Both Containerfiles already pin 3.44.8 (host toolchain);
+# this is the environment that was drifting away from them. Bump deliberately.
+env:
+  FLUTTER_VERSION: "3.44.8"
+
 jobs:
 
   # ----------------------------
@@ -18,6 +26,7 @@ jobs:
 
       - uses: subosito/flutter-action@v2
         with:
+          flutter-version: ${{ env.FLUTTER_VERSION }}
           channel: stable
           cache: true
 
@@ -44,6 +53,7 @@ jobs:
 
       - uses: subosito/flutter-action@v2
         with:
+          flutter-version: ${{ env.FLUTTER_VERSION }}
           channel: stable
           cache: true
 
@@ -84,6 +94,7 @@ jobs:
 
       - uses: subosito/flutter-action@v2
         with:
+          flutter-version: ${{ env.FLUTTER_VERSION }}
           channel: stable
           cache: true
 
@@ -123,6 +134,7 @@ jobs:
 
       - uses: subosito/flutter-action@v2
         with:
+          flutter-version: ${{ env.FLUTTER_VERSION }}
           channel: stable
           cache: true
 
@@ -163,6 +175,7 @@ jobs:
 
       - uses: subosito/flutter-action@v2
         with:
+          flutter-version: ${{ env.FLUTTER_VERSION }}
           channel: stable
           cache: true
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,14 @@ on:
     branches: [main, master]
   pull_request:
 
+# The toolchain is pinned, not tracked. `channel: stable` alone put CI on
+# whatever Flutter shipped that week: 3.44.9 was green on d18d384 and 3.47.0
+# failed the identical commit hours later, on a new lint plus a dart:io
+# signature change. Both Containerfiles already pin 3.44.8 (host toolchain);
+# this is the environment that was drifting away from them. Bump deliberately.
+env:
+  FLUTTER_VERSION: "3.44.8"
+
 jobs:
   analyze-and-test:
     runs-on: ubuntu-latest
@@ -13,6 +21,7 @@ jobs:
 
       - uses: subosito/flutter-action@v2
         with:
+          flutter-version: ${{ env.FLUTTER_VERSION }}
           channel: stable
 
       - name: Install Linux dependencies

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,11 +5,8 @@ on:
     branches: [main, master]
   pull_request:
 
-# The toolchain is pinned, not tracked. `channel: stable` alone put CI on
-# whatever Flutter shipped that week: 3.44.9 was green on d18d384 and 3.47.0
-# failed the identical commit hours later, on a new lint plus a dart:io
-# signature change. Both Containerfiles already pin 3.44.8 (host toolchain);
-# this is the environment that was drifting away from them. Bump deliberately.
+# Pinned, not tracked: an unpinned `stable` moved 3.44.9 -> 3.47.0 under an
+# unchanged main and broke it. Matches both Containerfiles. Bump deliberately.
 env:
   FLUTTER_VERSION: "3.44.8"
 


### PR DESCRIPTION
All five open PRs went red at once, on a job none of their diffs can reach — #151 changes one Python file and one markdown file and still failed 23 Dart analyzer issues. Nothing they did.

## The evidence

| run | commit | Flutter | result |
|---|---|---|---|
| CI on `main` 18:43 | `d18d384` | **3.44.9** | success |
| CI on #151 22:26 | `d18d384` + txlab | **3.47.0** | 23 issues, exit 1 |

Same base commit, opposite outcome, four hours apart. Every job used `channel: stable` with no version, so `stable` moved and took CI with it.

## What 3.47.0 brings

- **22 × `unawaited_return_in_try_block`** — a lint that did not exist on 3.44, spread across `message_modify_service.dart`, `reaction_service.dart`, `read_receipt_service.dart`, `transport_provider.dart`, `tor_service.dart` and others.
- **1 real `dart:io` break** — `NetworkInterface.addresses` now returns `List<InterfaceAddress>` instead of `List<InternetAddress>`, so `_FakeNetworkInterface.addresses` in `test/network_reachability_test.dart:13` is no longer a valid override.

23 issues, `flutter analyze` exits 1, all five PRs blocked.

## The fix

CI was the **only** environment still drifting. Both Containerfiles already pin `ARG FLUTTER_VERSION=3.44.8` against the host toolchain, and the lab one verifies the archive's SHA-256 so a tampered download aborts the build. An unpinned CI standing beside two pinned images is exactly the second-convention-beside-an-existing-one this repo does not keep.

All eleven `subosito/flutter-action` steps across `ci.yml`, `build.yml` and `build-pr.yml` now take `flutter-version: ${{ env.FLUTTER_VERSION }}`, with the version declared once per file. Laptop, lab and runner now agree on 3.44.8, which is the only thing that makes "`flutter analyze` 0 before every commit" mean anything.

Bumping is one line per workflow, and it becomes a deliberate commit that carries the 3.47 migration with it rather than a Tuesday.

## Deliberately not in this PR

The 3.47 migration itself — the 22 lint sites and the `InterfaceAddress` override. That is a real piece of work with a real diff, and doing it here would hide an unrelated 20-file change inside an infrastructure fix. It should land on its own, together with the version bump it enables.

## Verification

`python3 -c "yaml.safe_load(...)"` parses all three workflows; asserted that every one of the eleven `flutter-action` steps resolves `flutter-version` to the `env` value (1 in `ci.yml`, 5 in `build.yml`, 5 in `build-pr.yml`). Locally on the pinned 3.44.8: `flutter analyze` → **No issues found**.

**Merge this first.** The other five PRs are green underneath it — each was verified with a full suite in isolation on 3.44.8 — and their checks pass once their base carries the pin.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Pinned automated builds and continuous integration to Flutter version 3.44.8.
  * Applied the consistent Flutter version across Windows, Linux, macOS, iOS, and Android build workflows.
  * Preserved existing stable-channel and caching configurations for reliable build performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->