### PR TITLE
refactor(transfer): drop two comment claims and the unread fake-call fields

### DIFF
--- a/lib/services/chat_service.dart
+++ b/lib/services/chat_service.dart
@@ -691,9 +691,7 @@ class ChatService {
     if (!FileTransferPolicy.isChunkCandidate(fileSize)) return false;
 
     // A cold link reads wsConnected=false and an empty capability map until
-    // the handshake runs, so bring the link up before evaluating the
-    // predicate; the monolithic fallback pays this same connect budget and
-    // discards the link. This pins the peer and clears its backoff/quarantine.
+    // the handshake runs, so bring the link up before evaluating the predicate.
     try {
       await TransportProvider.instance.wsManager.prepareForFileTransfer(peerId);
     } catch (e) {

--- a/lib/util/file_transfer_policy.dart
+++ b/lib/util/file_transfer_policy.dart
@@ -24,8 +24,6 @@ class FileTransferPolicy {
   /// Per-chunk send retries before failing the transfer.
   static const int maxChunkRetries = 3;
 
-  /// True when [fileSizeBytes] reaches the chunked-transfer threshold.
-  /// Shared with the call-site size gate so the threshold has one home.
   static bool isChunkCandidate(int fileSizeBytes) =>
       fileSizeBytes >= chunkThresholdBytes;
 

--- a/test/chat_service_chunked_file_test.dart
+++ b/test/chat_service_chunked_file_test.dart
@@ -106,20 +106,8 @@ Future<Database> _openMessagesDb() async {
   return db;
 }
 
-class _FakePostmanCall {
-  _FakePostmanCall({
-    required this.peerId,
-    required this.payload,
-    required this.timeout,
-  });
-
-  final String peerId;
-  final Map<String, dynamic> payload;
-  final Duration timeout;
-}
-
 class _FakePostman implements SideChannelPostman {
-  final directCalls = <_FakePostmanCall>[];
+  final directCalls = <Map<String, dynamic>>[];
 
   @override
   Future<void> postDirect({
@@ -127,9 +115,7 @@ class _FakePostman implements SideChannelPostman {
     required Map<String, dynamic> payload,
     Duration timeout = const Duration(seconds: 30),
   }) async {
-    directCalls.add(
-      _FakePostmanCall(peerId: peerId, payload: payload, timeout: timeout),
-    );
+    directCalls.add(payload);
   }
 
   @override
@@ -388,7 +374,7 @@ void main() {
     expect(manager.retryDelayForTest(peerId), isNotNull,
         reason: 'bring-up would have pinned the peer and cleared the backoff');
     expect(postman.directCalls, hasLength(1));
-    expect(postman.directCalls.single.payload['fileSize'],
+    expect(postman.directCalls.single['fileSize'],
         FileTransferPolicy.chunkThresholdBytes - 1);
   });
 
@@ -455,6 +441,6 @@ void main() {
 
     expect(observed().nudges, 0);
     expect(postman.directCalls, hasLength(1));
-    expect(postman.directCalls.single.payload['type'], 'file');
+    expect(postman.directCalls.single['type'], 'file');
   });
 }


### PR DESCRIPTION
Post-merge review leftovers of #154. **Production diff is comments only** — 5 added, 23 removed, no behaviour change.

## The three cuts

| what | why it goes |
|---|---|
| `file_transfer_policy.dart` — the two doc lines on `isChunkCandidate` | Line 1 restated `chunkThresholdBytes`'s own doc. Line 2 ("so the threshold has one home") was **false in the merged tree**: `shouldAvoidWsMonolithicSend`, in the same class, inlines `>= chunkThresholdBytes` twice (`fileSize`, `message.length`). The comparison has four sites, two outside the helper. The method stays — it has two callers — the claim goes. |
| `chat_service.dart` — the last two of four comment lines at the bring-up | "the monolithic fallback pays this same connect budget and discards the link" is the #154 body's argument, not call-site information. "This pins the peer and clears its backoff/quarantine" repeats `pinPeer`'s own comment at `ws_connection_manager.dart:105-107`. |
| `chat_service_chunked_file_test.dart` — the `_FakePostmanCall` record | Carried `peerId` and `timeout` that **no assertion ever read**; all three tests read `.payload` only. Replaced by `final directCalls = <Map<String, dynamic>>[]`, −12 lines of scaffolding. |

## The table cell #154 left empty

#154's test table had `—` for the mordancy of *a throwing bring-up falls back without propagating*: reverting the whole fix (gate + bring-up + `try`/`catch`) does not kill it, because the pre-fix path also lands on HTTP. That was the wrong mutant — the test defends the `catch`, so the mutant has to be the `catch`. Measured per-part, each of the three tests dies against the part it defends:

| mutant (one part removed, other two kept) | test that fails | verbatim |
|---|---|---|
| the `isChunkCandidate` early return | sub-threshold file never brings the link up | `Expected: <0>` / `Actual: <1>` — bring-up must not run for sub-threshold |
| the reordering (bring-up before the predicate) | cold link is brought up before the chunked decision | `Expected: <1>` / `Actual: <0>` |
| the `try`/`catch` around the bring-up (bare `await` left) | a throwing bring-up falls back to monolithic without propagating | throw escapes: `Bad state: Local onion address not available`, then `TimeoutException after 0:00:10` |

So all three tests earn their keep, and none of them was cut here. Only the dead fields inside the fake were.

## Verification

`flutter analyze` 0 · full suite **1124 + 1 skip** green on this branch, on Flutter 3.44.8 (the pinned toolchain from #156).

Co-authored-by: xmreur <xmreur@gmail.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated internal comments and documentation for file transfer behavior.

* **Tests**
  * Simplified test call tracking and assertions without changing file transfer functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->