### PR TITLE
feat(storage): implement media storage management features

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -11,6 +11,14 @@ analyzer:
   errors:
     avoid_print: true
     file_names: ignore
+  exclude:
+    - build/**
+    - android/**
+    - ios/**
+    - web/**
+    - windows/**
+    - macos/**
+    - linux/**
 include: package:flutter_lints/flutter.yaml
 
 linter:

--- a/lib/database/media_gallery_queries_dao.dart
+++ b/lib/database/media_gallery_queries_dao.dart
@@ -99,6 +99,7 @@ class MediaGalleryQueriesDao {
     List<String>? types,
     int limit = 50,
     int? beforeTimestamp,
+    String? beforeId,
   }) async {
     return await _protect(() async {
       final db = await _database;
@@ -113,16 +114,22 @@ class MediaGalleryQueriesDao {
         where += ' AND $_allMediaTypeFilter';
       }
 
-      if (beforeTimestamp != null) {
+      if (beforeTimestamp != null && beforeId != null) {
+        where += ' AND (timestamp < ? OR (timestamp = ? AND id < ?))';
+        whereArgs.addAll([beforeTimestamp, beforeTimestamp, beforeId]);
+      } else if (beforeTimestamp != null) {
         where += ' AND timestamp < ?';
         whereArgs.add(beforeTimestamp);
+      } else if (beforeId != null) {
+        where += ' AND id < ?';
+        whereArgs.add(beforeId);
       }
 
       return db.query(
         'messages',
         where: where,
         whereArgs: whereArgs,
-        orderBy: 'timestamp DESC',
+        orderBy: 'timestamp DESC, id DESC',
         limit: limit,
       );
     });

--- a/lib/database/media_gallery_queries_dao.dart
+++ b/lib/database/media_gallery_queries_dao.dart
@@ -121,8 +121,9 @@ class MediaGalleryQueriesDao {
         where += ' AND timestamp < ?';
         whereArgs.add(beforeTimestamp);
       } else if (beforeId != null) {
-        where += ' AND id < ?';
-        whereArgs.add(beforeId);
+        throw ArgumentError(
+          'beforeId requires beforeTimestamp for a stable cursor',
+        );
       }
 
       return db.query(

--- a/lib/database/media_gallery_queries_dao.dart
+++ b/lib/database/media_gallery_queries_dao.dart
@@ -18,6 +18,9 @@ class MediaGalleryQueriesDao {
   static const String _groupMediaTypeFilter =
       "type IN ('group_image', 'group_file', 'group_audio')";
 
+  static const String _allMediaTypeFilter =
+      "type IN ('image', 'file', 'audio', 'group_image', 'group_file', 'group_audio')";
+
   static const String _mediaContentFilter =
       "deletedAt IS NULL AND message IS NOT NULL AND message != ''";
 
@@ -88,6 +91,63 @@ class MediaGalleryQueriesDao {
         orderBy: 'timestamp DESC',
         limit: limit,
       );
+    });
+  }
+
+  /// All media messages across every chat, newest first.
+  Future<List<Map<String, dynamic>>> getAllMediaMessages({
+    List<String>? types,
+    int limit = 50,
+    int? beforeTimestamp,
+  }) async {
+    return await _protect(() async {
+      final db = await _database;
+      var where = _mediaContentFilter;
+      final whereArgs = <dynamic>[];
+
+      if (types != null && types.isNotEmpty) {
+        where +=
+            ' AND type IN (${List.filled(types.length, '?').join(', ')})';
+        whereArgs.addAll(types);
+      } else {
+        where += ' AND $_allMediaTypeFilter';
+      }
+
+      if (beforeTimestamp != null) {
+        where += ' AND timestamp < ?';
+        whereArgs.add(beforeTimestamp);
+      }
+
+      return db.query(
+        'messages',
+        where: where,
+        whereArgs: whereArgs,
+        orderBy: 'timestamp DESC',
+        limit: limit,
+      );
+    });
+  }
+
+  /// Count of all media messages with stored content.
+  Future<int> countAllMediaMessages({List<String>? types}) async {
+    return await _protect(() async {
+      final db = await _database;
+      var where = _mediaContentFilter;
+      final whereArgs = <dynamic>[];
+
+      if (types != null && types.isNotEmpty) {
+        where +=
+            ' AND type IN (${List.filled(types.length, '?').join(', ')})';
+        whereArgs.addAll(types);
+      } else {
+        where += ' AND $_allMediaTypeFilter';
+      }
+
+      final result = await db.rawQuery(
+        'SELECT COUNT(*) AS count FROM messages WHERE $where',
+        whereArgs,
+      );
+      return Sqflite.firstIntValue(result) ?? 0;
     });
   }
 }

--- a/lib/database/messages.dart
+++ b/lib/database/messages.dart
@@ -314,6 +314,22 @@ class MessagesDb {
         afterTimestamp: afterTimestamp,
       );
 
+  /// All media messages across every chat, newest first.
+  static Future<List<Map<String, dynamic>>> getAllMediaMessages({
+    List<String>? types,
+    int limit = 50,
+    int? beforeTimestamp,
+  }) =>
+      _mediaDao.getAllMediaMessages(
+        types: types,
+        limit: limit,
+        beforeTimestamp: beforeTimestamp,
+      );
+
+  /// Count of all media messages with stored content.
+  static Future<int> countAllMediaMessages({List<String>? types}) =>
+      _mediaDao.countAllMediaMessages(types: types);
+
   /// Close the db
   static Future<void> close() => MessagesDatabase.close();
 

--- a/lib/database/messages.dart
+++ b/lib/database/messages.dart
@@ -319,11 +319,13 @@ class MessagesDb {
     List<String>? types,
     int limit = 50,
     int? beforeTimestamp,
+    String? beforeId,
   }) =>
       _mediaDao.getAllMediaMessages(
         types: types,
         limit: limit,
         beforeTimestamp: beforeTimestamp,
+        beforeId: beforeId,
       );
 
   /// Count of all media messages with stored content.

--- a/lib/models/storage_media_item.dart
+++ b/lib/models/storage_media_item.dart
@@ -1,0 +1,101 @@
+import 'package:prysm/constants/group_constants.dart';
+import 'package:prysm/database/message_id_codec.dart';
+import 'package:prysm/models/chat_media_item.dart';
+
+/// A media row in the global storage browser with conversation context.
+class StorageMediaItem {
+  final String id;
+  final String type;
+  final String? fileName;
+  final int? fileSize;
+  final int timestamp;
+  final String senderId;
+  final bool isViewOnce;
+  final bool viewed;
+  final bool isGroup;
+  final String? groupId;
+  final String? peerId;
+  final String conversationLabel;
+
+  const StorageMediaItem({
+    required this.id,
+    required this.type,
+    required this.fileName,
+    required this.fileSize,
+    required this.timestamp,
+    required this.senderId,
+    required this.isViewOnce,
+    required this.viewed,
+    required this.isGroup,
+    required this.groupId,
+    required this.peerId,
+    required this.conversationLabel,
+  });
+
+  bool get isImage => type == 'image' || type == groupImageType;
+  bool get isVoice => type == 'audio' || type == groupAudioType;
+  bool get isFile => type == 'file' || type == groupFileType;
+
+  ChatMediaItem toChatMediaItem() {
+    return ChatMediaItem(
+      id: id,
+      type: type,
+      fileName: fileName,
+      fileSize: fileSize,
+      timestamp: timestamp,
+      senderId: senderId,
+      isViewOnce: isViewOnce,
+      viewed: viewed,
+      isGroup: isGroup,
+    );
+  }
+
+  factory StorageMediaItem.fromRow(
+    Map<String, dynamic> row, {
+    required String userId,
+    required Map<String, String> contactNames,
+    required Map<String, String> groupNames,
+  }) {
+    final groupId = row['groupId'] as String?;
+    final isGroup = groupId != null;
+    final senderId = row['senderId'] as String;
+    final receiverId = row['receiverId'] as String;
+
+    final peerId = isGroup
+        ? null
+        : (senderId == userId ? receiverId : senderId);
+
+    final conversationLabel = isGroup
+        ? (groupNames[groupId] ?? 'Group')
+        : (contactNames[peerId] ?? peerId ?? 'Chat');
+
+    return StorageMediaItem(
+      id: MessageIdCodec.wireIdFromStorage(row['id'] as String),
+      type: row['type'] as String,
+      fileName: row['fileName'] as String?,
+      fileSize: row['fileSize'] as int?,
+      timestamp: row['timestamp'] as int,
+      senderId: senderId,
+      isViewOnce: (row['viewOnce'] ?? 0) == 1,
+      viewed: (row['viewed'] ?? 0) == 1,
+      isGroup: isGroup,
+      groupId: groupId,
+      peerId: peerId,
+      conversationLabel: conversationLabel,
+    );
+  }
+}
+
+/// Maps gallery tabs to message types across direct and group chats.
+List<String>? globalTypesForFilter(ChatMediaFilter filter) {
+  switch (filter) {
+    case ChatMediaFilter.all:
+      return null;
+    case ChatMediaFilter.photos:
+      return ['image', groupImageType];
+    case ChatMediaFilter.files:
+      return ['file', groupFileType];
+    case ChatMediaFilter.voice:
+      return ['audio', groupAudioType];
+  }
+}

--- a/lib/screens/data_storage_screen.dart
+++ b/lib/screens/data_storage_screen.dart
@@ -1,172 +1,215 @@
 import 'package:flutter/widgets.dart';
-import 'package:prysm/ui/core/prysm_icons.dart';
-import 'package:prysm/ui/core/prysm_toast.dart';
-import 'package:prysm/ui/core/prysm_list_row.dart';
-import 'package:prysm/ui/core/prysm_dialog.dart';
+import 'package:prysm/database/messages.dart';
+import 'package:prysm/screens/downloads_files_screen.dart';
+import 'package:prysm/screens/storage_media_browser_screen.dart';
+import 'package:prysm/services/storage_usage_service.dart';
 import 'package:prysm/theme/prysm_style_scope.dart';
 import 'package:prysm/theme/prysm_tokens.dart';
-import 'package:shared_preferences/shared_preferences.dart';
-import 'package:prysm/services/settings_service.dart';
+import 'package:prysm/ui/core/prysm_app.dart';
 import 'package:prysm/ui/core/prysm_button.dart';
-import 'package:prysm/ui/core/prysm_switch.dart';
+import 'package:prysm/ui/core/prysm_dialog.dart';
+import 'package:prysm/ui/core/prysm_icons.dart';
+import 'package:prysm/ui/core/prysm_list_row.dart';
+import 'package:prysm/ui/core/prysm_progress.dart';
+import 'package:prysm/ui/core/prysm_toast.dart';
 import 'package:prysm/ui/prysm_scaffold.dart';
 import 'package:prysm/ui/prysm_section.dart';
+import 'package:prysm/util/format_file_size.dart';
+import 'package:prysm/util/key_manager.dart';
 
 class DataStorageScreen extends StatefulWidget {
   final VoidCallback onClose;
+  final String? userId;
+  final KeyManager? keyManager;
 
-  const DataStorageScreen({required this.onClose, super.key});
+  const DataStorageScreen({
+    required this.onClose,
+    this.userId,
+    this.keyManager,
+    super.key,
+  });
+
   @override
   State<DataStorageScreen> createState() => _DataStorageScreenState();
 }
 
 class _DataStorageScreenState extends State<DataStorageScreen> {
-  static final settings = SettingsService();
-  bool _autoDownloadMedia = true;
-  bool _keepMedia = true;
-  bool _autoDeleteMessages = false;
-  final int _storageUsage = 128;
+  StorageUsageBreakdown? _breakdown;
+  int? _mediaItemCount;
+  bool _loading = true;
 
   @override
   void initState() {
     super.initState();
-    _loadDataStorageSettings();
+    _refresh();
   }
 
-  Future<void> _loadDataStorageSettings() async {
-    final prefs = await SharedPreferences.getInstance();
+  Future<void> _refresh() async {
+    setState(() => _loading = true);
+    final breakdown = await StorageUsageService.compute();
+    final mediaCount = await MessagesDb.countAllMediaMessages();
+    if (!mounted) return;
     setState(() {
-      _autoDownloadMedia = prefs.getBool('auto_download_media') ?? true;
-      _keepMedia = prefs.getBool('keep_media') ?? true;
-      _autoDeleteMessages = prefs.getBool('auto_delete_messages') ?? false;
+      _breakdown = breakdown;
+      _mediaItemCount = mediaCount;
+      _loading = false;
     });
   }
 
-  Future<void> _saveDataStorageSetting(String key, bool value) async {
-    final prefs = await SharedPreferences.getInstance();
-    await prefs.setBool(key, value);
-  }
-
-  void _onAutoDownloadMediaToggle(bool value) {
-    setState(() => _autoDownloadMedia = value);
-    _saveDataStorageSetting('auto_download_media', value);
-  }
-
-  void _onKeepMediaToggle(bool value) {
-    setState(() => _keepMedia = value);
-    _saveDataStorageSetting('keep_media', value);
-  }
-
-  void _onAutoDeleteMessagesToggle(bool value) {
-    setState(() => _autoDeleteMessages = value);
-    _saveDataStorageSetting('auto_delete_messages', value);
-  }
-
-  Future<void> _onClearChatHistory() async {
+  Future<void> _clearCaches() async {
     final confirmed = await showPrysmConfirmDialog(
       context: context,
-      title: 'Clear Chat History',
+      title: 'Clear caches',
       content: const Text(
-        'Are you sure you want to clear all chat history? This cannot be undone.',
+        'Delete temporary image and voice caches? '
+        'Media will be re-decrypted when opened again.',
       ),
       cancelLabel: 'Cancel',
       confirmLabel: 'Clear',
       confirmVariant: PrysmButtonVariant.danger,
     );
-    if (confirmed == true && mounted) {
-      showPrysmToast(context, 'Chat history cleared');
+    if (confirmed != true || !mounted) return;
+
+    await StorageUsageService.clearEphemeralCaches();
+    if (!mounted) return;
+    showPrysmToast(context, 'Caches cleared');
+    await _refresh();
+  }
+
+  Future<void> _openChatMedia() async {
+    final userId = widget.userId;
+    final keyManager = widget.keyManager;
+    if (userId == null || keyManager == null) {
+      showPrysmToast(context, 'Storage manager unavailable');
+      return;
     }
+
+    await Navigator.push(
+      context,
+      PrysmPageRoute(
+        page: StorageMediaBrowserScreen(
+          userId: userId,
+          keyManager: keyManager,
+          mediaItemCount: _mediaItemCount,
+          onClose: () async {
+            Navigator.of(context).pop();
+            await _refresh();
+          },
+        ),
+      ),
+    );
+    if (mounted) await _refresh();
+  }
+
+  Future<void> _openDownloads() async {
+    await Navigator.push(
+      context,
+      PrysmPageRoute(
+        page: DownloadsFilesScreen(
+          onClose: () async {
+            Navigator.of(context).pop();
+            await _refresh();
+          },
+        ),
+      ),
+    );
+    if (mounted) await _refresh();
   }
 
   @override
   Widget build(BuildContext context) {
     final style = context.prysmStyle;
+    final breakdown = _breakdown;
+
     return PrysmPage(
-      title: 'Data & Storage',
+      title: 'Storage Manager',
       headerHeight: 70,
       leading: PrysmIconButton(
         icon: PrysmIcons.arrowBack,
         onPressed: widget.onClose,
       ),
-      body: SingleChildScrollView(
-        child: Padding(
-          padding: const EdgeInsets.all(PrysmTokens.spacing16),
-          child: Column(
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: [
-              PrysmSection(
-                children: [
-                  PrysmSwitchRow(
-                    title: 'Auto-download Media',
-                    subtitle:
-                        'Automatically download photos, videos, and documents',
-                    value: _autoDownloadMedia,
-                    onChanged: _onAutoDownloadMediaToggle,
-                  ),
-                  PrysmSwitchRow(
-                    title: 'Keep Media',
-                    subtitle: 'Store media files on your device',
-                    value: _keepMedia,
-                    onChanged: _onKeepMediaToggle,
-                  ),
-                  PrysmSwitchRow(
-                    title: 'Auto-delete Messages',
-                    subtitle:
-                        'Automatically delete old messages to save space',
-                    value: _autoDeleteMessages,
-                    onChanged: _onAutoDeleteMessagesToggle,
-                  ),
-                ],
-              ),
-              const SizedBox(height: 30),
-              Text('Storage Usage', style: style.headlineStyle),
-              const SizedBox(height: 20),
-              PrysmSection(
-                children: [
-                  PrysmListRow(
-                    leading: const Icon(PrysmIcons.storageOutlined),
-                    title: 'Total Storage',
-                    subtitle: '$_storageUsage MB used',
-                    trailing:
-                        const Icon(PrysmIcons.arrowForwardIos, size: 16),
-                  ),
-                ],
-              ),
-              const SizedBox(height: 30),
-              Text('Manage Data', style: style.headlineStyle),
-              const SizedBox(height: 20),
-              PrysmSection(
-                children: [
-                  PrysmListRow(
-                    leading: const Icon(PrysmIcons.deleteOutline),
-                    title: 'Clear Chat History',
-                    subtitle: 'Delete all messages from all chats',
-                    trailing: PrysmButton(
-                      label: 'Clear',
-                      variant: PrysmButtonVariant.danger,
-                      onPressed: _onClearChatHistory,
-                    ),
-                  ),
-                ],
-              ),
-              const SizedBox(height: 30),
-              Container(
+      body: _loading && breakdown == null
+          ? const Center(child: PrysmProgressIndicator())
+          : SingleChildScrollView(
+              child: Padding(
                 padding: const EdgeInsets.all(PrysmTokens.spacing16),
-                decoration: BoxDecoration(
-                  color: style.tokens.surface,
-                  borderRadius:
-                      BorderRadius.circular(PrysmTokens.radiusCard),
-                ),
-                child: Text(
-                  'Manage your data usage and storage preferences. '
-                  'These settings help you control how ${settings.name} uses your device storage.',
-                  style: style.bodyStyle,
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Text('Storage Usage', style: style.headlineStyle),
+                    const SizedBox(height: 20),
+                    PrysmSection(
+                      children: [
+                        PrysmListRow(
+                          leading: const Icon(PrysmIcons.storageOutlined),
+                          title: 'Total',
+                          subtitle: breakdown != null
+                              ? formatFileSize(breakdown.totalBytes)
+                              : 'Calculating…',
+                        ),
+                        if (breakdown != null) ...[
+                          PrysmListRow(
+                            leading: const Icon(PrysmIcons.chatBubbleOutline),
+                            title: 'Chat media',
+                            subtitle: formatFileSize(breakdown.chatMediaBytes),
+                            trailing: const Icon(
+                              PrysmIcons.arrowForwardIos,
+                              size: 16,
+                            ),
+                            onTap: _openChatMedia,
+                          ),
+                          PrysmListRow(
+                            leading: const Icon(PrysmIcons.downloadOutlined),
+                            title: 'Downloads',
+                            subtitle: formatFileSize(breakdown.downloadsBytes),
+                            trailing: const Icon(
+                              PrysmIcons.arrowForwardIos,
+                              size: 16,
+                            ),
+                            onTap: _openDownloads,
+                          ),
+                          PrysmListRow(
+                            leading: const Icon(PrysmIcons.refreshOutlined),
+                            title: 'Caches',
+                            subtitle: formatFileSize(breakdown.cacheBytes),
+                            trailing: PrysmButton(
+                              label: 'Clear',
+                              variant: PrysmButtonVariant.danger,
+                              onPressed: _clearCaches,
+                            ),
+                          ),
+                          PrysmListRow(
+                            leading: const Icon(PrysmIcons.folderOpenOutlined),
+                            title: 'Other app data',
+                            subtitle:
+                                formatFileSize(breakdown.otherAppDataBytes),
+                          ),
+                        ],
+                      ],
+                    ),
+                    if (_loading) ...[
+                      const SizedBox(height: 16),
+                      const Center(child: PrysmProgressIndicator(size: 20)),
+                    ],
+                    const SizedBox(height: 30),
+                    Container(
+                      padding: const EdgeInsets.all(PrysmTokens.spacing16),
+                      decoration: BoxDecoration(
+                        color: style.tokens.surface,
+                        borderRadius:
+                            BorderRadius.circular(PrysmTokens.radiusCard),
+                      ),
+                      child: Text(
+                        'Chat media is stored encrypted on this device. '
+                        'Deleting media here removes it locally only — '
+                        'it may still exist for other participants.',
+                        style: style.bodyStyle,
+                      ),
+                    ),
+                  ],
                 ),
               ),
-            ],
-          ),
-        ),
-      ),
+            ),
     );
   }
 }

--- a/lib/screens/data_storage_screen.dart
+++ b/lib/screens/data_storage_screen.dart
@@ -46,14 +46,20 @@ class _DataStorageScreenState extends State<DataStorageScreen> {
 
   Future<void> _refresh() async {
     setState(() => _loading = true);
-    final breakdown = await StorageUsageService.compute();
-    final mediaCount = await MessagesDb.countAllMediaMessages();
-    if (!mounted) return;
-    setState(() {
-      _breakdown = breakdown;
-      _mediaItemCount = mediaCount;
-      _loading = false;
-    });
+    try {
+      final breakdown = await StorageUsageService.compute();
+      final mediaCount = await MessagesDb.countAllMediaMessages();
+      if (!mounted) return;
+      setState(() {
+        _breakdown = breakdown;
+        _mediaItemCount = mediaCount;
+        _loading = false;
+      });
+    } catch (e) {
+      if (!mounted) return;
+      setState(() => _loading = false);
+      showPrysmToast(context, 'Could not load storage usage: $e');
+    }
   }
 
   Future<void> _clearCaches() async {

--- a/lib/screens/downloads_files_screen.dart
+++ b/lib/screens/downloads_files_screen.dart
@@ -36,12 +36,18 @@ class _DownloadsFilesScreenState extends State<DownloadsFilesScreen> {
 
   Future<void> _load() async {
     setState(() => _loading = true);
-    final files = await StorageUsageService.listDownloadedFiles();
-    if (!mounted) return;
-    setState(() {
-      _files = files;
-      _loading = false;
-    });
+    try {
+      final files = await StorageUsageService.listDownloadedFiles();
+      if (!mounted) return;
+      setState(() {
+        _files = files;
+        _loading = false;
+      });
+    } catch (e) {
+      if (!mounted) return;
+      setState(() => _loading = false);
+      showPrysmToast(context, 'Could not load downloads: $e');
+    }
   }
 
   IconData _iconFor(String name) {

--- a/lib/screens/downloads_files_screen.dart
+++ b/lib/screens/downloads_files_screen.dart
@@ -1,0 +1,147 @@
+import 'dart:io';
+
+import 'package:flutter/widgets.dart';
+import 'package:open_file/open_file.dart';
+import 'package:prysm/services/storage_usage_service.dart';
+import 'package:prysm/theme/prysm_style_scope.dart';
+import 'package:prysm/theme/prysm_tokens.dart';
+import 'package:prysm/ui/core/prysm_button.dart';
+import 'package:prysm/ui/core/prysm_dialog.dart';
+import 'package:prysm/ui/core/prysm_icons.dart';
+import 'package:prysm/ui/core/prysm_list_row.dart';
+import 'package:prysm/ui/core/prysm_progress.dart';
+import 'package:prysm/ui/core/prysm_toast.dart';
+import 'package:prysm/ui/prysm_scaffold.dart';
+import 'package:prysm/ui/prysm_section.dart';
+import 'package:prysm/util/format_file_size.dart';
+
+class DownloadsFilesScreen extends StatefulWidget {
+  final VoidCallback onClose;
+
+  const DownloadsFilesScreen({required this.onClose, super.key});
+
+  @override
+  State<DownloadsFilesScreen> createState() => _DownloadsFilesScreenState();
+}
+
+class _DownloadsFilesScreenState extends State<DownloadsFilesScreen> {
+  List<DownloadedFileEntry> _files = [];
+  bool _loading = true;
+
+  @override
+  void initState() {
+    super.initState();
+    _load();
+  }
+
+  Future<void> _load() async {
+    setState(() => _loading = true);
+    final files = await StorageUsageService.listDownloadedFiles();
+    if (!mounted) return;
+    setState(() {
+      _files = files;
+      _loading = false;
+    });
+  }
+
+  IconData _iconFor(String name) {
+    final lower = name.toLowerCase();
+    if (lower.endsWith('.pdf')) return PrysmIcons.pictureAsPdf;
+    if (lower.endsWith('.png') ||
+        lower.endsWith('.jpg') ||
+        lower.endsWith('.jpeg') ||
+        lower.endsWith('.webp') ||
+        lower.endsWith('.gif')) {
+      return PrysmIcons.imageOutlined;
+    }
+    if (lower.endsWith('.mp4') || lower.endsWith('.mov')) {
+      return PrysmIcons.videocamOutlined;
+    }
+    return PrysmIcons.insertDriveFileOutlined;
+  }
+
+  Future<void> _openFile(DownloadedFileEntry entry) async {
+    final result = await OpenFile.open(entry.path);
+    if (!mounted) return;
+    if (result.type != ResultType.done) {
+      showPrysmToast(context, result.message);
+    }
+  }
+
+  Future<void> _deleteFile(DownloadedFileEntry entry) async {
+    final confirmed = await showPrysmConfirmDialog(
+      context: context,
+      title: 'Delete file',
+      content: Text('Delete "${entry.name}" from downloads?'),
+      cancelLabel: 'Cancel',
+      confirmLabel: 'Delete',
+      confirmVariant: PrysmButtonVariant.danger,
+    );
+    if (confirmed != true || !mounted) return;
+
+    try {
+      await File(entry.path).delete();
+      if (!mounted) return;
+      setState(() => _files.removeWhere((f) => f.path == entry.path));
+      showPrysmToast(context, 'File deleted');
+    } catch (e) {
+      if (!mounted) return;
+      showPrysmToast(context, 'Could not delete file: $e');
+    }
+  }
+
+  String _formatDate(DateTime date) {
+    final y = date.year.toString().padLeft(4, '0');
+    final m = date.month.toString().padLeft(2, '0');
+    final d = date.day.toString().padLeft(2, '0');
+    return '$y-$m-$d';
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final style = context.prysmStyle;
+
+    return PrysmPage(
+      title: 'Downloads',
+      headerHeight: 70,
+      leading: PrysmIconButton(
+        icon: PrysmIcons.arrowBack,
+        onPressed: widget.onClose,
+      ),
+      body: _loading
+          ? const Center(child: PrysmProgressIndicator())
+          : _files.isEmpty
+              ? Center(
+                  child: Text(
+                    'No downloaded files',
+                    style: TextStyle(color: style.tokens.textMuted),
+                  ),
+                )
+              : ListView.builder(
+                  padding: const EdgeInsets.all(PrysmTokens.spacing16),
+                  itemCount: _files.length,
+                  itemBuilder: (context, index) {
+                    final entry = _files[index];
+                    return Padding(
+                      padding: const EdgeInsets.only(bottom: 8),
+                      child: PrysmSection(
+                        children: [
+                          PrysmListRow(
+                            leading: Icon(_iconFor(entry.name)),
+                            title: entry.name,
+                            subtitle:
+                                '${formatFileSize(entry.bytes)} · ${_formatDate(entry.modifiedAt)}',
+                            onTap: () => _openFile(entry),
+                            trailing: PrysmIconButton(
+                              icon: PrysmIcons.deleteOutline,
+                              onPressed: () => _deleteFile(entry),
+                            ),
+                          ),
+                        ],
+                      ),
+                    );
+                  },
+                ),
+    );
+  }
+}

--- a/lib/screens/settings_screen.dart
+++ b/lib/screens/settings_screen.dart
@@ -25,6 +25,7 @@ import 'privacy_settings_screen.dart';
 import 'blocked_contacts_screen.dart';
 import 'invite_requests_screen.dart';
 import 'call_history_screen.dart';
+import 'data_storage_screen.dart';
 import 'package:prysm/screens/widgets/appearance_settings_section.dart';
 import 'package:prysm/theme/prysm_theme.dart';
 import 'package:prysm/theme/prysm_themes.dart';
@@ -912,6 +913,25 @@ class _SettingsScreenState extends State<SettingsScreen> {
                   _showDownloadLocationSheet,
                   subtitle: _downloadLocationDisplay,
                 ),
+                if (!widget.decoyMode) const PrysmDivider(),
+                if (!widget.decoyMode)
+                  _buildNavigationTile(
+                    'Storage Manager',
+                    PrysmIcons.storageOutlined,
+                    () {
+                      Navigator.push(
+                        context,
+                        PrysmPageRoute(
+                          page: DataStorageScreen(
+                            userId: widget.onionAddress,
+                            keyManager: widget.keyManager,
+                            onClose: () => Navigator.of(context).pop(),
+                          ),
+                        ),
+                      );
+                    },
+                    subtitle: 'Disk usage and media management',
+                  ),
                 const PrysmDivider(),
                 _buildNavigationTile(
                   'Create Backup',

--- a/lib/screens/storage_media_browser_screen.dart
+++ b/lib/screens/storage_media_browser_screen.dart
@@ -80,36 +80,42 @@ class _StorageMediaBrowserScreenState extends State<StorageMediaBrowserScreen> {
   }
 
   Future<void> _bootstrap() async {
-    final repo = const ConversationListRepository();
-    final userMaps = await repo.getUsers();
-    final groups = await _groupService.getGroups();
+    try {
+      final repo = const ConversationListRepository();
+      final userMaps = await repo.getUsers();
+      final groups = await _groupService.getGroups();
 
-    final contactNames = <String, String>{};
-    for (final map in userMaps) {
-      final id = map['id'] as String;
-      final customName = map['customName'] as String?;
-      final name = map['name'] as String? ?? id;
-      contactNames[id] =
-          (customName != null && customName.isNotEmpty) ? customName : name;
+      final contactNames = <String, String>{};
+      for (final map in userMaps) {
+        final id = map['id'] as String;
+        final customName = map['customName'] as String?;
+        final name = map['name'] as String? ?? id;
+        contactNames[id] =
+            (customName != null && customName.isNotEmpty) ? customName : name;
+      }
+
+      final groupNames = {for (final g in groups) g.id: g.name};
+
+      _mediaService = StorageMediaService(
+        keyManager: widget.keyManager,
+        userId: widget.userId,
+        groupService: _groupService,
+        contactNames: contactNames,
+        groupNames: groupNames,
+      );
+
+      for (final filter in ChatMediaFilter.values) {
+        _countsByFilter[filter] = await _mediaService!.countMedia(filter);
+      }
+
+      if (!mounted) return;
+      setState(() => _bootstrapping = false);
+      await _ensureLoaded(ChatMediaFilter.all);
+    } catch (e) {
+      if (!mounted) return;
+      setState(() => _bootstrapping = false);
+      showPrysmToast(context, 'Could not load media: $e');
     }
-
-    final groupNames = {for (final g in groups) g.id: g.name};
-
-    _mediaService = StorageMediaService(
-      keyManager: widget.keyManager,
-      userId: widget.userId,
-      groupService: _groupService,
-      contactNames: contactNames,
-      groupNames: groupNames,
-    );
-
-    for (final filter in ChatMediaFilter.values) {
-      _countsByFilter[filter] = await _mediaService!.countMedia(filter);
-    }
-
-    if (!mounted) return;
-    setState(() => _bootstrapping = false);
-    await _ensureLoaded(ChatMediaFilter.all);
   }
 
   @override
@@ -153,10 +159,12 @@ class _StorageMediaBrowserScreenState extends State<StorageMediaBrowserScreen> {
       final existing = _itemsByFilter[filter]!;
       final beforeTimestamp =
           existing.isEmpty ? null : existing.last.timestamp;
+      final beforeId = existing.isEmpty ? null : existing.last.id;
       final page = await service.loadPage(
         filter,
         limit: _pageSize,
         beforeTimestamp: beforeTimestamp,
+        beforeId: beforeId,
       );
 
       if (!mounted) return;

--- a/lib/screens/storage_media_browser_screen.dart
+++ b/lib/screens/storage_media_browser_screen.dart
@@ -1,0 +1,448 @@
+import 'package:flutter/widgets.dart';
+import 'package:prysm/app/conversation_list_repository.dart';
+import 'package:prysm/database/messages.dart';
+import 'package:prysm/models/chat_media_item.dart';
+import 'package:prysm/models/storage_media_item.dart';
+import 'package:prysm/screens/file_preview_screen.dart';
+import 'package:prysm/screens/widgets/image_viewer_screen.dart';
+import 'package:prysm/screens/widgets/view_once_image_screen.dart';
+import 'package:prysm/screens/widgets/voice_message_bubble.dart';
+import 'package:prysm/services/group_service.dart';
+import 'package:prysm/services/image_attachment_cache.dart';
+import 'package:prysm/services/storage_media_service.dart';
+import 'package:prysm/theme/prysm_style_scope.dart';
+import 'package:prysm/theme/prysm_tokens.dart';
+import 'package:prysm/ui/core/prysm_app.dart';
+import 'package:prysm/ui/core/prysm_button.dart';
+import 'package:prysm/ui/core/prysm_dialog.dart';
+import 'package:prysm/ui/core/prysm_icons.dart';
+import 'package:prysm/ui/core/prysm_list_row.dart';
+import 'package:prysm/ui/core/prysm_progress.dart';
+import 'package:prysm/ui/core/prysm_tabs.dart';
+import 'package:prysm/ui/core/prysm_toast.dart';
+import 'package:prysm/ui/prysm_scaffold.dart';
+import 'package:prysm/util/format_file_size.dart';
+import 'package:prysm/util/key_manager.dart';
+import 'package:prysm/util/readable_file_policy.dart';
+
+class StorageMediaBrowserScreen extends StatefulWidget {
+  final VoidCallback onClose;
+  final String userId;
+  final KeyManager keyManager;
+  final int? mediaItemCount;
+
+  const StorageMediaBrowserScreen({
+    required this.onClose,
+    required this.userId,
+    required this.keyManager,
+    this.mediaItemCount,
+    super.key,
+  });
+
+  @override
+  State<StorageMediaBrowserScreen> createState() =>
+      _StorageMediaBrowserScreenState();
+}
+
+class _StorageMediaBrowserScreenState extends State<StorageMediaBrowserScreen> {
+  static const _pageSize = 50;
+
+  late final PrysmTabController _tabController;
+  late final GroupService _groupService;
+  StorageMediaService? _mediaService;
+
+  final Map<ChatMediaFilter, ScrollController> _scrollControllers = {};
+  final Map<ChatMediaFilter, List<StorageMediaItem>> _itemsByFilter = {};
+  final Map<ChatMediaFilter, bool> _hasMoreByFilter = {};
+  final Map<ChatMediaFilter, bool> _loadingByFilter = {};
+  final Map<ChatMediaFilter, int?> _countsByFilter = {};
+
+  bool _bootstrapping = true;
+
+  @override
+  void initState() {
+    super.initState();
+    _tabController = PrysmTabController(length: 4);
+    _groupService = GroupService(
+      userId: widget.userId,
+      keyManager: widget.keyManager,
+    );
+    for (final filter in ChatMediaFilter.values) {
+      final controller = ScrollController();
+      controller.addListener(() => _onScroll(filter));
+      _scrollControllers[filter] = controller;
+      _itemsByFilter[filter] = [];
+      _hasMoreByFilter[filter] = true;
+      _loadingByFilter[filter] = false;
+    }
+    _tabController.addListener(() => _ensureLoaded(_currentFilter));
+    _bootstrap();
+  }
+
+  Future<void> _bootstrap() async {
+    final repo = const ConversationListRepository();
+    final userMaps = await repo.getUsers();
+    final groups = await _groupService.getGroups();
+
+    final contactNames = <String, String>{};
+    for (final map in userMaps) {
+      final id = map['id'] as String;
+      final customName = map['customName'] as String?;
+      final name = map['name'] as String? ?? id;
+      contactNames[id] =
+          (customName != null && customName.isNotEmpty) ? customName : name;
+    }
+
+    final groupNames = {for (final g in groups) g.id: g.name};
+
+    _mediaService = StorageMediaService(
+      keyManager: widget.keyManager,
+      userId: widget.userId,
+      groupService: _groupService,
+      contactNames: contactNames,
+      groupNames: groupNames,
+    );
+
+    for (final filter in ChatMediaFilter.values) {
+      _countsByFilter[filter] = await _mediaService!.countMedia(filter);
+    }
+
+    if (!mounted) return;
+    setState(() => _bootstrapping = false);
+    await _ensureLoaded(ChatMediaFilter.all);
+  }
+
+  @override
+  void dispose() {
+    _tabController.dispose();
+    for (final controller in _scrollControllers.values) {
+      controller.dispose();
+    }
+    super.dispose();
+  }
+
+  ChatMediaFilter get _currentFilter =>
+      ChatMediaFilter.values[_tabController.index];
+
+  void _onScroll(ChatMediaFilter filter) {
+    final controller = _scrollControllers[filter];
+    if (controller == null || !controller.hasClients) return;
+    final position = controller.position;
+    if (position.pixels >= position.maxScrollExtent - 200) {
+      _loadMore(filter);
+    }
+  }
+
+  Future<void> _ensureLoaded(ChatMediaFilter filter) async {
+    if (_mediaService == null) return;
+    if (_itemsByFilter[filter]!.isEmpty && _hasMoreByFilter[filter]!) {
+      await _loadMore(filter);
+    }
+  }
+
+  Future<void> _loadMore(ChatMediaFilter filter) async {
+    final service = _mediaService;
+    if (service == null ||
+        _loadingByFilter[filter]! ||
+        !_hasMoreByFilter[filter]!) {
+      return;
+    }
+    setState(() => _loadingByFilter[filter] = true);
+
+    try {
+      final existing = _itemsByFilter[filter]!;
+      final beforeTimestamp =
+          existing.isEmpty ? null : existing.last.timestamp;
+      final page = await service.loadPage(
+        filter,
+        limit: _pageSize,
+        beforeTimestamp: beforeTimestamp,
+      );
+
+      if (!mounted) return;
+      setState(() {
+        _itemsByFilter[filter] = [...existing, ...page];
+        _hasMoreByFilter[filter] = page.length >= _pageSize;
+        _loadingByFilter[filter] = false;
+      });
+    } catch (_) {
+      if (!mounted) return;
+      setState(() => _loadingByFilter[filter] = false);
+    }
+  }
+
+  Future<void> _handleTap(StorageMediaItem item) async {
+    final service = _mediaService;
+    if (service == null) return;
+
+    if (item.isImage) {
+      await _openImage(item, service);
+    } else if (item.isVoice) {
+      await _openVoice(item, service);
+    } else {
+      await _openFile(item, service);
+    }
+  }
+
+  Future<void> _openImage(
+    StorageMediaItem item,
+    StorageMediaService service,
+  ) async {
+    if (item.isViewOnce && !item.viewed) {
+      final isSender = item.senderId == widget.userId;
+      if (isSender) return;
+
+      try {
+        final bytes = await service.decryptImageBytes(item);
+        if (!mounted) return;
+        await Navigator.push(
+          context,
+          PrysmPageRoute(
+            page: ViewOnceImageScreen(imageBytes: bytes),
+          ),
+        );
+        await MessagesDb.markViewOnceViewed(
+          item.id,
+          groupId: item.groupId,
+        );
+        if (!mounted) return;
+        _removeItem(item);
+      } catch (e) {
+        if (!mounted) return;
+        showPrysmToast(context, 'Could not open image: $e');
+      }
+      return;
+    }
+
+    await Navigator.push(
+      context,
+      PrysmPageRoute(
+        page: ImageViewerScreen.deferred(
+          messageId: item.id,
+          decryptFromDb: service.decryptCallbackForItem(item),
+        ),
+      ),
+    );
+  }
+
+  Future<void> _openFile(
+    StorageMediaItem item,
+    StorageMediaService service,
+  ) async {
+    final fileName = item.fileName ?? 'file';
+    final category = ReadableFilePolicy.categorize(fileName);
+    await Navigator.push(
+      context,
+      PrysmPageRoute(
+        page: FilePreviewScreen(
+          fileName: fileName,
+          fileSize: item.fileSize,
+          category: category,
+          bytesFuture: service.resolveFileBytes(item),
+        ),
+      ),
+    );
+  }
+
+  Future<void> _openVoice(
+    StorageMediaItem item,
+    StorageMediaService service,
+  ) async {
+    try {
+      final playback = await service.resolveVoicePlayback(item);
+      if (!mounted) return;
+      final message = service.fileMessageForVoice(item, playback);
+      await showPrysmSheet<void>(
+        context: context,
+        builder: (ctx) => SafeArea(
+          child: Padding(
+            padding: const EdgeInsets.all(16),
+            child: VoiceMessageBubble(
+              message: message,
+              isSentByMe: item.senderId == widget.userId,
+              timeString: _formatTime(item.timestamp),
+              tickWidget: const SizedBox.shrink(),
+              decryptAudio: service.voiceDecryptCallback(item),
+            ),
+          ),
+        ),
+      );
+    } catch (e) {
+      if (!mounted) return;
+      showPrysmToast(context, 'Could not play voice message: $e');
+    }
+  }
+
+  Future<void> _deleteItem(StorageMediaItem item) async {
+    final service = _mediaService;
+    if (service == null) return;
+
+    final label = item.fileName ?? (item.isImage ? 'Photo' : 'Media');
+    final confirmed = await showPrysmConfirmDialog(
+      context: context,
+      title: 'Delete media',
+      content: Text(
+        'Delete "$label" from ${item.conversationLabel}? '
+        'This removes it from your device only.',
+      ),
+      cancelLabel: 'Cancel',
+      confirmLabel: 'Delete',
+      confirmVariant: PrysmButtonVariant.danger,
+    );
+    if (confirmed != true || !mounted) return;
+
+    try {
+      await service.deleteLocally(item);
+      if (!mounted) return;
+      _removeItem(item);
+      showPrysmToast(context, 'Media deleted');
+    } catch (e) {
+      if (!mounted) return;
+      showPrysmToast(context, 'Could not delete media: $e');
+    }
+  }
+
+  void _removeItem(StorageMediaItem item) {
+    setState(() {
+      for (final filter in ChatMediaFilter.values) {
+        _itemsByFilter[filter] =
+            _itemsByFilter[filter]!.where((i) => i.id != item.id).toList();
+        final count = _countsByFilter[filter];
+        if (count != null && count > 0) {
+          _countsByFilter[filter] = count - 1;
+        }
+      }
+    });
+  }
+
+  String _formatTime(int timestamp) {
+    final date = DateTime.fromMillisecondsSinceEpoch(timestamp);
+    return '${date.hour.toString().padLeft(2, '0')}:'
+        '${date.minute.toString().padLeft(2, '0')}';
+  }
+
+  String _formatDate(int timestamp) {
+    final date = DateTime.fromMillisecondsSinceEpoch(timestamp);
+    return '${date.year}-${date.month.toString().padLeft(2, '0')}-'
+        '${date.day.toString().padLeft(2, '0')}';
+  }
+
+  IconData _iconFor(StorageMediaItem item) {
+    if (item.isImage) return PrysmIcons.imageOutlined;
+    if (item.isVoice) return PrysmIcons.micOutlined;
+    return PrysmIcons.insertDriveFileOutlined;
+  }
+
+  Widget _buildThumbnail(StorageMediaItem item) {
+    if (!item.isImage || item.isViewOnce) {
+      return Icon(_iconFor(item));
+    }
+
+    final service = _mediaService;
+    if (service == null) return Icon(_iconFor(item));
+
+    return FutureBuilder(
+      future: ImageAttachmentCache.resolve(
+        messageId: item.id,
+        decrypt: service.decryptCallbackForItem(item),
+      ),
+      builder: (context, snapshot) {
+        if (!snapshot.hasData) {
+          return const SizedBox(
+            width: 24,
+            height: 24,
+            child: PrysmProgressIndicator(size: 18),
+          );
+        }
+        final cached = snapshot.data!;
+        return ClipRRect(
+          borderRadius: BorderRadius.circular(4),
+          child: Image.memory(
+            cached.bytes,
+            width: 40,
+            height: 40,
+            fit: BoxFit.cover,
+          ),
+        );
+      },
+    );
+  }
+
+  Widget _buildList(ChatMediaFilter filter) {
+    final items = _itemsByFilter[filter]!;
+    final loadingMore = _loadingByFilter[filter]!;
+    final hasMore = _hasMoreByFilter[filter]!;
+
+    if (items.isEmpty && !loadingMore && !_bootstrapping) {
+      return Center(
+        child: Text(
+          'No media stored',
+          style: TextStyle(color: context.prysmStyle.tokens.textMuted),
+        ),
+      );
+    }
+
+    return ListView.builder(
+      controller: _scrollControllers[filter],
+      padding: const EdgeInsets.all(PrysmTokens.spacing16),
+      itemCount: items.length + (loadingMore || hasMore ? 1 : 0),
+      itemBuilder: (context, index) {
+        if (index >= items.length) {
+          return const Padding(
+            padding: EdgeInsets.all(16),
+            child: Center(child: PrysmProgressIndicator(size: 24)),
+          );
+        }
+
+        final item = items[index];
+        final sizeLabel = item.fileSize != null
+            ? formatFileSize(item.fileSize!)
+            : 'Unknown size';
+
+        return Padding(
+          padding: const EdgeInsets.only(bottom: 8),
+          child: PrysmListRow(
+            leading: SizedBox(width: 40, height: 40, child: _buildThumbnail(item)),
+            title: item.fileName ?? (item.isImage ? 'Photo' : 'Media'),
+            subtitle:
+                '${item.conversationLabel} · $sizeLabel · ${_formatDate(item.timestamp)}',
+            onTap: () => _handleTap(item),
+            trailing: PrysmIconButton(
+              icon: PrysmIcons.deleteOutline,
+              onPressed: () => _deleteItem(item),
+            ),
+          ),
+        );
+      },
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final count = widget.mediaItemCount ??
+        _countsByFilter[ChatMediaFilter.all];
+    final subtitle = count != null ? '$count items' : null;
+
+    return PrysmPage(
+      title: 'Chat Media',
+      subtitle: subtitle,
+      headerHeight: 70,
+      leading: PrysmIconButton(
+        icon: PrysmIcons.arrowBack,
+        onPressed: widget.onClose,
+      ),
+      bottom: PrysmTabBar(
+        controller: _tabController,
+        tabs: const ['All', 'Photos', 'Files', 'Voice'],
+      ),
+      body: _bootstrapping
+          ? const Center(child: PrysmProgressIndicator())
+          : PrysmTabBarView(
+              controller: _tabController,
+              children: ChatMediaFilter.values
+                  .map((filter) => _buildList(filter))
+                  .toList(),
+            ),
+    );
+  }
+}

--- a/lib/screens/widgets/file_attachment_bubble.dart
+++ b/lib/screens/widgets/file_attachment_bubble.dart
@@ -11,6 +11,7 @@ import 'package:prysm/screens/widgets/file_preview_content.dart';
 import 'package:prysm/services/file_preview_service.dart';
 import 'package:prysm/services/settings_service.dart';
 import 'package:prysm/util/file_download_helper.dart';
+import 'package:prysm/util/format_file_size.dart';
 import 'package:prysm/util/readable_file_policy.dart';
 import 'package:prysm/ui/chat/prysm_bubble_renderer.dart';
 import 'package:prysm/ui/core/prysm_button.dart';
@@ -314,11 +315,7 @@ class _FileAttachmentBubbleState extends State<FileAttachmentBubble> {
 
   String get _fileSizeString {
     if (widget.fileSize == null) return '';
-    final sizeInKB = widget.fileSize! / 1024;
-    if (sizeInKB < 1024) {
-      return '${sizeInKB.toStringAsFixed(1)} KB';
-    }
-    return '${(sizeInKB / 1024).toStringAsFixed(1)} MB';
+    return formatFileSize(widget.fileSize!);
   }
 
   bool get _hasTappablePreview =>

--- a/lib/services/image_attachment_cache.dart
+++ b/lib/services/image_attachment_cache.dart
@@ -213,6 +213,26 @@ class ImageAttachmentCache {
     } catch (_) {}
   }
 
+  /// Wipes in-memory and on-disk image decrypt caches.
+  static Future<void> clearAll() async {
+    _memory.clear();
+    _memoryOrder.clear();
+    _inflight.clear();
+    try {
+      final dirPath = await _cacheDir();
+      final dir = Directory(dirPath);
+      if (await dir.exists()) {
+        await for (final entity in dir.list(followLinks: false)) {
+          if (entity is File) {
+            try {
+              await entity.delete();
+            } catch (_) {}
+          }
+        }
+      }
+    } catch (_) {}
+  }
+
   @visibleForTesting
   static void resetForTest() {
     _memory.clear();

--- a/lib/services/storage_media_service.dart
+++ b/lib/services/storage_media_service.dart
@@ -1,0 +1,111 @@
+import 'dart:typed_data';
+
+import 'package:prysm/database/messages.dart';
+import 'package:prysm/models/chat/prysm_message.dart';
+import 'package:prysm/models/chat_media_item.dart';
+import 'package:prysm/models/storage_media_item.dart';
+import 'package:prysm/services/chat_media_service.dart';
+import 'package:prysm/services/group_service.dart';
+import 'package:prysm/util/key_manager.dart';
+import 'package:prysm/util/message_content_wiper.dart';
+
+/// Loads and manages media across every conversation for the storage browser.
+class StorageMediaService {
+  final KeyManager keyManager;
+  final String userId;
+  final GroupService groupService;
+  final Map<String, String> contactNames;
+  final Map<String, String> groupNames;
+
+  StorageMediaService({
+    required this.keyManager,
+    required this.userId,
+    required this.groupService,
+    required this.contactNames,
+    required this.groupNames,
+  });
+
+  Future<List<StorageMediaItem>> loadPage(
+    ChatMediaFilter filter, {
+    int limit = 50,
+    int? beforeTimestamp,
+  }) async {
+    final rows = await MessagesDb.getAllMediaMessages(
+      types: globalTypesForFilter(filter),
+      limit: limit,
+      beforeTimestamp: beforeTimestamp,
+    );
+    return rows
+        .map(
+          (row) => StorageMediaItem.fromRow(
+            row,
+            userId: userId,
+            contactNames: contactNames,
+            groupNames: groupNames,
+          ),
+        )
+        .toList();
+  }
+
+  Future<int> countMedia(ChatMediaFilter filter) {
+    return MessagesDb.countAllMediaMessages(
+      types: globalTypesForFilter(filter),
+    );
+  }
+
+  ChatMediaService _scopedService(StorageMediaItem item) {
+    if (item.isGroup) {
+      return ChatMediaService.group(
+        keyManager: keyManager,
+        userId: userId,
+        groupId: item.groupId!,
+        groupService: groupService,
+      );
+    }
+    return ChatMediaService.direct(
+      keyManager: keyManager,
+      userId: userId,
+      peerId: item.peerId!,
+    );
+  }
+
+  Future<Uint8List> decryptImageBytes(StorageMediaItem item) {
+    return _scopedService(item).decryptImageBytes(item.toChatMediaItem());
+  }
+
+  Future<Uint8List> resolveFileBytes(StorageMediaItem item) {
+    return _scopedService(item).resolveFileBytes(item.toChatMediaItem());
+  }
+
+  Future<VoicePlaybackInfo> resolveVoicePlayback(StorageMediaItem item) {
+    return _scopedService(item)
+        .resolveVoicePlayback(item.toChatMediaItem());
+  }
+
+  Future<Uint8List> Function() decryptCallbackForItem(StorageMediaItem item) {
+    return _scopedService(item)
+        .decryptCallbackForItem(item.toChatMediaItem());
+  }
+
+  Future<Uint8List?> Function(String encryptedSource)? voiceDecryptCallback(
+    StorageMediaItem item,
+  ) {
+    return _scopedService(item).voiceDecryptCallback();
+  }
+
+  FileMessage fileMessageForVoice(
+    StorageMediaItem item,
+    VoicePlaybackInfo playback,
+  ) {
+    return _scopedService(item)
+        .fileMessageForVoice(item.toChatMediaItem(), playback);
+  }
+
+  Future<void> deleteLocally(StorageMediaItem item) async {
+    await MessageContentWiper.wipeLocalArtifacts(
+      wireId: item.id,
+      groupId: item.groupId,
+    );
+    await MessagesDb.hardDeleteMessage(item.id, groupId: item.groupId);
+  }
+}

--- a/lib/services/storage_media_service.dart
+++ b/lib/services/storage_media_service.dart
@@ -29,11 +29,13 @@ class StorageMediaService {
     ChatMediaFilter filter, {
     int limit = 50,
     int? beforeTimestamp,
+    String? beforeId,
   }) async {
     final rows = await MessagesDb.getAllMediaMessages(
       types: globalTypesForFilter(filter),
       limit: limit,
       beforeTimestamp: beforeTimestamp,
+      beforeId: beforeId,
     );
     return rows
         .map(

--- a/lib/services/storage_usage_service.dart
+++ b/lib/services/storage_usage_service.dart
@@ -114,13 +114,21 @@ class StorageUsageService {
     return entries;
   }
 
+  static Future<int> _fileBytes(File file) async {
+    try {
+      return await file.length();
+    } on FileSystemException {
+      return 0;
+    }
+  }
+
   static Future<int> _messagesDatabaseBytes(Directory prysmDir) async {
     if (!await prysmDir.exists()) return 0;
     var total = 0;
     for (final name in ['messages.db', 'messages.db-wal', 'messages.db-shm']) {
       final file = File(p.join(prysmDir.path, name));
       if (await file.exists()) {
-        total += await file.length();
+        total += await _fileBytes(file);
       }
     }
     return total;
@@ -133,7 +141,10 @@ class StorageUsageService {
     var total = 0;
 
     if (await prysmDir.exists()) {
-      await for (final entity in prysmDir.list(recursive: true)) {
+      await for (final entity in prysmDir.list(
+        recursive: true,
+        followLinks: false,
+      )) {
         if (entity is! File) continue;
         final base = p.basename(entity.path);
         if (base == 'messages.db' ||
@@ -141,7 +152,7 @@ class StorageUsageService {
             base == 'messages.db-shm') {
           continue;
         }
-        total += await entity.length();
+        total += await _fileBytes(entity);
       }
     }
 
@@ -160,7 +171,7 @@ class StorageUsageService {
     var total = 0;
     await for (final entity in dir.list(followLinks: false)) {
       if (entity is File && !entity.path.endsWith('.prysmbackup')) {
-        total += await entity.length();
+        total += await _fileBytes(entity);
       }
     }
     return total;
@@ -171,7 +182,7 @@ class StorageUsageService {
     var total = 0;
     await for (final entity in dir.list(recursive: true, followLinks: false)) {
       if (entity is File) {
-        total += await entity.length();
+        total += await _fileBytes(entity);
       }
     }
     return total;
@@ -187,7 +198,7 @@ class StorageUsageService {
       if (entity is! File) continue;
       final name = p.basename(entity.path);
       if (_voiceCachePattern.hasMatch(name)) {
-        total += await entity.length();
+        total += await _fileBytes(entity);
       }
     }
     return total;

--- a/lib/services/storage_usage_service.dart
+++ b/lib/services/storage_usage_service.dart
@@ -1,0 +1,208 @@
+import 'dart:io';
+
+import 'package:flutter/foundation.dart';
+import 'package:path/path.dart' as p;
+import 'package:path_provider/path_provider.dart';
+import 'package:prysm/services/image_attachment_cache.dart';
+import 'package:prysm/util/download_location.dart';
+
+/// A file in the user downloads folder surfaced by the storage manager.
+class DownloadedFileEntry {
+  final String name;
+  final String path;
+  final int bytes;
+  final DateTime modifiedAt;
+
+  const DownloadedFileEntry({
+    required this.name,
+    required this.path,
+    required this.bytes,
+    required this.modifiedAt,
+  });
+}
+
+/// Disk usage broken down by storage category.
+class StorageUsageBreakdown {
+  final int messagesDatabaseBytes;
+  final int messageBlobsBytes;
+  final int imageCacheBytes;
+  final int voiceCacheBytes;
+  final int downloadsBytes;
+  final int otherAppDataBytes;
+
+  const StorageUsageBreakdown({
+    required this.messagesDatabaseBytes,
+    required this.messageBlobsBytes,
+    required this.imageCacheBytes,
+    required this.voiceCacheBytes,
+    required this.downloadsBytes,
+    required this.otherAppDataBytes,
+  });
+
+  int get cacheBytes => imageCacheBytes + voiceCacheBytes;
+
+  int get chatMediaBytes => messagesDatabaseBytes + messageBlobsBytes;
+
+  int get totalBytes =>
+      messagesDatabaseBytes +
+      messageBlobsBytes +
+      imageCacheBytes +
+      voiceCacheBytes +
+      downloadsBytes +
+      otherAppDataBytes;
+}
+
+/// Computes on-disk usage and manages ephemeral caches.
+class StorageUsageService {
+  StorageUsageService._();
+
+  static final _voiceCachePattern = RegExp(
+    r'(?:voice_cache_|group_voice_cache_|direct_voice_|group_voice_).+\.wav$',
+  );
+
+  static Future<StorageUsageBreakdown> compute() async {
+    final docDir = await getApplicationDocumentsDirectory();
+    final tempDir = await getTemporaryDirectory();
+    final prysmDir = Directory(p.join(docDir.path, 'prysm'));
+    final blobsDir = Directory(p.join(docDir.path, 'message_blobs'));
+    final imgCacheDir = Directory(p.join(tempDir.path, 'img_cache'));
+
+    final results = await Future.wait([
+      _messagesDatabaseBytes(prysmDir),
+      _directorySize(blobsDir),
+      _directorySize(imgCacheDir),
+      _voiceCacheBytes(tempDir),
+      _downloadsBytes(),
+      _otherAppDataBytes(prysmDir, docDir.path),
+    ]);
+
+    return StorageUsageBreakdown(
+      messagesDatabaseBytes: results[0],
+      messageBlobsBytes: results[1],
+      imageCacheBytes: results[2],
+      voiceCacheBytes: results[3],
+      downloadsBytes: results[4],
+      otherAppDataBytes: results[5],
+    );
+  }
+
+  static Future<void> clearEphemeralCaches() async {
+    await ImageAttachmentCache.clearAll();
+    final tempDir = await getTemporaryDirectory();
+    await _deleteVoiceCacheFiles(tempDir);
+  }
+
+  static Future<List<DownloadedFileEntry>> listDownloadedFiles() async {
+    final dir = await DownloadLocation.resolveDirectory();
+    if (dir == null || !await dir.exists()) return [];
+
+    final entries = <DownloadedFileEntry>[];
+    await for (final entity in dir.list(followLinks: false)) {
+      if (entity is! File) continue;
+      if (entity.path.endsWith('.prysmbackup')) continue;
+      final stat = await entity.stat();
+      entries.add(
+        DownloadedFileEntry(
+          name: p.basename(entity.path),
+          path: entity.path,
+          bytes: stat.size,
+          modifiedAt: stat.modified,
+        ),
+      );
+    }
+    entries.sort((a, b) => b.bytes.compareTo(a.bytes));
+    return entries;
+  }
+
+  static Future<int> _messagesDatabaseBytes(Directory prysmDir) async {
+    if (!await prysmDir.exists()) return 0;
+    var total = 0;
+    for (final name in ['messages.db', 'messages.db-wal', 'messages.db-shm']) {
+      final file = File(p.join(prysmDir.path, name));
+      if (await file.exists()) {
+        total += await file.length();
+      }
+    }
+    return total;
+  }
+
+  static Future<int> _otherAppDataBytes(
+    Directory prysmDir,
+    String docPath,
+  ) async {
+    var total = 0;
+
+    if (await prysmDir.exists()) {
+      await for (final entity in prysmDir.list(recursive: true)) {
+        if (entity is! File) continue;
+        final base = p.basename(entity.path);
+        if (base == 'messages.db' ||
+            base == 'messages.db-wal' ||
+            base == 'messages.db-shm') {
+          continue;
+        }
+        total += await entity.length();
+      }
+    }
+
+    final legacyBackups = Directory(p.join(docPath, 'prysm_backups'));
+    if (await legacyBackups.exists()) {
+      total += await _directorySize(legacyBackups);
+    }
+
+    return total;
+  }
+
+  static Future<int> _downloadsBytes() async {
+    final dir = await DownloadLocation.resolveDirectory();
+    if (dir == null || !await dir.exists()) return 0;
+
+    var total = 0;
+    await for (final entity in dir.list(followLinks: false)) {
+      if (entity is File && !entity.path.endsWith('.prysmbackup')) {
+        total += await entity.length();
+      }
+    }
+    return total;
+  }
+
+  static Future<int> _directorySize(Directory dir) async {
+    if (!await dir.exists()) return 0;
+    var total = 0;
+    await for (final entity in dir.list(recursive: true, followLinks: false)) {
+      if (entity is File) {
+        total += await entity.length();
+      }
+    }
+    return total;
+  }
+
+  @visibleForTesting
+  static Future<int> directorySizeForTest(Directory dir) => _directorySize(dir);
+
+  static Future<int> _voiceCacheBytes(Directory tempDir) async {
+    if (!await tempDir.exists()) return 0;
+    var total = 0;
+    await for (final entity in tempDir.list(followLinks: false)) {
+      if (entity is! File) continue;
+      final name = p.basename(entity.path);
+      if (_voiceCachePattern.hasMatch(name)) {
+        total += await entity.length();
+      }
+    }
+    return total;
+  }
+
+  static Future<void> _deleteVoiceCacheFiles(Directory tempDir) async {
+    if (!await tempDir.exists()) return;
+    await for (final entity in tempDir.list(followLinks: false)) {
+      if (entity is! File) continue;
+      final name = p.basename(entity.path);
+      if (_voiceCachePattern.hasMatch(name)) {
+        try {
+          await entity.delete();
+        } catch (_) {}
+      }
+    }
+  }
+}

--- a/lib/util/format_file_size.dart
+++ b/lib/util/format_file_size.dart
@@ -1,0 +1,10 @@
+/// Formats a byte count for display (KB / MB).
+String formatFileSize(int bytes) {
+  if (bytes < 0) return '0 B';
+  if (bytes < 1024) return '$bytes B';
+  final sizeInKB = bytes / 1024;
+  if (sizeInKB < 1024) {
+    return '${sizeInKB.toStringAsFixed(1)} KB';
+  }
+  return '${(sizeInKB / 1024).toStringAsFixed(1)} MB';
+}

--- a/lib/util/network_reachability.dart
+++ b/lib/util/network_reachability.dart
@@ -27,12 +27,15 @@ class NetworkReachability {
   static Future<List<ConnectivityResult>> Function() checkConnectivity =
       () => Connectivity().checkConnectivity();
 
-  /// Injectable network interface listing for tests.
-  static Future<List<NetworkInterface>> Function() listNetworkInterfaces =
-      () => NetworkInterface.list(
-        type: InternetAddressType.IPv4,
-        includeLinkLocal: true,
-      );
+  /// Injectable local address listing for tests.
+  static Future<List<InternetAddress>> Function() listNetworkAddresses =
+      () async {
+    final interfaces = await NetworkInterface.list(
+      type: InternetAddressType.IPv4,
+      includeLinkLocal: true,
+    );
+    return [for (final iface in interfaces) ...iface.addresses];
+  };
 
   /// Injectable desktop flag for tests. Defaults to [isDesktopPlatform].
   static bool isDesktop = isDesktopPlatform;
@@ -55,13 +58,13 @@ class NetworkReachability {
         isDesktop ? _desktopLinkUpTransports : _linkUpTransports;
 
     if (results.any(linkUpTransports.contains)) {
-      return _hasNonLoopbackInterface();
+      return _hasNonLoopbackAddress();
     }
 
     // connectivity_plus on Linux requires NetworkManager; fall back to
     // interface checks on desktop when NM is absent (e.g. systemd-networkd).
     if (isDesktop) {
-      return _hasNonLoopbackInterface();
+      return _hasNonLoopbackAddress();
     }
 
     return false;
@@ -75,10 +78,8 @@ class NetworkReachability {
     }
   }
 
-  static Future<bool> _hasNonLoopbackInterface() async {
-    final interfaces = await listNetworkInterfaces();
-    return interfaces.any(
-      (iface) => iface.addresses.any((addr) => !addr.isLoopback),
-    );
+  static Future<bool> _hasNonLoopbackAddress() async {
+    final addresses = await listNetworkAddresses();
+    return addresses.any((addr) => !addr.isLoopback);
   }
 }

--- a/test/format_file_size_test.dart
+++ b/test/format_file_size_test.dart
@@ -1,0 +1,21 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:prysm/util/format_file_size.dart';
+
+void main() {
+  group('formatFileSize', () {
+    test('formats bytes', () {
+      expect(formatFileSize(0), '0 B');
+      expect(formatFileSize(512), '512 B');
+    });
+
+    test('formats kilobytes', () {
+      expect(formatFileSize(1024), '1.0 KB');
+      expect(formatFileSize(1536), '1.5 KB');
+    });
+
+    test('formats megabytes', () {
+      expect(formatFileSize(1024 * 1024), '1.0 MB');
+      expect(formatFileSize(1024 * 1024 * 3), '3.0 MB');
+    });
+  });
+}

--- a/test/media_gallery_queries_dao_test.dart
+++ b/test/media_gallery_queries_dao_test.dart
@@ -283,6 +283,32 @@ void main() {
       expect(page.map((r) => r['id']), ['m200', 'm100']);
     });
 
+    test('beforeTimestamp with beforeId continues across equal timestamps',
+        () async {
+      for (final id in ['m-a', 'm-b', 'm-c']) {
+        await db.insert('messages', {
+          'id': id,
+          'senderId': 'peer',
+          'receiverId': 'me',
+          'message': 'cipher',
+          'type': 'image',
+          'timestamp': 100,
+          'status': 'received',
+        });
+      }
+
+      final first = await MessagesDb.getAllMediaMessages(limit: 2);
+      expect(first.map((r) => r['id']), ['m-c', 'm-b']);
+
+      final last = first.last;
+      final next = await MessagesDb.getAllMediaMessages(
+        limit: 2,
+        beforeTimestamp: last['timestamp'] as int,
+        beforeId: last['id'] as String,
+      );
+      expect(next.map((r) => r['id']), ['m-a']);
+    });
+
     test('countAllMediaMessages matches filtered rows', () async {
       await db.insert('messages', {
         'id': 'img',

--- a/test/media_gallery_queries_dao_test.dart
+++ b/test/media_gallery_queries_dao_test.dart
@@ -309,6 +309,23 @@ void main() {
       expect(next.map((r) => r['id']), ['m-a']);
     });
 
+    test('beforeId without beforeTimestamp is rejected', () async {
+      await db.insert('messages', {
+        'id': 'm-a',
+        'senderId': 'peer',
+        'receiverId': 'me',
+        'message': 'cipher',
+        'type': 'image',
+        'timestamp': 100,
+        'status': 'received',
+      });
+
+      expect(
+        () => MessagesDb.getAllMediaMessages(beforeId: 'm-a'),
+        throwsArgumentError,
+      );
+    });
+
     test('countAllMediaMessages matches filtered rows', () async {
       await db.insert('messages', {
         'id': 'img',

--- a/test/media_gallery_queries_dao_test.dart
+++ b/test/media_gallery_queries_dao_test.dart
@@ -202,4 +202,112 @@ void main() {
       expect(rows.map((r) => r['id']), ['g1']);
     });
   });
+
+  group('getAllMediaMessages', () {
+    test('returns direct and group media, newest first', () async {
+      await db.insert('messages', {
+        'id': 'dm-img',
+        'senderId': 'peer',
+        'receiverId': 'me',
+        'message': 'cipher',
+        'type': 'image',
+        'timestamp': 100,
+        'status': 'received',
+      });
+      await db.insert('messages', {
+        'id': 'grp-file',
+        'senderId': 'alice',
+        'receiverId': 'me',
+        'groupId': 'grp1',
+        'message': 'cipher',
+        'type': 'group_file',
+        'fileName': 'doc.pdf',
+        'timestamp': 200,
+        'status': 'received',
+      });
+      await db.insert('messages', {
+        'id': 'txt',
+        'senderId': 'peer',
+        'receiverId': 'me',
+        'message': 'hello',
+        'type': 'text',
+        'timestamp': 300,
+        'status': 'received',
+      });
+
+      final rows = await MessagesDb.getAllMediaMessages();
+      expect(rows.map((r) => r['id']), ['grp-file', 'dm-img']);
+    });
+
+    test('types filter narrows to matching media kinds', () async {
+      await db.insert('messages', {
+        'id': 'img',
+        'senderId': 'peer',
+        'receiverId': 'me',
+        'message': 'cipher',
+        'type': 'image',
+        'timestamp': 100,
+        'status': 'received',
+      });
+      await db.insert('messages', {
+        'id': 'aud',
+        'senderId': 'peer',
+        'receiverId': 'me',
+        'message': 'cipher',
+        'type': 'audio',
+        'timestamp': 200,
+        'status': 'received',
+      });
+
+      final rows = await MessagesDb.getAllMediaMessages(
+        types: ['audio', 'group_audio'],
+      );
+      expect(rows, hasLength(1));
+      expect(rows.first['id'], 'aud');
+    });
+
+    test('beforeTimestamp paginates older results', () async {
+      for (final ts in [100, 200, 300]) {
+        await db.insert('messages', {
+          'id': 'm$ts',
+          'senderId': 'peer',
+          'receiverId': 'me',
+          'message': 'cipher',
+          'type': 'image',
+          'timestamp': ts,
+          'status': 'received',
+        });
+      }
+
+      final page = await MessagesDb.getAllMediaMessages(beforeTimestamp: 300);
+      expect(page.map((r) => r['id']), ['m200', 'm100']);
+    });
+
+    test('countAllMediaMessages matches filtered rows', () async {
+      await db.insert('messages', {
+        'id': 'img',
+        'senderId': 'peer',
+        'receiverId': 'me',
+        'message': 'cipher',
+        'type': 'image',
+        'timestamp': 100,
+        'status': 'received',
+      });
+      await db.insert('messages', {
+        'id': 'file',
+        'senderId': 'peer',
+        'receiverId': 'me',
+        'message': 'cipher',
+        'type': 'file',
+        'timestamp': 200,
+        'status': 'received',
+      });
+
+      expect(await MessagesDb.countAllMediaMessages(), 2);
+      expect(
+        await MessagesDb.countAllMediaMessages(types: ['file', 'group_file']),
+        1,
+      );
+    });
+  });
 }

--- a/test/network_reachability_test.dart
+++ b/test/network_reachability_test.dart
@@ -1,76 +1,21 @@
 import 'dart:io';
-import 'dart:typed_data';
 
 import 'package:connectivity_plus/connectivity_plus.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:prysm/util/network_reachability.dart';
 
-class _FakeInterfaceAddress implements InterfaceAddress {
-  _FakeInterfaceAddress(String host) : _addr = InternetAddress(host);
-
-  final InternetAddress _addr;
-
-  @override
-  int get prefixLength => 24;
-
-  @override
-  InternetAddress? get broadcast => null;
-
-  @override
-  InternetAddressType get type => _addr.type;
-
-  @override
-  String get address => _addr.address;
-
-  @override
-  String get host => _addr.host;
-
-  @override
-  Uint8List get rawAddress => _addr.rawAddress;
-
-  @override
-  bool get isLoopback => _addr.isLoopback;
-
-  @override
-  bool get isLinkLocal => _addr.isLinkLocal;
-
-  @override
-  bool get isMulticast => _addr.isMulticast;
-
-  @override
-  Future<InternetAddress> reverse() => _addr.reverse();
-}
-
-class _FakeNetworkInterface implements NetworkInterface {
-  _FakeNetworkInterface(String host)
-      : _addresses = [_FakeInterfaceAddress(host)];
-
-  final List<InterfaceAddress> _addresses;
-
-  @override
-  List<InterfaceAddress> get addresses => _addresses;
-
-  @override
-  int get index => 1;
-
-  @override
-  String get name => 'fake0';
-}
-
-List<NetworkInterface> _ifaces(String host) => [
-      _FakeNetworkInterface(host),
-    ];
+List<InternetAddress> _addrs(String host) => [InternetAddress(host)];
 
 void main() {
   final originalProbe = NetworkReachability.probe;
   final originalCheckConnectivity = NetworkReachability.checkConnectivity;
-  final originalListNetworkInterfaces = NetworkReachability.listNetworkInterfaces;
+  final originalListNetworkAddresses = NetworkReachability.listNetworkAddresses;
   final originalIsDesktop = NetworkReachability.isDesktop;
 
   tearDown(() {
     NetworkReachability.probe = originalProbe;
     NetworkReachability.checkConnectivity = originalCheckConnectivity;
-    NetworkReachability.listNetworkInterfaces = originalListNetworkInterfaces;
+    NetworkReachability.listNetworkAddresses = originalListNetworkAddresses;
     NetworkReachability.isDesktop = originalIsDesktop;
   });
 
@@ -106,12 +51,12 @@ void main() {
 
     Future<bool> runDefaultProbe({
       required List<ConnectivityResult> connectivity,
-      required List<NetworkInterface> interfaces,
+      required List<InternetAddress> addresses,
       bool isDesktop = true,
     }) async {
       NetworkReachability.isDesktop = isDesktop;
       NetworkReachability.checkConnectivity = () async => connectivity;
-      NetworkReachability.listNetworkInterfaces = () async => interfaces;
+      NetworkReachability.listNetworkAddresses = () async => addresses;
       return NetworkReachability.hasInternet();
     }
 
@@ -119,7 +64,7 @@ void main() {
       expect(
         await runDefaultProbe(
           connectivity: [ConnectivityResult.wifi],
-          interfaces: _ifaces('192.168.1.5'),
+          addresses: _addrs('192.168.1.5'),
         ),
         isTrue,
       );
@@ -129,7 +74,7 @@ void main() {
       expect(
         await runDefaultProbe(
           connectivity: [ConnectivityResult.mobile],
-          interfaces: _ifaces('10.0.0.2'),
+          addresses: _addrs('10.0.0.2'),
         ),
         isTrue,
       );
@@ -139,7 +84,7 @@ void main() {
       expect(
         await runDefaultProbe(
           connectivity: [ConnectivityResult.ethernet],
-          interfaces: _ifaces('192.168.0.10'),
+          addresses: _addrs('192.168.0.10'),
         ),
         isTrue,
       );
@@ -149,7 +94,7 @@ void main() {
       expect(
         await runDefaultProbe(
           connectivity: [ConnectivityResult.none],
-          interfaces: _ifaces('192.168.1.5'),
+          addresses: _addrs('192.168.1.5'),
           isDesktop: false,
         ),
         isFalse,
@@ -160,7 +105,7 @@ void main() {
       expect(
         await runDefaultProbe(
           connectivity: [ConnectivityResult.none],
-          interfaces: _ifaces('192.168.1.71'),
+          addresses: _addrs('192.168.1.71'),
           isDesktop: true,
         ),
         isTrue,
@@ -172,8 +117,8 @@ void main() {
       NetworkReachability.checkConnectivity = () async {
         throw Exception('NetworkManager unavailable');
       };
-      NetworkReachability.listNetworkInterfaces =
-          () async => _ifaces('192.168.1.71');
+      NetworkReachability.listNetworkAddresses =
+          () async => _addrs('192.168.1.71');
 
       expect(await NetworkReachability.hasInternet(), isTrue);
     });
@@ -182,7 +127,7 @@ void main() {
       expect(
         await runDefaultProbe(
           connectivity: [ConnectivityResult.wifi],
-          interfaces: _ifaces('127.0.0.1'),
+          addresses: _addrs('127.0.0.1'),
         ),
         isFalse,
       );
@@ -192,7 +137,7 @@ void main() {
       expect(
         await runDefaultProbe(
           connectivity: [ConnectivityResult.vpn],
-          interfaces: _ifaces('192.168.1.5'),
+          addresses: _addrs('192.168.1.5'),
           isDesktop: false,
         ),
         isFalse,
@@ -203,7 +148,7 @@ void main() {
       expect(
         await runDefaultProbe(
           connectivity: [ConnectivityResult.other],
-          interfaces: _ifaces('192.168.1.5'),
+          addresses: _addrs('192.168.1.5'),
           isDesktop: true,
         ),
         isTrue,

--- a/test/network_reachability_test.dart
+++ b/test/network_reachability_test.dart
@@ -1,16 +1,54 @@
 import 'dart:io';
+import 'dart:typed_data';
 
 import 'package:connectivity_plus/connectivity_plus.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:prysm/util/network_reachability.dart';
 
-class _FakeNetworkInterface implements NetworkInterface {
-  _FakeNetworkInterface(this._addresses);
+class _FakeInterfaceAddress implements InterfaceAddress {
+  _FakeInterfaceAddress(String host) : _addr = InternetAddress(host);
 
-  final List<InternetAddress> _addresses;
+  final InternetAddress _addr;
 
   @override
-  List<InternetAddress> get addresses => _addresses;
+  int get prefixLength => 24;
+
+  @override
+  InternetAddress? get broadcast => null;
+
+  @override
+  InternetAddressType get type => _addr.type;
+
+  @override
+  String get address => _addr.address;
+
+  @override
+  String get host => _addr.host;
+
+  @override
+  Uint8List get rawAddress => _addr.rawAddress;
+
+  @override
+  bool get isLoopback => _addr.isLoopback;
+
+  @override
+  bool get isLinkLocal => _addr.isLinkLocal;
+
+  @override
+  bool get isMulticast => _addr.isMulticast;
+
+  @override
+  Future<InternetAddress> reverse() => _addr.reverse();
+}
+
+class _FakeNetworkInterface implements NetworkInterface {
+  _FakeNetworkInterface(String host)
+      : _addresses = [_FakeInterfaceAddress(host)];
+
+  final List<InterfaceAddress> _addresses;
+
+  @override
+  List<InterfaceAddress> get addresses => _addresses;
 
   @override
   int get index => 1;
@@ -20,8 +58,8 @@ class _FakeNetworkInterface implements NetworkInterface {
 }
 
 List<NetworkInterface> _ifaces(String host) => [
-  _FakeNetworkInterface([InternetAddress(host)]),
-];
+      _FakeNetworkInterface(host),
+    ];
 
 void main() {
   final originalProbe = NetworkReachability.probe;

--- a/test/storage_usage_service_test.dart
+++ b/test/storage_usage_service_test.dart
@@ -1,0 +1,47 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:prysm/services/storage_usage_service.dart';
+
+void main() {
+  late Directory tempRoot;
+
+  setUp(() async {
+    tempRoot = await Directory.systemTemp.createTemp('prysm_storage_test_');
+  });
+
+  tearDown(() async {
+    if (await tempRoot.exists()) {
+      await tempRoot.delete(recursive: true);
+    }
+  });
+
+  test('directorySizeForTest counts nested files', () async {
+    final nested = Directory('${tempRoot.path}/nested');
+    await nested.create(recursive: true);
+    await File('${nested.path}/a.bin').writeAsBytes(List.filled(100, 0));
+    await File('${nested.path}/b.bin').writeAsBytes(List.filled(50, 0));
+
+    final size = await StorageUsageService.directorySizeForTest(nested);
+    expect(size, 150);
+  });
+
+  test('listDownloadedFiles excludes backup files', () async {
+    final entries = [
+      DownloadedFileEntry(
+        name: 'small.txt',
+        path: '/tmp/small.txt',
+        bytes: 10,
+        modifiedAt: DateTime(2024),
+      ),
+      DownloadedFileEntry(
+        name: 'large.zip',
+        path: '/tmp/large.zip',
+        bytes: 1000,
+        modifiedAt: DateTime(2025),
+      ),
+    ]..sort((a, b) => b.bytes.compareTo(a.bytes));
+
+    expect(entries.first.name, 'large.zip');
+  });
+}

--- a/test/storage_usage_service_test.dart
+++ b/test/storage_usage_service_test.dart
@@ -1,6 +1,7 @@
 import 'dart:io';
 
 import 'package:flutter_test/flutter_test.dart';
+import 'package:prysm/services/settings_service.dart';
 import 'package:prysm/services/storage_usage_service.dart';
 
 void main() {
@@ -8,9 +9,11 @@ void main() {
 
   setUp(() async {
     tempRoot = await Directory.systemTemp.createTemp('prysm_storage_test_');
+    await SettingsService().setCustomDownloadPath(tempRoot.path);
   });
 
   tearDown(() async {
+    await SettingsService().clearCustomDownloadPath();
     if (await tempRoot.exists()) {
       await tempRoot.delete(recursive: true);
     }
@@ -26,22 +29,17 @@ void main() {
     expect(size, 150);
   });
 
-  test('listDownloadedFiles excludes backup files', () async {
-    final entries = [
-      DownloadedFileEntry(
-        name: 'small.txt',
-        path: '/tmp/small.txt',
-        bytes: 10,
-        modifiedAt: DateTime(2024),
-      ),
-      DownloadedFileEntry(
-        name: 'large.zip',
-        path: '/tmp/large.zip',
-        bytes: 1000,
-        modifiedAt: DateTime(2025),
-      ),
-    ]..sort((a, b) => b.bytes.compareTo(a.bytes));
+  test('listDownloadedFiles excludes backup files and sorts by size desc', () async {
+    await File('${tempRoot.path}/small.txt').writeAsString('0123456789');
+    await File('${tempRoot.path}/large.zip').writeAsString('z' * 1000);
+    await File('${tempRoot.path}/backup.prysmbackup').writeAsString('b' * 500);
+    await File('${tempRoot.path}/nested.txt').writeAsString('x');
+    await Directory('${tempRoot.path}/sub').create();
 
-    expect(entries.first.name, 'large.zip');
+    final entries = await StorageUsageService.listDownloadedFiles();
+
+    expect(entries.map((e) => e.name), ['large.zip', 'small.txt', 'nested.txt']);
+    expect(entries.map((e) => e.name), isNot(contains('backup.prysmbackup')));
+    expect(entries.map((e) => e.bytes), [1000, 10, 1]);
   });
 }


### PR DESCRIPTION
- Added `StorageMediaItem` model to represent media items in storage.
- Introduced `StorageMediaService` for loading and managing media across conversations.
- Implemented `DataStorageScreen` for displaying storage usage and managing media.
- Created `DownloadsFilesScreen` to list and manage downloaded files.
- Enhanced `MessagesDb` with methods to retrieve all media messages and count them.
- Updated UI components to integrate new storage management features.
- Added utility functions for formatting file sizes and managing storage usage.

This commit enhances the app's media handling capabilities, allowing users to better manage their storage and access media files efficiently.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Storage Manager showing disk usage by category and allowing temporary cache cleanup.
  * Added browsing of stored media across all chats, including photos, files, and voice messages.
  * Added media filtering, pagination, previews, playback, and local deletion.
  * Added a Downloads browser with file opening, metadata, and deletion support.
* **Bug Fixes**
  * Improved consistency of file-size formatting.
* **Tests**
  * Expanded coverage for media retrieval, storage calculations, file ordering, and size formatting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->