### PR TITLE
fix(inbound): gate unknown senders on an opt-in setting, and block peers in groups too

### DIFF
--- a/lib/constants/group_constants.dart
+++ b/lib/constants/group_constants.dart
@@ -63,6 +63,20 @@ const Set<String> disappearingTimerTypes = {
   disappearingTimerType,
 };
 
+/// Every type whose payload legitimately carries a `groupId`. Inbound traffic
+/// that pairs a `groupId` with any other type is forging group scope, which
+/// would otherwise skip the direct-message authentication and the
+/// unknown-sender gate — both of which key off `groupId == null`.
+const Set<String> groupScopedTypes = {
+  ...groupControlTypes,
+  ...groupMessageTypes,
+  groupHistoryRelayType,
+  groupReactionType,
+  groupMessageModifyType,
+  groupReadReceiptType,
+  groupReadWaterlineType,
+};
+
 bool isGroupControlType(String type) => groupControlTypes.contains(type);
 bool isGroupMessageType(String type) => groupMessageTypes.contains(type);
 bool isReactionType(String type) => reactionTypes.contains(type);
@@ -70,6 +84,7 @@ bool isMessageModifyType(String type) => messageModifyTypes.contains(type);
 bool isReadReceiptType(String type) => readReceiptTypes.contains(type);
 bool isDisappearingTimerType(String type) =>
     disappearingTimerTypes.contains(type);
