### PR TITLE
feat(file_transfer): add beginAckTimeout to handle stale links during…

### DIFF
--- a/lib/services/file_transfer_handler.dart
+++ b/lib/services/file_transfer_handler.dart
@@ -215,11 +215,30 @@ class FileTransferHandler {
     // conflicting reuse of the same transferId is rejected outright.
     final existing = _active[transferId];
     if (existing != null) {
+      // An idempotent ack is only granted when the retried begin is an exact
+      // match for every immutable begin field as stored (nonce/wrapped key
+      // canonicalized, scheme resolved the same way the session stores it).
+      // A retry that differs in any of them is a conflicting reuse and must
+      // not be acknowledged or allowed to overwrite the session.
+      final resolvedScheme =
+          payload['scheme'] == CryptoConstants.schemeFileSigned1
+              ? CryptoConstants.schemeFileSigned1
+              : CryptoConstants.schemeFileAead1;
       final sameTransfer = existing.messageId == payload['messageId'] &&
           existing.senderId == payload['senderId'] &&
           existing.receiverId == payload['receiverId'] &&
+          existing.type == payload['type'] &&
+          existing.fileName == payload['fileName'] &&
           existing.fileSize == payload['fileSize'] &&
-          existing.totalChunks == payload['totalChunks'];
+          existing.timestamp == payload['timestamp'] &&
+          existing.ciphertextSize == payload['ciphertextSize'] &&
+          existing.totalChunks == payload['totalChunks'] &&
+          existing.chunkSize == payload['chunkSize'] &&
+          existing.scheme == resolvedScheme &&
+          base64Encode(existing.nonce) == payload['nonce'] &&
+          mapEquals(existing.wrappedKey, payload['wrappedKey']) &&
+          existing.replyTo == payload['replyTo'] &&
+          existing.viewOnce == (payload['viewOnce'] == true);
       if (sameTransfer) {
         Logging.debug(
           'begin duplicate transfer=$transferId message=${payload['messageId']} '

--- a/lib/services/file_transfer_handler.dart
+++ b/lib/services/file_transfer_handler.dart
@@ -206,6 +206,36 @@ class FileTransferHandler {
       return error;
     }
 
+    final transferId = payload['transferId'] as String;
+
+    // A sender retries the begin on a rebuilt link after its first ack timed
+    // out; the receiver may already hold this transfer. A retried begin for
+    // the same transfer must be answered with the existing acknowledgement
+    // (idempotent) and must never clobber the in-progress session, while a
+    // conflicting reuse of the same transferId is rejected outright.
+    final existing = _active[transferId];
+    if (existing != null) {
+      final sameTransfer = existing.messageId == payload['messageId'] &&
+          existing.senderId == payload['senderId'] &&
+          existing.receiverId == payload['receiverId'] &&
+          existing.fileSize == payload['fileSize'] &&
+          existing.totalChunks == payload['totalChunks'];
+      if (sameTransfer) {
+        Logging.debug(
+          'begin duplicate transfer=$transferId message=${payload['messageId']} '
+          'from $peerOnion returning existing ack',
+          'FileTransferHandler',
+        );
+        return {'ok': true, 'transferId': transferId};
+      }
+      Logging.error(
+        'begin conflicting duplicate transfer=$transferId from '
+        '${Logging.redactOnion(peerOnion)} rejected',
+        'FileTransferHandler',
+      );
+      return {'error': 'Transfer already exists'};
+    }
+
     if (_active.length >= InboundLimits.maxConcurrentInboundTransfers) {
       Logging.error(
         'begin rejected from ${Logging.redactOnion(peerOnion)}: '
@@ -215,7 +245,6 @@ class FileTransferHandler {
       return {'error': 'Too many transfers'};
     }
 
-    final transferId = payload['transferId'] as String;
     final nonce = base64Decode(payload['nonce'] as String);
 
     // Peers predating the scheme field send no scheme; anything that is not a

--- a/lib/services/file_transfer_sender.dart
+++ b/lib/services/file_transfer_sender.dart
@@ -106,15 +106,20 @@ class FileTransferSender {
       // so tear it down and re-dial before giving up to the HTTP fallback.
       // Begin/end acks are request responses, so the push subscription only
       // needs to be live for chunk acks and is attached after begin succeeds.
+      final wireTimestamp = timestamp ?? DateTime.now().millisecondsSinceEpoch;
       for (var attempt = 0; ; attempt++) {
         if (attempt > 0) {
           Logging.debug(
             'begin not acked, rebuilding link peer=$peerOnion',
             'FileTransferSender',
           );
-          await _manager.disconnectPeer(peerOnion);
+          await _manager
+              .disconnectPeer(peerOnion)
+              .then((_) => _manager.prepareForFileTransfer(peerOnion))
+              .timeout(beginAckTimeout);
+        } else {
+          await _manager.prepareForFileTransfer(peerOnion);
         }
-        await _manager.prepareForFileTransfer(peerOnion);
         Logging.debug('WS ready peer=$peerOnion', 'FileTransferSender');
 
         Logging.debug(
@@ -136,7 +141,7 @@ class FileTransferSender {
               'type': type,
               'fileName': fileName,
               'fileSize': fileSize,
-              'timestamp': timestamp ?? DateTime.now().millisecondsSinceEpoch,
+              'timestamp': wireTimestamp,
               'wrappedKey': parts.wrappedKey,
               'nonce': base64Encode(parts.nonce),
               'scheme': parts.scheme,

--- a/lib/services/file_transfer_sender.dart
+++ b/lib/services/file_transfer_sender.dart
@@ -47,14 +47,21 @@ FileTransferParts parseFileTransferParts(String peerPayload) {
 
 /// Sends encrypted file ciphertext in WebSocket chunks with per-chunk acks.
 class FileTransferSender {
-  FileTransferSender(this._manager,
-      {this.ackTimeout = const Duration(seconds: 60)});
+  FileTransferSender(
+    this._manager, {
+    this.ackTimeout = const Duration(seconds: 60),
+    this.beginAckTimeout = FileTransferPolicy.beginAckTimeout,
+  });
 
   final WsConnectionManager _manager;
 
   /// Per-chunk ack wait before a retry. Injectable so tests can drive the
   /// retry/abort paths without a real 60 s delay; production keeps 60 s.
   final Duration ackTimeout;
+
+  /// Wait for the begin ack on an allegedly-ready link before rebuilding it.
+  /// Injectable so tests can drive the stale-link path without the real 2 s.
+  final Duration beginAckTimeout;
 
   Future<bool> send({
     required String peerOnion,
@@ -93,93 +100,111 @@ class FileTransferSender {
       pendingChunkAcks.remove(key)?.complete();
     }
 
-    controlSub = _manager.pushFramesFor(peerOnion).listen((frame) {
-      final op = frame['op'];
-      if (!WsFrame.isFileTransferOp(op is String ? op : '')) return;
+    try {
+      // The begin ack is the proof that the receiver actually accepted the
+      // link: a timeout on an allegedly-ready link means the link is stale,
+      // so tear it down and re-dial before giving up to the HTTP fallback.
+      // Begin/end acks are request responses, so the push subscription only
+      // needs to be live for chunk acks and is attached after begin succeeds.
+      for (var attempt = 0; ; attempt++) {
+        if (attempt > 0) {
+          Logging.debug(
+            'begin not acked, rebuilding link peer=$peerOnion',
+            'FileTransferSender',
+          );
+          await _manager.disconnectPeer(peerOnion);
+        }
+        await _manager.prepareForFileTransfer(peerOnion);
+        Logging.debug('WS ready peer=$peerOnion', 'FileTransferSender');
 
-      final payload = frame['payload'];
-      if (payload is! Map<String, dynamic>) {
         Logging.debug(
-          'ignoring file-transfer frame op=$op without map payload',
+          'begin transfer=$transferId message=$messageId chunks=$totalChunks '
+          'ciphertext=${ciphertext.length} peer=$peerOnion',
           'FileTransferSender',
         );
-        return;
+
+        final Map<String, dynamic> beginResult;
+        try {
+          beginResult = await _manager.request(
+            peerOnion,
+            'file_transfer_begin',
+            payload: {
+              'transferId': transferId,
+              'messageId': messageId,
+              'senderId': senderId,
+              'receiverId': receiverId,
+              'type': type,
+              'fileName': fileName,
+              'fileSize': fileSize,
+              'timestamp': timestamp ?? DateTime.now().millisecondsSinceEpoch,
+              'wrappedKey': parts.wrappedKey,
+              'nonce': base64Encode(parts.nonce),
+              'scheme': parts.scheme,
+              'ciphertextSize': ciphertext.length,
+              'totalChunks': totalChunks,
+              'chunkSize': chunkSize,
+              'replyTo': ?replyToId,
+              'viewOnce': viewOnce,
+              'expiresAt': ?expiresAt,
+            },
+            bypassQueue: true,
+            timeout: beginAckTimeout,
+          );
+        } on TimeoutException {
+          if (attempt >= FileTransferPolicy.beginRetries) rethrow;
+          continue;
+        }
+
+        if (beginResult.containsKey('error')) {
+          throw StateError(
+            beginResult['error']?.toString() ?? 'begin rejected',
+          );
+        }
+
+        Logging.debug(
+          'begin ack transfer=$transferId result=$beginResult',
+          'FileTransferSender',
+        );
+        break;
       }
 
-      if (op == 'file_transfer_chunk_ack') {
-        final tid = payload['transferId'];
-        final index = payload['chunkIndex'];
-        if (tid is! String || index is! int) {
+      controlSub = _manager.pushFramesFor(peerOnion).listen((frame) {
+        final op = frame['op'];
+        if (!WsFrame.isFileTransferOp(op is String ? op : '')) return;
+
+        final payload = frame['payload'];
+        if (payload is! Map<String, dynamic>) {
           Logging.debug(
-            'ignoring chunk_ack with bad fields tid=$tid index=$index',
+            'ignoring file-transfer frame op=$op without map payload',
             'FileTransferSender',
           );
           return;
         }
-        if (tid != transferId) return;
-        Logging.debug(
-          'chunk_ack ${index + 1}/$totalChunks transfer=$transferId',
-          'FileTransferSender',
-        );
-        completeChunkAck('$tid:$index');
-      } else if (op == 'file_transfer_begin_ack' || op == 'file_transfer_end_ack') {
-        Logging.debug(
-          'push $op transfer=${payload['transferId']} payload=$payload',
-          'FileTransferSender',
-        );
-      }
-    });
 
-    try {
-      if (!_manager.isConnected(peerOnion)) {
-        await _manager.prepareForFileTransfer(peerOnion);
-      } else {
-        _manager.pinPeer(peerOnion);
-      }
-      Logging.debug('WS ready peer=$peerOnion', 'FileTransferSender');
-
-      Logging.debug(
-        'begin transfer=$transferId message=$messageId chunks=$totalChunks '
-        'ciphertext=${ciphertext.length} peer=$peerOnion',
-        'FileTransferSender',
-      );
-
-      final beginResult = await _manager.request(
-        peerOnion,
-        'file_transfer_begin',
-        payload: {
-          'transferId': transferId,
-          'messageId': messageId,
-          'senderId': senderId,
-          'receiverId': receiverId,
-          'type': type,
-          'fileName': fileName,
-          'fileSize': fileSize,
-          'timestamp': timestamp ?? DateTime.now().millisecondsSinceEpoch,
-          'wrappedKey': parts.wrappedKey,
-          'nonce': base64Encode(parts.nonce),
-          'scheme': parts.scheme,
-          'ciphertextSize': ciphertext.length,
-          'totalChunks': totalChunks,
-          'chunkSize': chunkSize,
-          'replyTo': ?replyToId,
-          'viewOnce': viewOnce,
-          'expiresAt': ?expiresAt,
-        },
-        bypassQueue: true,
-        timeout: const Duration(seconds: 30),
-      );
-
-      if (beginResult.containsKey('error')) {
-        throw StateError(
-          beginResult['error']?.toString() ?? 'begin rejected',
-        );
-      }
-
-      Logging.debug(
-        'begin ack transfer=$transferId result=$beginResult',
-        'FileTransferSender',
-      );
+        if (op == 'file_transfer_chunk_ack') {
+          final tid = payload['transferId'];
+          final index = payload['chunkIndex'];
+          if (tid is! String || index is! int) {
+            Logging.debug(
+              'ignoring chunk_ack with bad fields tid=$tid index=$index',
+              'FileTransferSender',
+            );
+            return;
+          }
+          if (tid != transferId) return;
+          Logging.debug(
+            'chunk_ack ${index + 1}/$totalChunks transfer=$transferId',
+            'FileTransferSender',
+          );
+          completeChunkAck('$tid:$index');
+        } else if (op == 'file_transfer_begin_ack' ||
+            op == 'file_transfer_end_ack') {
+          Logging.debug(
+            'push $op transfer=${payload['transferId']} payload=$payload',
+            'FileTransferSender',
+          );
+        }
+      });
 
       var ackedChunks = 0;
       var nextIndex = 0;
@@ -330,7 +355,7 @@ class FileTransferSender {
       // Stop any chunk still looping through retries from sending more
       // frames once the ack subscription is gone.
       abandoned = true;
-      await controlSub.cancel();
+      await controlSub?.cancel();
       for (final completer in pendingChunkAcks.values) {
         if (!completer.isCompleted) {
           completer.completeError(StateError('transfer cancelled'));

--- a/lib/util/file_transfer_policy.dart
+++ b/lib/util/file_transfer_policy.dart
@@ -24,6 +24,16 @@ class FileTransferPolicy {
   /// Per-chunk send retries before failing the transfer.
   static const int maxChunkRetries = 3;
 
+  /// How long the sender waits for the file_transfer_begin ack on an
+  /// allegedly-ready link before treating the link as stale. Healthy ack
+  /// times are well under a second, so this never bites a live link.
+  static const Duration beginAckTimeout = Duration(seconds: 2);
+
+  /// Fresh-link rebuilds after a begin ack timeout: each rebuild tears the
+  /// stale link down and re-dials before the transfer gives up to the HTTP
+  /// fallback. Bounded so a genuinely dead receiver costs seconds, not 30.
+  static const int beginRetries = 2;
+
   static bool isChunkCandidate(int fileSizeBytes) =>
       fileSizeBytes >= chunkThresholdBytes;
 

--- a/test/file_transfer_handler_test.dart
+++ b/test/file_transfer_handler_test.dart
@@ -129,4 +129,140 @@ void main() {
     );
     expect(endResult['error'], 'Incomplete transfer');
   });
+
+  test('duplicate begin with matching metadata returns the existing ack',
+      () async {
+    final handler = FileTransferHandler.instance;
+    const transferId = '550e8400-e29b-41d4-a716-446655440002';
+    final ciphertext =
+        Uint8List.fromList(List<int>.generate(300, (i) => i % 251));
+    final chunkSize = FileTransferPolicy.chunkSizeBytes;
+    final totalChunks = FileTransferPolicy.chunkCountForSize(ciphertext.length);
+
+    Map<String, dynamic> beginPayload() => {
+          'transferId': transferId,
+          'messageId': 'msg-dupe',
+          'senderId': 'peer.onion',
+          'receiverId': 'local.onion',
+          'type': 'file',
+          'fileName': 'test.bin',
+          'fileSize': 300,
+          'timestamp': 1,
+          'wrappedKey': {'ephemeralPub': 'abc'},
+          'nonce': base64Encode(Uint8List(12)),
+          'ciphertextSize': ciphertext.length,
+          'totalChunks': totalChunks,
+          'chunkSize': chunkSize,
+        };
+
+    final first = await handler.handleBegin(
+      beginPayload(),
+      peerOnion: 'peer.onion',
+      localOnion: 'local.onion',
+    );
+    expect(first['ok'], isTrue);
+
+    // A sender retries the begin on a rebuilt link after its ack timed out;
+    // the receiver already holds this transfer and must answer idempotently.
+    final dupe = await handler.handleBegin(
+      beginPayload(),
+      peerOnion: 'peer.onion',
+      localOnion: 'local.onion',
+    );
+    expect(dupe['ok'], isTrue, reason: 'matching duplicate must be idempotent');
+    expect(dupe['transferId'], transferId);
+
+    // The retried begin must not have clobbered the session: chunks still
+    // reassemble into the original message.
+    for (var i = 0; i < totalChunks; i++) {
+      final offset = i * chunkSize;
+      final end = offset + chunkSize > ciphertext.length
+          ? ciphertext.length
+          : offset + chunkSize;
+      await handler.handleChunk(
+        FileTransferChunkFrame(
+          transferId: transferId,
+          chunkIndex: i,
+          payload: ciphertext.sublist(offset, end),
+        ),
+        peerOnion: 'peer.onion',
+        sendAck: (_, {payload}) async {},
+      );
+    }
+
+    final testRouter = _TestRouter();
+    handler.routerOverride = testRouter;
+    final endResult = await handler.handleEnd(
+      {'transferId': transferId},
+      peerOnion: 'peer.onion',
+    );
+    expect(endResult['ok'], isTrue);
+    expect(testRouter.lastProcessed?['id'], 'msg-dupe');
+  });
+
+  test('conflicting duplicate begin is rejected without overwriting',
+      () async {
+    final handler = FileTransferHandler.instance;
+    const transferId = '550e8400-e29b-41d4-a716-446655440003';
+    final ciphertext =
+        Uint8List.fromList(List<int>.generate(300, (i) => i % 251));
+    final chunkSize = FileTransferPolicy.chunkSizeBytes;
+    final totalChunks = FileTransferPolicy.chunkCountForSize(ciphertext.length);
+
+    Map<String, dynamic> beginPayload(String messageId) => {
+          'transferId': transferId,
+          'messageId': messageId,
+          'senderId': 'peer.onion',
+          'receiverId': 'local.onion',
+          'type': 'file',
+          'fileName': 'test.bin',
+          'fileSize': 300,
+          'timestamp': 1,
+          'wrappedKey': {'ephemeralPub': 'abc'},
+          'nonce': base64Encode(Uint8List(12)),
+          'ciphertextSize': ciphertext.length,
+          'totalChunks': totalChunks,
+          'chunkSize': chunkSize,
+        };
+
+    final first = await handler.handleBegin(
+      beginPayload('msg-orig'),
+      peerOnion: 'peer.onion',
+      localOnion: 'local.onion',
+    );
+    expect(first['ok'], isTrue);
+
+    final conflict = await handler.handleBegin(
+      beginPayload('msg-other'),
+      peerOnion: 'peer.onion',
+      localOnion: 'local.onion',
+    );
+    expect(conflict['error'], 'Transfer already exists');
+
+    // The original session must survive the rejected duplicate.
+    for (var i = 0; i < totalChunks; i++) {
+      final offset = i * chunkSize;
+      final end = offset + chunkSize > ciphertext.length
+          ? ciphertext.length
+          : offset + chunkSize;
+      await handler.handleChunk(
+        FileTransferChunkFrame(
+          transferId: transferId,
+          chunkIndex: i,
+          payload: ciphertext.sublist(offset, end),
+        ),
+        peerOnion: 'peer.onion',
+        sendAck: (_, {payload}) async {},
+      );
+    }
+
+    final testRouter = _TestRouter();
+    handler.routerOverride = testRouter;
+    final endResult = await handler.handleEnd(
+      {'transferId': transferId},
+      peerOnion: 'peer.onion',
+    );
+    expect(endResult['ok'], isTrue);
+    expect(testRouter.lastProcessed?['id'], 'msg-orig');
+  });
 }

--- a/test/file_transfer_handler_test.dart
+++ b/test/file_transfer_handler_test.dart
@@ -265,4 +265,80 @@ void main() {
     expect(endResult['ok'], isTrue);
     expect(testRouter.lastProcessed?['id'], 'msg-orig');
   });
+
+  test('duplicate begin with differing immutable metadata is rejected',
+        () async {
+    final handler = FileTransferHandler.instance;
+    const transferId = '550e8400-e29b-41d4-a716-446655440004';
+    final ciphertext =
+        Uint8List.fromList(List<int>.generate(300, (i) => i % 251));
+    final chunkSize = FileTransferPolicy.chunkSizeBytes;
+    final totalChunks = FileTransferPolicy.chunkCountForSize(ciphertext.length);
+
+    Map<String, dynamic> beginPayload({
+      required int ciphertextSize,
+      required int chunks,
+    }) =>
+        {
+          'transferId': transferId,
+          'messageId': 'msg-sz',
+          'senderId': 'peer.onion',
+          'receiverId': 'local.onion',
+          'type': 'file',
+          'fileName': 'test.bin',
+          'fileSize': 300,
+          'timestamp': 1,
+          'wrappedKey': {'ephemeralPub': 'abc'},
+          'nonce': base64Encode(Uint8List(12)),
+          'ciphertextSize': ciphertextSize,
+          'totalChunks': chunks,
+          'chunkSize': chunkSize,
+        };
+
+    final first = await handler.handleBegin(
+      beginPayload(ciphertextSize: ciphertext.length, chunks: totalChunks),
+      peerOnion: 'peer.onion',
+      localOnion: 'local.onion',
+    );
+    expect(first['ok'], isTrue);
+
+    // Same transferId and identifying fields, but a different ciphertext
+    // size (with a chunk count consistent with it): the idempotent ack must
+    // not be granted for a transfer whose immutable metadata differs.
+    final conflict = await handler.handleBegin(
+      beginPayload(
+        ciphertextSize: ciphertext.length + FileTransferPolicy.chunkSizeBytes,
+        chunks: totalChunks + 1,
+      ),
+      peerOnion: 'peer.onion',
+      localOnion: 'local.onion',
+    );
+    expect(conflict['error'], 'Transfer already exists');
+
+    // The original session must survive the rejected duplicate.
+    for (var i = 0; i < totalChunks; i++) {
+      final offset = i * chunkSize;
+      final end = offset + chunkSize > ciphertext.length
+          ? ciphertext.length
+          : offset + chunkSize;
+      await handler.handleChunk(
+        FileTransferChunkFrame(
+          transferId: transferId,
+          chunkIndex: i,
+          payload: ciphertext.sublist(offset, end),
+        ),
+        peerOnion: 'peer.onion',
+        sendAck: (_, {payload}) async {},
+      );
+    }
+
+    final testRouter = _TestRouter();
+    handler.routerOverride = testRouter;
+    final endResult = await handler.handleEnd(
+      {'transferId': transferId},
+      peerOnion: 'peer.onion',
+    );
+    expect(endResult['ok'], isTrue);
+    expect(testRouter.lastProcessed?['id'], 'msg-sz');
+  });
 }

--- a/test/file_transfer_sender_test.dart
+++ b/test/file_transfer_sender_test.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 import 'dart:convert';
+import 'dart:io';
 import 'dart:typed_data';
 
 import 'package:flutter_test/flutter_test.dart';
@@ -155,6 +156,39 @@ class _GatedAckLink extends _AckLinkBase {
         return;
       }
     }
+  }
+}
+
+/// A link that reports connected but never acks the begin: the sender's
+/// readiness gate is satisfied while the receiver never accepts the transfer,
+/// exactly the cold-restart case from the field report. The begin request
+/// times out; the sender must tear the link down and re-dial.
+class _StaleBeginLink extends _AckLinkBase {
+  _StaleBeginLink(super.peerOnion);
+
+  var closed = false;
+
+  @override
+  Future<Map<String, dynamic>> request(
+    String op, {
+    Map<String, dynamic>? payload,
+    Duration timeout = const Duration(seconds: 30),
+  }) async {
+    sentOps.add(op);
+    sentPayloads.add(payload);
+    if (op == 'file_transfer_begin') {
+      await Completer<Map<String, dynamic>>().future.timeout(timeout);
+    }
+    return {'ok': true};
+  }
+
+  @override
+  Future<void> sendBytes(List<int> bytes) async {}
+
+  @override
+  Future<void> close() async {
+    closed = true;
+    await super.close();
   }
 }
 
@@ -843,5 +877,105 @@ void main() {
     await Future<void>.delayed(const Duration(milliseconds: 20));
 
     started.manager.dispose();
+  });
+
+  test('begin timeout on an allegedly-ready link rebuilds and retries',
+      () async {
+    FileTransferProgress.resetForTest();
+
+    final torDataDir = Directory.systemTemp.createTempSync('fts_rebuild');
+    addTearDown(() => torDataDir.deleteSync(recursive: true));
+    Directory('${torDataDir.path}/hidden_service').createSync(recursive: true);
+    File('${torDataDir.path}/hidden_service/hostname')
+        .writeAsStringSync('${'z' * 56}.onion');
+
+    final manager = WsConnectionManager(
+      TorManager(
+        torPath: '/bin/false',
+        dataDir: torDataDir.path,
+        controlPassword: 'test-password',
+      ),
+    );
+    // Lexically smaller than the fake local onion, so the manager waits for
+    // an inbound link instead of dialing out over SOCKS.
+    const peer =
+        '0000000000000000000000000000000000000000000000000000000000000000.onion';
+
+    final stale = _StaleBeginLink(peer);
+    manager.registerLinkForTest(peer, stale);
+
+    _ChunkAckLink? fresh;
+    manager.nudgePeerForInbound = (peerOnion) async {
+      await Future<void>.delayed(Duration.zero);
+      fresh = _ChunkAckLink(peerOnion);
+      manager.registerLinkForTest(peerOnion, fresh!, outbound: true);
+    };
+
+    final ciphertext =
+        Uint8List.fromList(List<int>.generate(300000, (i) => i % 251));
+    final sender = FileTransferSender(
+      manager,
+      beginAckTimeout: const Duration(milliseconds: 50),
+    );
+    final ok = await sender.send(
+      peerOnion: peer,
+      messageId: 'msg-rebuild-1',
+      senderId: 'me.onion',
+      receiverId: peer,
+      type: 'file',
+      fileName: 'rebuild.bin',
+      fileSize: ciphertext.length,
+      peerPayload: _envelopePayload(ciphertext),
+    );
+
+    expect(ok, isTrue);
+    expect(stale.closed, isTrue, reason: 'stale link must be torn down');
+    expect(fresh, isNotNull);
+    expect(fresh!.sentOps, contains('file_transfer_begin'),
+        reason: 'fresh link must carry the retried begin');
+    expect(fresh!.sentOps, contains('file_transfer_end'));
+
+    manager.dispose();
+  });
+
+  test('begin timeout with no fresh link fails fast, not after 30 s', () async {
+    FileTransferProgress.resetForTest();
+
+    final manager = WsConnectionManager(
+      TorManager(
+        torPath: '/bin/false',
+        dataDir: '/tmp/file-transfer-sender',
+        controlPassword: 'test-password',
+      ),
+    );
+    const peer = 'peer.onion';
+    final stale = _StaleBeginLink(peer);
+    manager.registerLinkForTest(peer, stale);
+
+    final ciphertext =
+        Uint8List.fromList(List<int>.generate(300000, (i) => i % 251));
+    final sender = FileTransferSender(
+      manager,
+      beginAckTimeout: const Duration(milliseconds: 50),
+    );
+    final stopwatch = Stopwatch()..start();
+    final ok = await sender.send(
+      peerOnion: peer,
+      messageId: 'msg-rebuild-fail',
+      senderId: 'me.onion',
+      receiverId: peer,
+      type: 'file',
+      fileName: 'rebuild-fail.bin',
+      fileSize: ciphertext.length,
+      peerPayload: _envelopePayload(ciphertext),
+    );
+    stopwatch.stop();
+
+    expect(ok, isFalse);
+    expect(stale.closed, isTrue, reason: 'stale link must be torn down');
+    expect(stopwatch.elapsed, lessThan(const Duration(seconds: 10)),
+        reason: 'must not wait out the old 30 s begin timeout');
+
+    manager.dispose();
   });
 }


### PR DESCRIPTION
… file transfer

- Introduced beginAckTimeout to allow the sender to wait for a file_transfer_begin acknowledgment before considering the link stale.
- Updated FileTransferSender to manage link rebuilding upon timeout, enhancing reliability in file transfers.
- Added tests to verify behavior when the begin acknowledgment is not received, ensuring the sender retries with a fresh link.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved file-transfer startup reliability by retrying when the initial acknowledgement times out.
  * Stale connections are now closed and rebuilt automatically before retrying.
  * File transfers now fail promptly when no replacement connection is available.
  * Duplicate transfer requests with matching details are handled safely without disrupting the active transfer.
  * Conflicting reuse of a transfer ID is rejected to prevent transfer corruption.

* **Configuration**
  * Added configurable acknowledgement timeout and retry limits, with sensible defaults.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->