### PR TITLE
feat(privacy): update privacy settings description and enhance call m…

### DIFF
--- a/lib/screens/privacy_settings_screen.dart
+++ b/lib/screens/privacy_settings_screen.dart
@@ -182,7 +182,7 @@ class _PrivacySettingsScreenState extends State<PrivacySettingsScreen> {
                   PrysmSwitchRow(
                     title: 'Refuse messages from non-contacts',
                     subtitle:
-                        'When enabled, people who are not in your contacts cannot message you directly.',
+                        'When enabled, people who are not in your contacts cannot message or call you directly.',
                     value: _refuseUnknownSenders,
                     onChanged: _onRefuseUnknownSendersToggle,
                   ),

--- a/lib/server/inbound_message_router.dart
+++ b/lib/server/inbound_message_router.dart
@@ -281,6 +281,19 @@ class InboundMessageRouter {
       return _handleGroupControl(data, type);
     }
 
+    // Group traffic is only accepted from members of the addressed group. A
+    // stranger who guesses a groupId must not be able to plant rows or
+    // trigger notifications (or a users row via ensureUserExist below) — not
+    // just via chat messages, but via group modifies, read receipts, and
+    // reactions too. Ack-and-drop — indistinguishable from delivery — so the
+    // sender cannot tell this gate from a real delivery, matching
+    // _senderRefused. Control and invite messages are excluded: they are
+    // authenticated by their own signed-envelope flow in _handleGroupControl.
+    final groupId = data['groupId'] as String?;
+    if (groupId != null && !await DBHelper.isGroupMember(groupId, senderId)) {
+      return InboundHandleResult.ok({'status': 'received', 'id': data['id']});
+    }
+
     if (isMessageModifyType(type)) {
       return _handleMessageModify(data, type);
     }
@@ -534,16 +547,6 @@ class InboundMessageRouter {
     final senderId = data['senderId'] as String;
     final local = localOnionAddress();
     final inboundGroupId = data['groupId'] as String?;
-
-    if (inboundGroupId != null &&
-        !await DBHelper.isGroupMember(inboundGroupId, senderId)) {
-      // Group traffic is only accepted from members of the addressed group.
-      // A stranger who guesses a groupId must not be able to plant rows or
-      // trigger notifications (or a users row via ensureUserExist below).
-      // Ack-and-drop — indistinguishable from delivery — so the sender
-      // cannot tell this gate from a real delivery, matching _senderRefused.
-      return InboundHandleResult.ok({'status': 'received', 'id': data['id']});
-    }
 
     await DBHelper.ensureUserExist(senderId);
 

--- a/lib/server/inbound_message_router.dart
+++ b/lib/server/inbound_message_router.dart
@@ -533,6 +533,17 @@ class InboundMessageRouter {
     final receiverId = data['receiverId'] as String;
     final senderId = data['senderId'] as String;
     final local = localOnionAddress();
+    final inboundGroupId = data['groupId'] as String?;
+
+    if (inboundGroupId != null &&
+        !await DBHelper.isGroupMember(inboundGroupId, senderId)) {
+      // Group traffic is only accepted from members of the addressed group.
+      // A stranger who guesses a groupId must not be able to plant rows or
+      // trigger notifications (or a users row via ensureUserExist below).
+      // Ack-and-drop — indistinguishable from delivery — so the sender
+      // cannot tell this gate from a real delivery, matching _senderRefused.
+      return InboundHandleResult.ok({'status': 'received', 'id': data['id']});
+    }
 
     await DBHelper.ensureUserExist(senderId);
 
@@ -542,7 +553,6 @@ class InboundMessageRouter {
         ? incomingTimestamp
         : timeReceived;
 
-    final inboundGroupId = data['groupId'] as String?;
     final localUserId = local;
     var messageStatus = (data['status'] as String?) ?? 'received';
     if (inboundGroupId != null && localUserId != null) {

--- a/lib/services/call/call_manager.dart
+++ b/lib/services/call/call_manager.dart
@@ -7,6 +7,8 @@ import 'package:prysm/database/call_logs_db.dart';
 import 'package:prysm/database/messages.dart';
 import 'package:prysm/server/inbound_rate_limiter.dart';
 import 'package:prysm/services/block_service.dart';
+import 'package:prysm/services/settings_service.dart';
+import 'package:prysm/util/db_helper.dart';
 import 'package:prysm/services/call/audio_engine.dart';
 import 'package:prysm/services/call/call_session.dart';
 import 'package:prysm/services/call/opus_codec.dart';
@@ -53,16 +55,28 @@ typedef CallAudioFactory =
       required CallAudioSendCallback onSendFrame,
     });
 
+/// Returns true when an inbound caller should be silently refused (no ring,
+/// no reply, no log). Mirrors [InboundMessageRouter._senderRefused] on the
+/// call signaling surface.
+typedef SenderRefusedCallback = Future<bool> Function(String peerOnion);
+
+Future<bool> _defaultSenderRefused(String peerOnion) async {
+  if (!SettingsService().refuseUnknownSenders) return false;
+  return (await DBHelper.getUserById(peerOnion)) == null;
+}
+
 class CallManager extends ChangeNotifier {
   CallManager({
     required KeyManager keyManager,
     CallTransport? transport,
     CallKeyResolver? keyResolver,
     CallAudioFactory? audioFactory,
+    SenderRefusedCallback? senderRefused,
   }) : _keyManager = keyManager,
        _transport = transport,
        _keyResolver = keyResolver,
-       _audioFactory = audioFactory ?? createCallAudio;
+       _audioFactory = audioFactory ?? createCallAudio,
+       _senderRefused = senderRefused ?? _defaultSenderRefused;
 
   static CallManager? _instance;
 
@@ -79,6 +93,7 @@ class CallManager extends ChangeNotifier {
     CallTransport? transport,
     CallKeyResolver? keyResolver,
     CallAudioFactory? audioFactory,
+    SenderRefusedCallback? senderRefused,
   }) {
     final existing = _instance;
     if (existing != null && identical(existing._keyManager, keyManager)) {
@@ -90,6 +105,7 @@ class CallManager extends ChangeNotifier {
       transport: transport,
       keyResolver: keyResolver,
       audioFactory: audioFactory,
+      senderRefused: senderRefused,
     );
   }
 
@@ -133,6 +149,7 @@ class CallManager extends ChangeNotifier {
   CallTransport? _transport;
   CallKeyResolver? _keyResolver;
   final CallAudioFactory _audioFactory;
+  final SenderRefusedCallback _senderRefused;
   final InboundRateLimiter _offerLimiter = InboundRateLimiter(
     window: inboundOfferWindow,
     maxPerKey: maxInboundOffersPerWindow,
@@ -395,6 +412,13 @@ class CallManager extends ChangeNotifier {
       if (callId != null) {
         await _sendEnd(event.peerOnion, callId, reason: 'declined');
       }
+      return;
+    }
+
+    // Privacy gate: when the user refuses unknown senders, a caller who is
+    // not a known contact is dropped silently — no ring, no `call_end`
+    // reply, no missed-call log — so the caller cannot probe liveness.
+    if (await _senderRefused(event.peerOnion)) {
       return;
     }
 

--- a/test/call_manager_test.dart
+++ b/test/call_manager_test.dart
@@ -34,6 +34,7 @@ void main() {
   late CallSignalingNotifier notifier;
   late CallManager manager;
   late _RecordingForegroundSession foreground;
+  late _RefusingSenderRefused senderRefused;
 
   late IdentityPublicKeys peerKeys;
   late IdentityPublicKeys localKeys;
@@ -78,12 +79,14 @@ void main() {
     CallManager.resetForTest();
     foreground = _RecordingForegroundSession();
     CallForegroundSession.testOverride = foreground;
+    senderRefused = _RefusingSenderRefused();
     manager = CallManager(
       keyManager: keyManager,
       transport: transport,
       keyResolver: keyResolver,
       audioFactory: ({required session, required onSendFrame}) =>
           _FakeCallAudio(onSendFrame: onSendFrame),
+      senderRefused: (peerOnion) => senderRefused.call(peerOnion),
     );
     manager.start();
   });
@@ -351,6 +354,54 @@ void main() {
     },
   );
 
+  test(
+    'incoming offer from a refused unknown sender neither rings nor logs',
+    () async {
+      // Stands in for `refuseUnknownSenders && no users row` so the test DB
+      // stays hermetic (no users table in this suite).
+      senderRefused.value = true;
+
+      final caller = CallSession.createOutbound(
+        callId: 'refused-offer',
+        sessionId: 13,
+        peerOnion: 'local.onion',
+      );
+      notifier.applyInbound('stranger.onion', 'call_offer', {
+        'callId': caller.callId,
+        'sessionId': caller.sessionId,
+        'wrappedKey': await caller.wrapKeyForPeer(localKeys, peerKeyManager),
+      });
+
+      await Future<void>.delayed(Duration.zero);
+      expect(senderRefused.callers, ['stranger.onion']);
+      // No ring.
+      expect(manager.snapshot.state, CallState.idle);
+      // No reply that could leak liveness.
+      expect(transport.sentFrames.where((f) => f.op == 'call_end'), isEmpty);
+      // No missed-call log.
+      expect(await CallLogsDb.getLogs(), isEmpty);
+    },
+  );
+
+  test(
+    'offer from a non-refused sender still rings',
+    () async {
+      final caller = CallSession.createOutbound(
+        callId: 'accepted-offer',
+        sessionId: 14,
+        peerOnion: 'local.onion',
+      );
+      notifier.applyInbound('known.onion', 'call_offer', {
+        'callId': caller.callId,
+        'sessionId': caller.sessionId,
+        'wrappedKey': await caller.wrapKeyForPeer(localKeys, peerKeyManager),
+      });
+
+      await Future<void>.delayed(Duration.zero);
+      expect(manager.snapshot.state, CallState.incoming);
+    },
+  );
+
   test('inbound call_offer flood from one sender is rate-limited', () async {
     var incomingTransitions = 0;
     manager.addListener(() {
@@ -535,6 +586,16 @@ class _FakeKeyResolver implements CallKeyResolver {
 
   @override
   Future<IdentityPublicKeys?> resolve(String peerOnion) async => key;
+}
+
+class _RefusingSenderRefused {
+  bool value = false;
+  final callers = <String>[];
+
+  Future<bool> call(String peerOnion) async {
+    callers.add(peerOnion);
+    return value;
+  }
 }
 
 class _FakeCallAudio implements CallAudio {

--- a/test/group_invite_mode_screens_test.dart
+++ b/test/group_invite_mode_screens_test.dart
@@ -102,7 +102,7 @@ void main() {
     expect(
       find.text(
         'When enabled, people who are not in your contacts cannot message '
-        'you directly.',
+        'or call you directly.',
       ),
       findsOneWidget,
     );

--- a/test/security/group_inbound_claim_resolve_test.dart
+++ b/test/security/group_inbound_claim_resolve_test.dart
@@ -380,6 +380,19 @@ void main() {
       'publicKeyPem': jsonEncode(await alice.toPublicJson()),
     });
 
+    // The membership gate only admits group traffic from members of the
+    // addressed group, so the sender under test must be in group_members.
+    await dbHelperDb.insert(
+      'group_members',
+      {
+        'groupId': 'g1',
+        'memberId': 'alice.onion',
+        'role': 'member',
+        'joinedAt': 0,
+      },
+      conflictAlgorithm: ConflictAlgorithm.replace,
+    );
+
     router = InboundMessageRouter(
       keyManager: KeyManager(),
       settings: SettingsService(),

--- a/test/security/group_message_anti_replay_test.dart
+++ b/test/security/group_message_anti_replay_test.dart
@@ -204,6 +204,29 @@ void main() {
       'publicKeyPem': jsonEncode(await bob.toPublicJson()),
     });
 
+    // The membership gate only admits group traffic from members of the
+    // addressed group, so the senders under test must be in group_members.
+    await dbHelperDb.insert(
+      'group_members',
+      {
+        'groupId': 'g1',
+        'memberId': 'alice.onion',
+        'role': 'member',
+        'joinedAt': 0,
+      },
+      conflictAlgorithm: ConflictAlgorithm.replace,
+    );
+    await dbHelperDb.insert(
+      'group_members',
+      {
+        'groupId': 'g1',
+        'memberId': 'bob.onion',
+        'role': 'member',
+        'joinedAt': 0,
+      },
+      conflictAlgorithm: ConflictAlgorithm.replace,
+    );
+
     router = InboundMessageRouter(
       keyManager: KeyManager(),
       settings: SettingsService(),

--- a/test/security/group_message_legacy_scheme_test.dart
+++ b/test/security/group_message_legacy_scheme_test.dart
@@ -201,6 +201,20 @@ void main() {
     dbHelperDb = await _openDbHelperDb();
     DBHelper.setDatabaseForTest(dbHelperDb);
 
+    // The membership gate only admits group traffic from members of the
+    // addressed group, so the sender under test must be a member for the
+    // legacy-scheme gate (not the membership gate) to fire.
+    await dbHelperDb.insert(
+      'group_members',
+      {
+        'groupId': 'g1',
+        'memberId': 'alice.onion',
+        'role': 'member',
+        'joinedAt': 0,
+      },
+      conflictAlgorithm: ConflictAlgorithm.replace,
+    );
+
     router = InboundMessageRouter(
       keyManager: KeyManager(),
       settings: SettingsService(),

--- a/test/security/group_profile_fetch_gate_test.dart
+++ b/test/security/group_profile_fetch_gate_test.dart
@@ -346,6 +346,15 @@ void main() {
       'publicKeyPem': aliceJson,
     });
 
+    // The membership gate only admits group traffic from members of the
+    // addressed group, so the good-path sender must be a member of g1.
+    await dbHelperDb.insert('group_members', {
+      'groupId': 'g1',
+      'memberId': 'alice.onion',
+      'role': 'member',
+      'joinedAt': 0,
+    });
+
     fetched = [];
     router = InboundMessageRouter(
       keyManager: KeyManager.fromIdentity(localIdentity),
@@ -370,9 +379,9 @@ void main() {
 
   group('M2: group-chat profile fetch is gated', () {
     test(
-      'RED: a legacy group-aead envelope from an unknown sender is rejected '
-      'with 400 and never fetches the sender profile (pre-fix: fetch fires '
-      'before the legacy gate)', () async {
+      'RED: a legacy group-aead envelope from a non-member is acked-but-'
+      'dropped and never fetches the sender profile (pre-fix: the fetch '
+      'fired before the legacy gate)', () async {
         final result = await router.handleMessage(
           await _legacyGroupMessage(
             id: 'm1',
@@ -381,8 +390,12 @@ void main() {
           ),
         );
 
-        expect(result.statusCode, 400);
+        // The membership gate drops non-member group traffic first; the
+        // fetch must not fire.
+        expect(result.statusCode, 200);
+        expect(result.jsonBody?['status'], 'received');
         expect(fetched, isEmpty);
+        expect(await messagesDb.query('messages'), isEmpty);
       },
     );
 
@@ -420,6 +433,12 @@ void main() {
           'memberId': 'local.onion',
           'role': 'member',
           'joinedAt': 2000,
+        });
+        await dbHelperDb.insert('group_members', {
+          'groupId': 'g1',
+          'memberId': 'attacker.onion',
+          'role': 'member',
+          'joinedAt': 0,
         });
 
         final result = await router.handleMessage(
@@ -459,10 +478,9 @@ void main() {
     );
 
     test(
-      'RED: a non-parseable (garbage) group envelope from an unknown sender '
-      'is stored but never fetches the sender profile (pre-fix: the '
-      'fail-open gates pass it through and the fetch fires anyway)',
-      () async {
+      'RED: a non-parseable (garbage) group envelope from a non-member is '
+      'acked-but-dropped and never fetches the sender profile (pre-fix: the '
+      'fail-open gates passed it through and stored it)', () async {
         final result = await router.handleMessage({
           'id': 'm1',
           'senderId': 'attacker.onion',
@@ -473,25 +491,22 @@ void main() {
           'timestamp': 1000,
         });
 
-        // Accepted and stored exactly like today: the fetch is the only
-        // thing suppressed for senders whose identity is not in the local
-        // user store.
+        // The membership gate drops non-member group traffic entirely:
+        // nothing is stored, and the fetch must not fire.
         expect(result.statusCode, 200);
         expect(result.jsonBody?['status'], 'received');
         expect(fetched, isEmpty);
 
         final rows = await messagesDb.query('messages');
-        expect(rows, hasLength(1));
-        expect(rows.single['senderId'], 'attacker.onion');
-        expect(rows.single['groupId'], 'g1');
+        expect(rows, isEmpty);
       },
     );
 
     test(
-      'RED: a self-signed sender-key envelope from an unknown sender is '
-      'stored but never fetches the sender profile (pre-fix: the fail-open '
-      'anti-replay gate passes an unresolvable sender through and the fetch '
-      'fires)',
+      'RED: a self-signed sender-key envelope from a non-member is '
+      'acked-but-dropped and never fetches the sender profile (pre-fix: the '
+      'fail-open anti-replay gate passed an unresolvable sender through and '
+      'the fetch fired)',
       () async {
         final attacker = await IdentityKeyPair.generate();
         final result = await router.handleMessage(
@@ -505,14 +520,14 @@ void main() {
           ),
         );
 
+        // The membership gate drops non-member group traffic entirely:
+        // nothing is stored, and the fetch must not fire.
         expect(result.statusCode, 200);
         expect(result.jsonBody?['status'], 'received');
         expect(fetched, isEmpty);
 
         final rows = await messagesDb.query('messages');
-        expect(rows, hasLength(1));
-        expect(rows.single['senderId'], 'attacker.onion');
-        expect(rows.single['groupId'], 'g1');
+        expect(rows, isEmpty);
       },
     );
 

--- a/test/security/refuse_unknown_senders_test.dart
+++ b/test/security/refuse_unknown_senders_test.dart
@@ -174,6 +174,55 @@ void main() {
   );
 
   test(
+    'group message from a sender who is not a member is acked and dropped: '
+    'no users row, no message row (membership gate is independent of '
+    'refuseUnknownSenders)',
+    () async {
+      final result = await router.processMessage({
+        'id': 'msg-t6',
+        'senderId': 'stranger.onion',
+        'receiverId': 'local.onion',
+        'message': 'cipher',
+        'type': groupTextType,
+        'groupId': 'grp-forged',
+        'timestamp': 1,
+      });
+
+      expect(result.statusCode, 200);
+      expect(result.jsonBody?['status'], 'received');
+      expect(result.jsonBody?['id'], 'msg-t6');
+      expect(await messageRowCount(), 0);
+      expect(await DBHelper.getUserById('stranger.onion'), isNull);
+    },
+  );
+
+  test(
+    'group message from a member of the group is stored',
+    () async {
+      await dbHelperDb.insert('group_members', {
+        'groupId': 'grp-1',
+        'memberId': 'alice.onion',
+        'role': 'member',
+        'joinedAt': 0,
+      });
+
+      final result = await router.processMessage({
+        'id': 'msg-t7',
+        'senderId': 'alice.onion',
+        'receiverId': 'local.onion',
+        'message': 'cipher',
+        'type': groupTextType,
+        'groupId': 'grp-1',
+        'timestamp': 1,
+      });
+
+      expect(result.statusCode, 200);
+      expect(result.jsonBody?['status'], 'received');
+      expect(await messageRowCount(), 1);
+    },
+  );
+
+  test(
     'a forged groupId on a direct type is rejected, not treated as group traffic',
     () async {
       Map<String, dynamic> forged(String id) => {


### PR DESCRIPTION
…anagement for unknown senders

- Updated the description for the 'Refuse messages from non-contacts' setting to clarify that it also applies to calls.
- Implemented logic in CallManager to silently refuse calls from unknown senders when the refuseUnknownSenders setting is enabled, ensuring no notifications are sent to the caller.
- Enhanced InboundMessageRouter to restrict group message traffic to members only, preventing unauthorized access.
- Added tests to verify the behavior of the new call management features and group message handling.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Updated privacy settings to clarify that refusing messages from non-contacts also prevents direct calls.
  * Refused calls from blocked or unknown senders are discarded without ringing, replying, or creating missed-call records.

* **Security Improvements**
  * Group messages from non-members are acknowledged but not processed or stored.
  * Valid messages from group members continue to be accepted normally.

* **Tests**
  * Added coverage for sender refusal and group membership enforcement.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->