### PR TITLE
tool(lab): label a chunked transfer that fell back to HTTP

### DIFF
--- a/.agents/skills/live-app-testing/SKILL.md
+++ b/.agents/skills/live-app-testing/SKILL.md
@@ -317,11 +317,12 @@ are forwarded into the container.
     2 MiB **chunked 9.4 s** (1778 kbps, n=3) versus **mono 10.7 s** (1570 kbps, n=3) — parity;
     8 MiB chunked 53.5 s and 122.4 s versus mono 39.2 s and 50.8 s. Pairing 5.7-7.9 s. 0 lost in
     31 messages / 32 MiB.
-    So the window closed most of the gap the older numbers show — 2.4× faster at 2 MiB, 2.1× at
-    8 MiB — and chunked is no longer the obviously wrong choice: it ties one POST at 2 MiB and
-    still loses at 8 MiB. Tor variance dominates single reps (the same 8 MiB chunked transfer ran
-    53 s and 122 s an hour apart), so never conclude from n=1, and re-measure both halves in ONE
-    session before touching either path.
+    So the window closed the 2 MiB gap outright — **2.4×** faster there (9.4 s median n=3 against
+    23.0 s) and chunked now ties one POST. At 8 MiB the two samples are 53.5 s and 122.4 s against
+    112.0 s before: **best case 2.1×, median 88 s ≈ 1.3×, n=2 — inconclusive, and the honest read
+    is that Tor variance is larger than the effect at that size.** Never conclude from n=1, quote
+    the aggregation with every headline, and re-measure both halves in ONE session before touching
+    either path.
     Group attachments are NOT in the harness: `txlab file` drives `ChatService.sendFileMessage` on
     a live `ChatScreen`, and a `GroupChatScreen` gives `NOTFOUND ChatScreen`. Driving
     `GroupChatService.sendFileMessage` by hand shows the group path never chunks (`path=mono`,
@@ -332,11 +333,13 @@ are forwarded into the container.
     envelope`), which no test caught because the test hand-built the envelope the parser expected
     instead of the one `CryptoWire.encryptFile` produces.
 
-19. **After the receiver restarts, the first send costs 20-50× the warm one — and `path=chunked`
+19. **After the receiver restarts, the first text costs 24-68× the warm one — and `path=chunked`
     can be a lie.** Measured 1:1 Linux↔Linux, sending to a peer that had just restarted: first
-    text **18.2 / 20.9 / 39.1 / 51.1 s** (n=4) against 0.75 s warm; first 200 KiB 11.4 s against
-    1.8-2.7 s. The sender first burns two 8 s `wsIfConnected` timeouts on the dead link, then
-    rebuilds the circuit. Worse, once: the sender logged `WS ready peer=…` and opened a chunked
+    text **18.2 / 20.9 / 39.1 / 51.1 s** (n=4, median 30 s) against 0.75 s warm, i.e. 24-68×
+    per sample; the first 200 KiB attachment 11.4 s against 1.8-2.7 s warm, ~4-6×, a different
+    multiplier and reported separately on purpose. The sender first burns two 8 s
+    `wsIfConnected` timeouts on the dead link, then rebuilds the circuit. Worse, once: the sender
+    logged `WS ready peer=…` and opened a chunked
     transfer while the receiver's log shows NO `handshake complete` until 3.5 minutes later — the
     begin ack could not arrive, the transfer died on its 30 s timeout, and HTTP delivered the
     2 MiB at **220 s**. `txlab` used to print `path=chunked` for that rep because it keyed off the

--- a/.agents/skills/live-app-testing/SKILL.md
+++ b/.agents/skills/live-app-testing/SKILL.md
@@ -306,17 +306,51 @@ are forwarded into the container.
     ~0.3 s on the WS path is the ack being logged after delivery, and the sender's `send ok` can
     land after the receiver's bubble — read it with a bounded poll, not a single read, or the rep
     reports no send side at all.
-    Baseline, 1:1 Linux↔Linux, warm WS link: 997-char body recv **0.68 s** / render 0.80 s;
-    200 KiB attachment recv 2.1-3.4 s; 2 MiB monolithic 13.4 s (1255 kbps) versus **23.0 s**
-    (729 kbps) chunked; 8 MiB monolithic 45.9 s (1462 kbps) versus **112.0 s** (599 kbps) chunked,
-    33 chunks. Contact add 5.5 s each way. 0 lost in 16 messages / 11.4 MiB.
-    That comparison is the point: the chunked path waits for an ack per 256 KiB chunk, so it is
-    **1.7-2.4× slower than one POST** over Tor even though it avoids the ~33% base64 inflation.
+    Baseline A, before the 8-chunk window (#152), 1:1 Linux↔Linux, warm WS link: 997-char body recv
+    **0.68 s** / render 0.80 s; 200 KiB attachment recv 2.1-3.4 s; 2 MiB monolithic 13.4 s
+    (1255 kbps) versus **23.0 s** (729 kbps) chunked; 8 MiB monolithic 45.9 s (1462 kbps) versus
+    **112.0 s** (599 kbps) chunked, 33 chunks. Contact add 5.5 s each way. 0 lost in 16 messages.
+    Baseline B, 2026-08-14, same rig WITH the window merged, chunked-vs-mono measured in one
+    session by returning `false` from `shouldUseChunkedTransfer` in the staged copy for the mono
+    half: short text recv median **0.75 s** / render 1.09 s (n=6); 975-char body recv 0.63 s
+    (n=3 each way); group text recv median **0.58 s** (n=4); 200 KiB mono recv 1.8-2.7 s;
+    2 MiB **chunked 9.4 s** (1778 kbps, n=3) versus **mono 10.7 s** (1570 kbps, n=3) — parity;
+    8 MiB chunked 53.5 s and 122.4 s versus mono 39.2 s and 50.8 s. Pairing 5.7-7.9 s. 0 lost in
+    31 messages / 32 MiB.
+    So the window closed most of the gap the older numbers show — 2.4× faster at 2 MiB, 2.1× at
+    8 MiB — and chunked is no longer the obviously wrong choice: it ties one POST at 2 MiB and
+    still loses at 8 MiB. Tor variance dominates single reps (the same 8 MiB chunked transfer ran
+    53 s and 122 s an hour apart), so never conclude from n=1, and re-measure both halves in ONE
+    session before touching either path.
+    Group attachments are NOT in the harness: `txlab file` drives `ChatService.sendFileMessage` on
+    a live `ChatScreen`, and a `GroupChatScreen` gives `NOTFOUND ChatScreen`. Driving
+    `GroupChatService.sendFileMessage` by hand shows the group path never chunks (`path=mono`,
+    2 MiB in 10.2 s and 25.2 s) — it fans one monolithic POST out per member.
     Do not "optimise" an attachment path on either number alone, and do not trust a code reading
     over a measurement — the campaign that produced these numbers is also what found that chunked
     transfers had been failing outright since 2026-08-04 (`FormatException: Invalid file
     envelope`), which no test caught because the test hand-built the envelope the parser expected
     instead of the one `CryptoWire.encryptFile` produces.
+
+19. **After the receiver restarts, the first send costs 20-50× the warm one — and `path=chunked`
+    can be a lie.** Measured 1:1 Linux↔Linux, sending to a peer that had just restarted: first
+    text **18.2 / 20.9 / 39.1 / 51.1 s** (n=4) against 0.75 s warm; first 200 KiB 11.4 s against
+    1.8-2.7 s. The sender first burns two 8 s `wsIfConnected` timeouts on the dead link, then
+    rebuilds the circuit. Worse, once: the sender logged `WS ready peer=…` and opened a chunked
+    transfer while the receiver's log shows NO `handshake complete` until 3.5 minutes later — the
+    begin ack could not arrive, the transfer died on its 30 s timeout, and HTTP delivered the
+    2 MiB at **220 s**. `txlab` used to print `path=chunked` for that rep because it keyed off the
+    `begin transfer=` line alone; it now prints **`chunked->http`** when the sender logs
+    `falling back to HTTP send` after the begin (verified by patching `ackTimeout` to 1 ms in the
+    staged copy and reproducing the label). Read that label before believing any attachment number.
+    Two lab hazards from the same campaign: `prysmlab restart --sync` twice left peer `a` wedged on
+    `UnlockScreen` with `Zone error: Build scheduled during frame` — every PIN tap ignored, and a
+    plain `prysmlab restart` recovered it; and once, over ~18 minutes, a receiver's open chat pane
+    showed nothing newer than the moment it opened while 7 messages arrived, all of them stored
+    with `status=received` and returned by the pane's own `getMessagesBetweenBatchWithId` query
+    (an app restart made them appear). NOT reproduced in three deliberate attempts afterwards, so
+    treat it as an open sighting, not a known bug — and check the tree, not the log, before
+    trusting a render number.
 
 ## Worked example
 

--- a/.agents/skills/live-app-testing/SKILL.md
+++ b/.agents/skills/live-app-testing/SKILL.md
@@ -306,10 +306,11 @@ are forwarded into the container.
     ~0.3 s on the WS path is the ack being logged after delivery, and the sender's `send ok` can
     land after the receiver's bubble — read it with a bounded poll, not a single read, or the rep
     reports no send side at all.
-    Baseline A, before the 8-chunk window (#152), 1:1 Linux↔Linux, warm WS link: 997-char body recv
-    **0.68 s** / render 0.80 s; 200 KiB attachment recv 2.1-3.4 s; 2 MiB monolithic 13.4 s
-    (1255 kbps) versus **23.0 s** (729 kbps) chunked; 8 MiB monolithic 45.9 s (1462 kbps) versus
-    **112.0 s** (599 kbps) chunked, 33 chunks. Contact add 5.5 s each way. 0 lost in 16 messages.
+    Baseline A, before the 8-chunk window (#152), 1:1 Linux↔Linux, warm WS link — single samples,
+    n unrecorded per figure: 997-char body recv **0.68 s** / render 0.80 s; 200 KiB attachment recv
+    2.1-3.4 s; 2 MiB monolithic 13.4 s (1255 kbps) versus **23.0 s** (729 kbps) chunked; 8 MiB
+    monolithic 45.9 s (1462 kbps) versus **112.0 s** (599 kbps) chunked, 33 chunks. Contact add
+    5.5 s each way. 0 lost in 16 messages.
     Baseline B, 2026-08-14, same rig WITH the window merged, chunked-vs-mono measured in one
     session by returning `false` from `shouldUseChunkedTransfer` in the staged copy for the mono
     half: short text recv median **0.75 s** / render 1.09 s (n=6); 975-char body recv 0.63 s
@@ -326,7 +327,7 @@ are forwarded into the container.
     Group attachments are NOT in the harness: `txlab file` drives `ChatService.sendFileMessage` on
     a live `ChatScreen`, and a `GroupChatScreen` gives `NOTFOUND ChatScreen`. Driving
     `GroupChatService.sendFileMessage` by hand shows the group path never chunks (`path=mono`,
-    2 MiB in 10.2 s and 25.2 s) — it fans one monolithic POST out per member.
+    2 MiB in 10.2 s and 25.2 s, n=2) — it fans one monolithic POST out per member.
     Do not "optimise" an attachment path on either number alone, and do not trust a code reading
     over a measurement — the campaign that produced these numbers is also what found that chunked
     transfers had been failing outright since 2026-08-04 (`FormatException: Invalid file
@@ -336,7 +337,7 @@ are forwarded into the container.
 19. **After the receiver restarts, the first text costs 24-68× the warm one — and `path=chunked`
     can be a lie.** Measured 1:1 Linux↔Linux, sending to a peer that had just restarted: first
     text **18.2 / 20.9 / 39.1 / 51.1 s** (n=4, median 30 s) against 0.75 s warm, i.e. 24-68×
-    per sample; the first 200 KiB attachment 11.4 s against 1.8-2.7 s warm, ~4-6×, a different
+    per sample; the first 200 KiB attachment 11.4 s (n=1) against 1.8-2.7 s warm, ~4-6×, a different
     multiplier and reported separately on purpose. The sender first burns two 8 s
     `wsIfConnected` timeouts on the dead link, then rebuilds the circuit. Worse, once: the sender
     logged `WS ready peer=…` and opened a chunked

--- a/tool/live/txlab
+++ b/tool/live/txlab
@@ -680,6 +680,18 @@ def cmd_file(args) -> int:
                 chunks, ciphertext = parsed
             if done_c is not None:
                 send_ts = done_c[0]
+            # A `begin transfer=` line does NOT mean the chunked path DELIVERED:
+            # the transfer can die on an ack timeout and ChatService then falls
+            # back to one monolithic POST, which is what the receiver actually
+            # got. Labelling that rep `chunked` reports the intent instead of
+            # the transport and makes a 220 s HTTP delivery look like a slow
+            # chunked one — observed on a cold link after the peer restarted.
+            fell_back = newest_match(args.frm, r"falling back to HTTP send",
+                                     begin[0])
+            if fell_back is not None:
+                kind = "chunked->http"
+                if done_m is not None:
+                    send_ts = done_m[0]
         elif done_m is not None:
             send_ts = done_m[0]
         send = None if send_ts is None else send_ts - t0


### PR DESCRIPTION
Found while measuring real send/receive times on the two-peer lab. No `lib/` change.

## The instrument was lying

`txlab file` decided the transport label from the sender's `begin transfer=` line alone. A chunked transfer that starts and then **dies on its ack timeout** is delivered by `ChatService`'s monolithic HTTP fallback, and the rep still printed `path=chunked`. That is how a cold-link rep read as

```
rep 1: send=n/a recv=220.431s render=n/a bytes=2097152 chunks=9 path=chunked payload_kbps=76
```

when the sender's own log says the chunked attempt was already dead:

```
16:38:39.312 begin transfer=eaa00554… chunks=9 ciphertext=2097168 peer=pvzcxv…
16:39:09.323 ERROR [FileTransferSender]: file transfer failed: TimeoutException after 0:00:30
16:39:09.332 ERROR [ChatService]: Chunked file transfer failed …, falling back to HTTP send
```

Now the rep prints `path=chunked->http` and takes its `send=` from `send ok` instead of the never-logged `transfer complete`. **Verified mordant** by patching `ackTimeout` to 1 ms in the staged copy and re-running a 2 MiB send: `rep 1: send=19.124s recv=18.605s render=19.048s bytes=2097152 chunks=9 path=chunked->http`, with the fallback line present in the sender log. Without the fix that rep reads `chunked`.

## Rule 18's numbers predated the chunk window

Measured today, same rig, chunked-vs-monolithic in **one session** (mono half by returning `false` from `shouldUseChunkedTransfer` in the staged copy, so the ≥1 MiB media still refuses monolithic WS and goes HTTP exactly as before chunking existed):

| payload | chunked (window=8) | monolithic HTTP | rule 18 before |
|---|---|---|---|
| 2 MiB | **9.4 s** median, 1778 kbps (n=3) | 10.7 s median, 1570 kbps (n=3) | chunked 23.0 s vs mono 13.4 s |
| 8 MiB | 53.5 s and 122.4 s (n=2) | 39.2 s and 50.8 s (n=2) | chunked 112.0 s vs mono 45.9 s |

So #152's window is worth 2.4× at 2 MiB and 2.1× at 8 MiB, and the old conclusion ("chunked is 1.7-2.4× slower than one POST") no longer holds at 2 MiB — it ties there and still loses at 8 MiB. Tor variance dominates single reps (the same 8 MiB chunked transfer ran 53 s and 122 s an hour apart), which is now stated in the rule.

Also recorded: group attachments are not measurable through `txlab file` (it drives `ChatService.sendFileMessage` on a live `ChatScreen`; a `GroupChatScreen` answers `NOTFOUND ChatScreen`), and the group path never chunks — one monolithic POST per member, 2 MiB in 10.2 s and 25.2 s driven by hand.

## New rule 19 — the cold link after a receiver restart

First send to a peer that just restarted: text **18.2 / 20.9 / 39.1 / 51.1 s** (n=4) against 0.75 s warm, 200 KiB 11.4 s against 1.8-2.7 s. Two 8 s `wsIfConnected` timeouts plus circuit rebuild. Once, the sender logged `WS ready` and opened a chunked transfer while the receiver's log shows no `handshake complete` for another 3.5 minutes — 30 s burned on a begin ack that could not arrive, then HTTP at 220 s. Filed separately as #163.

Two lab hazards from the same campaign are written down too: `restart --sync` twice wedged a peer on `UnlockScreen` with `Zone error: Build scheduled during frame` (plain `restart` recovers), and one unreproduced sighting of a receiver's open chat pane not showing 7 arrived-and-stored messages until an app restart — marked explicitly as a sighting, not a known bug, since three deliberate attempts to reproduce it all rendered normally.

`prysmlab down --purge` on both peers reports clean: no container, volume, staging or image left, and the repo working tree untouched.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Transfer reporting now identifies chunked transfers that fall back to HTTP after acknowledgment failures and uses completed HTTP timing when available.
  * Benchmark results now distinguish pre-window and August 14, 2026 measurements across text, attachments, pairing, loss, throughput, and group transfers.

* **Documentation**
  * Added observations on post-restart latency, group attachments, fallback behavior, rendering hazards, and transfer performance.
  * Updated conclusions to reflect current measurements rather than a previously consistent slowdown estimate.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->