+bool isGroupScopedType(String type) => groupScopedTypes.contains(type);
 
 const Set<String> directMessageTypes = {
   'text',

--- a/lib/models/settings.dart
+++ b/lib/models/settings.dart
@@ -24,6 +24,10 @@ class Settings {
   final PanicAction panicAction;
   final GroupInviteMode groupInviteMode;
 
+  /// Refuse direct messages from senders with no `users` row. Off by default:
+  /// a published Prysm ID stays reachable unless the user opts out.
+  final bool refuseUnknownSenders;
+
   // Theme
   final int themeMode; // 0=light, 1=dark, 2=pink, 3=cyan, 4=purple, 5=orange
   final AppearanceSettings appearance;
@@ -58,6 +62,7 @@ class Settings {
     this.messageRetentionDays = 30,
     this.panicAction = PanicAction.decoy,
     this.groupInviteMode = GroupInviteMode.holdAsRequest,
+    this.refuseUnknownSenders = false,
     this.themeMode = 0,
     this.appearance = const AppearanceSettings(),
     this.avatar,
@@ -85,6 +90,7 @@ class Settings {
     'messageRetentionDays': messageRetentionDays,
     'panicAction': panicAction.name,
     'groupInviteMode': groupInviteMode.name,
+    'refuseUnknownSenders': refuseUnknownSenders,
     'themeMode': themeMode,
     'appearance': appearance.toJson(),
     'avatar': avatar,
@@ -114,6 +120,7 @@ class Settings {
     groupInviteMode: GroupInviteMode.fromJson(
       json['groupInviteMode'] as String?,
     ),
+    refuseUnknownSenders: json['refuseUnknownSenders'] ?? false,
     themeMode: json['themeMode'] ?? 0,
     appearance: AppearanceSettings.fromJson(
       json['appearance'] as Map<String, dynamic>?,
@@ -145,6 +152,7 @@ class Settings {
     int? messageRetentionDays,
     PanicAction? panicAction,
     GroupInviteMode? groupInviteMode,
+    bool? refuseUnknownSenders,
     int? themeMode,
     AppearanceSettings? appearance,
     String? avatar,
@@ -172,6 +180,7 @@ class Settings {
     messageRetentionDays: messageRetentionDays ?? this.messageRetentionDays,
     panicAction: panicAction ?? this.panicAction,
     groupInviteMode: groupInviteMode ?? this.groupInviteMode,
+    refuseUnknownSenders: refuseUnknownSenders ?? this.refuseUnknownSenders,
     themeMode: themeMode ?? this.themeMode,
     appearance: appearance ?? this.appearance,
     avatar: avatar ?? this.avatar,
@@ -215,6 +224,7 @@ class Settings {
         other.messageRetentionDays == messageRetentionDays &&
         other.panicAction == panicAction &&
         other.groupInviteMode == groupInviteMode &&
+        other.refuseUnknownSenders == refuseUnknownSenders &&
         other.themeMode == themeMode &&
         other.appearance == appearance &&
         other.avatar == avatar &&
@@ -242,6 +252,7 @@ class Settings {
         messageRetentionDays.hashCode ^
         panicAction.hashCode ^
         groupInviteMode.hashCode ^
+        refuseUnknownSenders.hashCode ^
         themeMode.hashCode ^
         appearance.hashCode ^
         (avatar?.hashCode ?? 0) ^

--- a/lib/screens/privacy_settings_screen.dart
+++ b/lib/screens/privacy_settings_screen.dart
@@ -40,6 +40,7 @@ class _PrivacySettingsScreenState extends State<PrivacySettingsScreen> {
   bool _typingIndicators = true;
   bool _lastSeen = true;
   bool _profilePhoto = true;
+  bool _refuseUnknownSenders = false;
   GroupInviteMode _groupInviteMode = SettingsService().groupInviteMode;
 
   /// True while a mode change is being persisted. Blocks a second selection
@@ -60,6 +61,7 @@ class _PrivacySettingsScreenState extends State<PrivacySettingsScreen> {
       _typingIndicators = settings.enableTypingIndicators;
       _lastSeen = prefs.getBool('last_seen') ?? true;
       _profilePhoto = prefs.getBool('profile_photo') ?? true;
+      _refuseUnknownSenders = settings.refuseUnknownSenders;
     });
   }
 
@@ -125,6 +127,11 @@ class _PrivacySettingsScreenState extends State<PrivacySettingsScreen> {
     _savePrivacySetting('profile_photo', value);
   }
 
+  Future<void> _onRefuseUnknownSendersToggle(bool value) async {
+    setState(() => _refuseUnknownSenders = value);
+    await settings.setRefuseUnknownSenders(value);
+  }
+
   @override
   Widget build(BuildContext context) {
     final style = context.prysmStyle;
@@ -171,6 +178,13 @@ class _PrivacySettingsScreenState extends State<PrivacySettingsScreen> {
                     title: 'Profile Photo',
                     value: _profilePhoto,
                     onChanged: _onProfilePhotoToggle,
+                  ),
+                  PrysmSwitchRow(
+                    title: 'Refuse messages from non-contacts',
+                    subtitle:
+                        'When enabled, people who are not in your contacts cannot message you directly.',
+                    value: _refuseUnknownSenders,
+                    onChanged: _onRefuseUnknownSendersToggle,
                   ),
                 ],
               ),

--- a/lib/server/inbound_message_router.dart
+++ b/lib/server/inbound_message_router.dart
@@ -265,7 +265,7 @@ class InboundMessageRouter {
       'InboundMessageRouter',
     );
 
-    if (_isBlockedDm(data)) {
+    if (await _senderRefused(data)) {
       return InboundHandleResult.ok({'status': 'received', 'id': data['id']});
     }
 
@@ -903,9 +903,29 @@ class InboundMessageRouter {
     return data['fileName'] is String && data['fileSize'] is int;
   }
 
-  bool _isBlockedDm(Map<String, dynamic> data) {
-    if (data['groupId'] != null) return false;
-    return BlockService.instance.isBlocked(data['senderId'] as String);
+  /// True when [data]'s sender may not reach us; the caller acks-and-drops.
+  ///
+  /// Blocked peers are refused in groups too, not only in DMs. A group
+  /// co-member is otherwise reachable whatever their contact status — group
+  /// invites stay governed by `groupInviteMode`. The refuse-unknown-senders
+  /// setting defaults off and short-circuits ahead of the DB lookup, and
+  /// "unknown" means what the sync-hint gate means by it (`getUserById`).
+  Future<bool> _senderRefused(Map<String, dynamic> data) async {
+    final senderId = data['senderId'] as String;
+
+    if (BlockService.instance.isBlocked(senderId)) {
+      return true;
+    }
+
+    if (data['groupId'] != null) {
+      return false;
+    }
+
+    if (!settings.refuseUnknownSenders) {
+      return false;
+    }
+
+    return (await DBHelper.getUserById(senderId)) == null;
   }
 
   bool _shouldRedactProfileForRequester(

--- a/lib/server/inbound_message_router.dart
+++ b/lib/server/inbound_message_router.dart
@@ -218,6 +218,12 @@ class InboundMessageRouter {
       );
     }
 
+    if (data['groupId'] != null && !isGroupScopedType(type)) {
+      return InboundHandleResult.badRequest(
+        'groupId not allowed for a non-group type',
+      );
+    }
+
     if (isGroupControlType(type)) {
       return _validateAddressedToLocal(data, controlMessage: true);
     }

--- a/lib/services/settings_service.dart
+++ b/lib/services/settings_service.dart
@@ -59,6 +59,7 @@ class SettingsService {
   int get messageRetentionDays => _settings.messageRetentionDays;
   PanicAction get panicAction => _settings.panicAction;
   GroupInviteMode get groupInviteMode => _settings.groupInviteMode;
+  bool get refuseUnknownSenders => _settings.refuseUnknownSenders;
 
   // Theme
   int get themeMode => _settings.themeMode;
@@ -222,6 +223,11 @@ class SettingsService {
 
   Future<void> setGroupInviteMode(GroupInviteMode value) async {
     _settings = _settings.copyWith(groupInviteMode: value);
+    await save();
+  }
+
+  Future<void> setRefuseUnknownSenders(bool value) async {
+    _settings = _settings.copyWith(refuseUnknownSenders: value);
     await save();
   }
 

--- a/test/group_invite_mode_screens_test.dart
+++ b/test/group_invite_mode_screens_test.dart
@@ -110,6 +110,7 @@ void main() {
     // Toggling must commit through SettingsService, not just repaint.
     final settings = SettingsService();
     final before = settings.refuseUnknownSenders;
+    addTearDown(() => settings.setRefuseUnknownSenders(before));
     await tester.tap(
       find.descendant(of: row, matching: find.byType(PrysmSwitch)),
     );

--- a/test/group_invite_mode_screens_test.dart
+++ b/test/group_invite_mode_screens_test.dart
@@ -18,8 +18,10 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:prysm/models/appearance_settings.dart';
 import 'package:prysm/models/group_invite_mode.dart';
 import 'package:prysm/screens/privacy_settings_screen.dart';
+import 'package:prysm/services/settings_service.dart';
 import 'package:prysm/theme/prysm_style_resolver.dart';
 import 'package:prysm/theme/prysm_style_scope.dart';
+import 'package:prysm/ui/core/prysm_switch.dart';
 import 'package:prysm/util/key_manager.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
@@ -78,5 +80,40 @@ void main() {
             'manager',
       );
     }
+  });
+
+  testWidgets('refuse non-contacts toggle is offered and persists',
+      (tester) async {
+    SharedPreferences.setMockInitialValues({});
+
+    await tester.pumpWidget(
+      wrapWithStyle(
+        PrivacySettingsScreen(onClose: () {}, keyManager: KeyManager()),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    // The row must exist and state the offer in plain terms.
+    final row = find.widgetWithText(
+      PrysmSwitchRow,
+      'Refuse messages from non-contacts',
+    );
+    expect(row, findsOneWidget);
+    expect(
+      find.text(
+        'When enabled, people who are not in your contacts cannot message '
+        'you directly.',
+      ),
+      findsOneWidget,
+    );
+
+    // Toggling must commit through SettingsService, not just repaint.
+    final settings = SettingsService();
+    final before = settings.refuseUnknownSenders;
+    await tester.tap(
+      find.descendant(of: row, matching: find.byType(PrysmSwitch)),
+    );
+    await tester.pumpAndSettle();
+    expect(settings.refuseUnknownSenders, isNot(before));
   });
 }

--- a/test/security/refuse_unknown_senders_test.dart
+++ b/test/security/refuse_unknown_senders_test.dart
@@ -1,0 +1,175 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:prysm/constants/group_constants.dart';
+import 'package:prysm/database/blocked_users_db.dart';
+import 'package:prysm/database/conversation_preferences_db.dart';
+import 'package:prysm/database/message_schema_migrations.dart';
+import 'package:prysm/database/messages.dart';
+import 'package:prysm/server/inbound_message_router.dart';
+import 'package:prysm/services/block_service.dart';
+import 'package:prysm/services/settings_service.dart';
+import 'package:prysm/util/db_helper.dart';
+import 'package:prysm/util/key_manager.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:sqflite_common_ffi/sqflite_ffi.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  late Database dbHelperDb;
+  late Database messagesDb;
+  late SettingsService settings;
+  late InboundMessageRouter router;
+
+  setUpAll(() {
+    sqfliteFfiInit();
+    databaseFactory = databaseFactoryFfi;
+  });
+
+  setUp(() async {
+    dbHelperDb = await databaseFactory.openDatabase(
+      '${inMemoryDatabasePath}_${DateTime.now().microsecondsSinceEpoch}',
+      options: OpenDatabaseOptions(
+        version: 1,
+        onCreate: (db, _) async {
+          await db.execute('''
+            CREATE TABLE users (
+              id TEXT PRIMARY KEY,
+              name TEXT,
+              avatarUrl TEXT,
+              avatarBase64 TEXT,
+              customName TEXT,
+              publicKeyPem TEXT,
+              identityJson TEXT
+            )
+          ''');
+          await db.execute('''
+            CREATE TABLE group_members (
+              groupId TEXT NOT NULL,
+              memberId TEXT NOT NULL,
+              role TEXT NOT NULL,
+              joinedAt INTEGER NOT NULL,
+              PRIMARY KEY (groupId, memberId)
+            )
+          ''');
+          await ConversationPreferencesDb.createTable(db);
+          await BlockedUsersDb.createTable(db);
+        },
+      ),
+    );
+    DBHelper.setDatabaseForTest(dbHelperDb);
+    await BlockService.instance.init();
+
+    messagesDb = await databaseFactory.openDatabase(
+      '${inMemoryDatabasePath}_${DateTime.now().microsecondsSinceEpoch}',
+      options: OpenDatabaseOptions(
+        version: MessageSchemaMigrations.dbVersion,
+        onCreate: MessageSchemaMigrations.onCreate,
+      ),
+    );
+    MessagesDb.setDatabaseForTest(messagesDb);
+
+    SharedPreferences.setMockInitialValues({});
+    settings = SettingsService();
+    await settings.init();
+
+    router = InboundMessageRouter(
+      keyManager: KeyManager(),
+      settings: settings,
+      localOnionAddress: () => 'local.onion',
+    );
+  });
+
+  tearDown(() async {
+    DBHelper.setDatabaseForTest(null);
+    MessagesDb.setDatabaseForTest(null);
+    await dbHelperDb.close();
+    await messagesDb.close();
+  });
+
+  Future<int> messageRowCount() async =>
+      (await messagesDb.query('messages')).length;
+
+  test(
+    'setting on: unknown-sender DM is acked and dropped, no users row',
+    () async {
+      await settings.setRefuseUnknownSenders(true);
+      addTearDown(() => settings.setRefuseUnknownSenders(false));
+
+      final result = await router.processMessage({
+        'id': 'msg-t1',
+        'senderId': 'stranger.onion',
+        'receiverId': 'local.onion',
+        'message': 'cipher',
+        'type': 'text',
+        'timestamp': 1,
+      });
+
+      // A fake 200 leaks nothing and stops the sender's retry storm.
+      expect(result.statusCode, 200);
+      expect(await messageRowCount(), 0);
+      expect(await DBHelper.getUserById('stranger.onion'), isNull);
+    },
+  );
+
+  test(
+    'setting off: first-contact DM from an unknown sender is stored',
+    () async {
+      // Default-off setting untouched: the first-contact flow keeps working.
+      final result = await router.processMessage({
+        'id': 'msg-t2',
+        'senderId': 'firstcontact.onion',
+        'receiverId': 'local.onion',
+        'message': 'cipher',
+        'type': 'text',
+        'timestamp': 1,
+      });
+
+      expect(result.statusCode, 200);
+      expect(await messageRowCount(), 1);
+      // ensureUserExist creates the Unknown-xxxxxx contact row as before.
+      expect(await DBHelper.getUserById('firstcontact.onion'), isNotNull);
+    },
+  );
+
+  test(
+    'setting on: DM from a sender with a users row is stored',
+    () async {
+      await dbHelperDb.insert('users', {'id': 'alice.onion', 'name': 'Alice'});
+      await settings.setRefuseUnknownSenders(true);
+      addTearDown(() => settings.setRefuseUnknownSenders(false));
+
+      final result = await router.processMessage({
+        'id': 'msg-t3',
+        'senderId': 'alice.onion',
+        'receiverId': 'local.onion',
+        'message': 'cipher',
+        'type': 'text',
+        'timestamp': 1,
+      });
+
+      expect(result.statusCode, 200);
+      expect(await messageRowCount(), 1);
+    },
+  );
+
+  test(
+    'blocked sender group message is acked and dropped (no groupId exemption)',
+    () async {
+      await BlockService.instance.block('blocked.onion');
+
+      final result = await router.processMessage({
+        'id': 'msg-t4',
+        'senderId': 'blocked.onion',
+        'receiverId': 'local.onion',
+        'message': 'cipher',
+        'type': groupTextType,
+        'groupId': 'grp-1',
+        'timestamp': 1,
+      });
+
+      expect(result.statusCode, 200);
+      expect(await messageRowCount(), 0);
+      expect(await DBHelper.getUserById('blocked.onion'), isNull);
+    },
+  );
+}

--- a/test/security/refuse_unknown_senders_test.dart
+++ b/test/security/refuse_unknown_senders_test.dart
@@ -172,4 +172,34 @@ void main() {
       expect(await DBHelper.getUserById('blocked.onion'), isNull);
     },
   );
+
+  test(
+    'a forged groupId on a direct type is rejected, not treated as group traffic',
+    () async {
+      Map<String, dynamic> forged(String id) => {
+        'id': id,
+        'senderId': 'stranger.onion',
+        'receiverId': 'local.onion',
+        'message': 'cipher',
+        'type': 'text',
+        'groupId': 'grp-forged',
+        'timestamp': 1,
+      };
+
+      // With the setting on, `groupId` would otherwise skip the gate entirely.
+      await settings.setRefuseUnknownSenders(true);
+      addTearDown(() => settings.setRefuseUnknownSenders(false));
+      final refused = await router.handleMessage(forged('msg-t5-on'));
+      expect(refused.statusCode, 400);
+
+      // And with it off, the same payload would have skipped DirectMessageAuth,
+      // which only runs when `groupId == null`.
+      await settings.setRefuseUnknownSenders(false);
+      final unsigned = await router.handleMessage(forged('msg-t5-off'));
+      expect(unsigned.statusCode, 400);
+
+      expect(await messageRowCount(), 0);
+      expect(await DBHelper.getUserById('stranger.onion'), isNull);
+    },
+  );
 }


### PR DESCRIPTION
Closes #159. The [diagnosis comment](https://github.com/xmreur/prysm/issues/159#issuecomment-5294225079) has the full trace; the short version is that the setting the issue assumes **did not exist**, and the `403 'Unknown sender'` came from a gate that only the hint path has.

## What was actually broken

| | before | after |
|---|---|---|
| `/sync-hint` from an unknown sender | `403` (unconditional, `inbound_message_router.dart:152-155`) | unchanged |
| DM from an unknown sender | **accepted and stored**, then `ensureUserExist` created their `users` row so the hint gate stopped 403-ing | refused when `refuseUnknownSenders` is on, and no `users` row is created |
| **group** message from a **blocked** peer | **stored and notified** — `_isBlockedDm` returned false whenever `groupId != null` | refused, like their DMs, calls, typing and file transfers already were |

The second row is the issue; the third is a hole found while reading it, and it needed no policy decision — blocking was enforced everywhere except that one branch.

## The change

One gate, at the single convergence point of HTTP `POST /message`, both WS routes and file transfer. `_isBlockedDm` is gone, replaced by `_senderRefused` called at `processMessage:268` — **before** `_handleChatMessage`'s `ensureUserExist`, so a refused stranger leaves no trace:

```dart
if (BlockService.instance.isBlocked(senderId)) return true;   // groups too, now
if (data['groupId'] != null) return false;                    // co-members stay reachable
if (!settings.refuseUnknownSenders) return false;             // default off, before any DB hit
return (await DBHelper.getUserById(senderId)) == null;        // same "unknown" as the hint gate
```

Deliberate choices:
- **Default off.** A published Prysm ID stays reachable; privacy users opt in. The `!settings.refuseUnknownSenders` short-circuit sits ahead of the DB lookup, so the default path costs nothing.
- **Ack-and-drop with a fake `200`**, reusing what blocked DMs already do: it leaks nothing about block-vs-refuse-vs-offline, and it stops the sender's retry storm instead of feeding it (the 3-4 minutes in the issue are sender-side retry, one 25 s `interactiveConnectBudget` per cycle).
- **"Unknown" means `getUserById == null`**, the same definition the hint gate uses. One definition, not two.
- **Group invites untouched** — `groupInviteMode` still governs those.

Known consequence of dropping blocked peers' group messages: their group history has holes, and the sender-key anti-replay index is not advanced for the dropped messages. Both follow from the decision that blocking blocks.

## Tests

`test/security/refuse_unknown_senders_test.dart`, harness copied from `inbound_sender_auth_test.dart` + the `MessagesDb` wiring of `inbound_profile_fetch_gate_test.dart`. Assertions are `messages` row counts and the presence/absence of a `users` row — observable state, not mock calls. Each was re-run against its own mutant by hand:

| test | mutant | verbatim failure |
|---|---|---|
| setting on: unknown-sender DM is acked and dropped, no users row | contact lookup replaced by `return false` | `Expected: <0>` / `Actual: <1>` |
| setting off: first-contact DM from an unknown sender is stored | setting read inverted (default becomes refuse) | `Expected: <1>` / `Actual: <0>` |
| setting on: DM from a sender with a users row is stored | — guards the false-positive edge of the two above |
| blocked sender group message is acked and dropped | `if (data['groupId'] != null) return false;` restored ahead of the block check | `Expected: <0>` / `Actual: <1>` |

Plus one `testWidgets` in `test/group_invite_mode_screens_test.dart` for the privacy toggle, mordant against removing the row and against a repaint-only handler.

The four tests most likely to regress — `inbound_profile_fetch_gate_test.dart`, `group_profile_fetch_gate_test.dart`, `inbound_block_test.dart`, `inbound_sender_auth_test.dart`, all of which assert unknown-sender traffic **is** processed — stay green on the default.

## Verification

`flutter analyze` 0 · full suite **1129 + 1 skip** green on Flutter 3.44.8 (the pinned toolchain).

## Not in this PR

The issue's other two product asks: prominence during onboarding, and explicit feedback to the blocked sender. Feedback in particular cannot be done with the ack-and-drop response — telling the sender they were refused is exactly the leak that response avoids, so it needs its own decision.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a privacy setting to refuse direct messages from non-contacts.
  * Added a switch and explanatory text in Privacy Settings.
  * Blocked senders’ messages are acknowledged and discarded, while group messages remain unaffected by the non-contact setting.

* **Bug Fixes**
  * Blocked senders can no longer deliver messages through group conversations.
  * Invalid group identifiers on direct messages are rejected.

* **Tests**
  * Added coverage for the privacy setting, persistence, and message-filtering behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->