### PR TITLE
feat: add message forwarding functionality and localization updates

### DIFF
--- a/lib/database/message_query_filters.dart
+++ b/lib/database/message_query_filters.dart
@@ -37,5 +37,6 @@ class MessageQueryFilters {
     'editedAt',
     'readAt',
     'expiresAt',
+    'forwarded',
   ];
 }

--- a/lib/database/message_schema_migrations.dart
+++ b/lib/database/message_schema_migrations.dart
@@ -11,7 +11,7 @@ class MessageSchemaMigrations {
   MessageSchemaMigrations._();
 
   /// Current schema version. Bump alongside a new _upgradeToVN step.
-  static const int dbVersion = 15;
+  static const int dbVersion = 16;
 
   static Future<void> onCreate(Database db, int version) async {
     await _createV2(db);
@@ -35,6 +35,7 @@ class MessageSchemaMigrations {
     if (oldVersion < 13) await _upgradeToV13(db);
     if (oldVersion < 14) await _upgradeToV14(db);
     if (oldVersion < 15) await _upgradeToV15(db);
+    if (oldVersion < 16) await _upgradeToV16(db);
   }
 
   static Future<void> migrateOversizedMessagePayloads(Database db) async {
@@ -111,7 +112,8 @@ class MessageSchemaMigrations {
                 groupId TEXT,
                 deletedAt INTEGER,
                 editedAt INTEGER,
-                expiresAt INTEGER
+                expiresAt INTEGER,
+                forwarded INTEGER NOT NULL DEFAULT 0
             )
         ''');
 
@@ -281,6 +283,23 @@ class MessageSchemaMigrations {
     ''');
   }
 
+  static Future<void> _upgradeToV16(Database db) async {
+    Logging.info('UPGRADING DB TO v16', 'MessagesDb');
+    final messageCols = await db.rawQuery('PRAGMA table_info(messages)');
+    if (!messageCols.any((col) => col['name'] == 'forwarded')) {
+      await db.execute(
+        'ALTER TABLE messages ADD COLUMN forwarded INTEGER NOT NULL DEFAULT 0',
+      );
+    }
+    final selfCols = await db.rawQuery('PRAGMA table_info(self_messages)');
+    if (selfCols.isNotEmpty &&
+        !selfCols.any((col) => col['name'] == 'forwarded')) {
+      await db.execute(
+        'ALTER TABLE self_messages ADD COLUMN forwarded INTEGER NOT NULL DEFAULT 0',
+      );
+    }
+  }
+
   /// Plaintext FTS5 index for local message search (protected by SQLCipher),
   /// plus the message_search_rows side table that keeps deletes O(1).
   static Future<void> createMessageSearchFtsTable(Database db) async {
@@ -356,7 +375,8 @@ class MessageSchemaMigrations {
         viewOnce INTEGER DEFAULT 0,
         viewed INTEGER DEFAULT 0,
         deletedAt INTEGER,
-        editedAt INTEGER
+        editedAt INTEGER,
+        forwarded INTEGER NOT NULL DEFAULT 0
       )
     ''');
     await db.execute(

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -73,6 +73,13 @@
       }
     }
   },
+  "@couldNotForwardE": {
+    "placeholders": {
+      "e": {
+        "type": "String"
+      }
+    }
+  },
   "@couldNotLoadDownloadsE": {
     "placeholders": {
       "e": {
@@ -831,6 +838,7 @@
   "couldNotDeleteForEveryone": "Could not delete for everyone",
   "couldNotDeleteMediaE": "Could not delete media: {e}",
   "couldNotEditMessage": "Could not edit message",
+  "couldNotForwardE": "Could not forward: {e}",
   "couldNotLoadDownloadsE": "Could not load downloads: {e}",
   "couldNotLoadImage": "Could not load image",
   "couldNotLoadMediaE": "Could not load media: {e}",
@@ -978,6 +986,8 @@
   "fontInter": "Inter",
   "fontJetBrainsMono": "JetBrains Mono",
   "fontSystem": "System",
+  "forward": "Forward",
+  "forwarded": "Forwarded",
   "galleryAccessDenied": "Gallery access denied",
   "general": "General",
   "getStarted": "Get started",
@@ -1323,6 +1333,7 @@
   "shareToPrysm": "Share to Prysm",
   "sharedMedia": "Shared Media",
   "showAnEmptyAppWhileYourRealData": "Show an empty app while your real data stays encrypted on disk",
+  "showAsForwarded": "Show as forwarded",
   "showFullQr": "Show full QR",
   "showInChat": "Show in chat",
   "showMyQrCode": "Show my QR code",

--- a/lib/l10n/app_it.arb
+++ b/lib/l10n/app_it.arb
@@ -28,6 +28,13 @@
       }
     }
   },
+  "@couldNotForwardE": {
+    "placeholders": {
+      "e": {
+        "type": "String"
+      }
+    }
+  },
   "@couldNotLoadDownloadsE": {
     "placeholders": {
       "e": {
@@ -457,6 +464,7 @@
   "couldNotDeleteForEveryone": "Impossibile cancellare per tutti",
   "couldNotDeleteMediaE": "Impossibile cancellare media: {e}",
   "couldNotEditMessage": "Impossibile modificare il messaggio",
+  "couldNotForwardE": "Impossibile inoltrare: {e}",
   "couldNotLoadDownloadsE": "Impossibile caricare i downloads: {e}",
   "couldNotLoadImage": "Impossibile copiare l'immagine",
   "couldNotLoadMediaE": "Impossibile caricare i media: {e}",
@@ -604,6 +612,8 @@
   "fontInter": "Inter",
   "fontJetBrainsMono": "JetBrains Mono",
   "fontSystem": "Sistema",
+  "forward": "Inoltra",
+  "forwarded": "Inoltrato",
   "galleryAccessDenied": "Accesso alla galleria negato",
   "general": "Generale",
   "getStarted": "Inizia",
@@ -949,6 +959,7 @@
   "shareToPrysm": "Condividi su Prysm",
   "sharedMedia": "Media condivisi",
   "showAnEmptyAppWhileYourRealData": "Mostra l'app vuota mentre i dati reali rimangono cifrati sul disco",
+  "showAsForwarded": "Mostra come inoltrato",
   "showFullQr": "Mostra QR completo",
   "showInChat": "Mostra in chat",
   "showMyQrCode": "Mostra il mio codice QR",

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -902,6 +902,12 @@ abstract class AppLocalizations {
   /// **'Could not edit message'**
   String get couldNotEditMessage;
 
+  /// No description provided for @couldNotForwardE.
+  ///
+  /// In en, this message translates to:
+  /// **'Could not forward: {e}'**
+  String couldNotForwardE(String e);
+
   /// No description provided for @couldNotLoadDownloadsE.
   ///
   /// In en, this message translates to:
@@ -1783,6 +1789,18 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'System'**
   String get fontSystem;
+
+  /// No description provided for @forward.
+  ///
+  /// In en, this message translates to:
+  /// **'Forward'**
+  String get forward;
+
+  /// No description provided for @forwarded.
+  ///
+  /// In en, this message translates to:
+  /// **'Forwarded'**
+  String get forwarded;
 
   /// No description provided for @galleryAccessDenied.
   ///
@@ -3853,6 +3871,12 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'Show an empty app while your real data stays encrypted on disk'**
   String get showAnEmptyAppWhileYourRealData;
+
+  /// No description provided for @showAsForwarded.
+  ///
+  /// In en, this message translates to:
+  /// **'Show as forwarded'**
+  String get showAsForwarded;
 
   /// No description provided for @showFullQr.
   ///

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -470,6 +470,11 @@ class AppLocalizationsEn extends AppLocalizations {
   String get couldNotEditMessage => 'Could not edit message';
 
   @override
+  String couldNotForwardE(String e) {
+    return 'Could not forward: $e';
+  }
+
+  @override
   String couldNotLoadDownloadsE(String e) {
     return 'Could not load downloads: $e';
   }
@@ -984,6 +989,12 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get fontSystem => 'System';
+
+  @override
+  String get forward => 'Forward';
+
+  @override
+  String get forwarded => 'Forwarded';
 
   @override
   String get galleryAccessDenied => 'Gallery access denied';
@@ -2160,6 +2171,9 @@ class AppLocalizationsEn extends AppLocalizations {
   @override
   String get showAnEmptyAppWhileYourRealData =>
       'Show an empty app while your real data stays encrypted on disk';
+
+  @override
+  String get showAsForwarded => 'Show as forwarded';
 
   @override
   String get showFullQr => 'Show full QR';

--- a/lib/l10n/app_localizations_it.dart
+++ b/lib/l10n/app_localizations_it.dart
@@ -472,6 +472,11 @@ class AppLocalizationsIt extends AppLocalizations {
   String get couldNotEditMessage => 'Impossibile modificare il messaggio';
 
   @override
+  String couldNotForwardE(String e) {
+    return 'Impossibile inoltrare: $e';
+  }
+
+  @override
   String couldNotLoadDownloadsE(String e) {
     return 'Impossibile caricare i downloads: $e';
   }
@@ -993,6 +998,12 @@ class AppLocalizationsIt extends AppLocalizations {
 
   @override
   String get fontSystem => 'Sistema';
+
+  @override
+  String get forward => 'Inoltra';
+
+  @override
+  String get forwarded => 'Inoltrato';
 
   @override
   String get galleryAccessDenied => 'Accesso alla galleria negato';
@@ -2183,6 +2194,9 @@ class AppLocalizationsIt extends AppLocalizations {
   @override
   String get showAnEmptyAppWhileYourRealData =>
       'Mostra l\'app vuota mentre i dati reali rimangono cifrati sul disco';
+
+  @override
+  String get showAsForwarded => 'Mostra come inoltrato';
 
   @override
   String get showFullQr => 'Mostra QR completo';

--- a/lib/screens/chat.dart
+++ b/lib/screens/chat.dart
@@ -90,6 +90,11 @@ import 'package:prysm/util/key_manager.dart';
 import 'package:image_picker/image_picker.dart';
 import 'package:file_picker/file_picker.dart';
 import 'package:prysm/models/contact.dart';
+import 'package:prysm/models/conversation.dart';
+import 'package:prysm/models/detached_chat_launch.dart';
+import 'package:prysm/models/group.dart';
+import 'package:prysm/screens/widgets/forward_message_flow.dart';
+import 'package:prysm/screens/widgets/message_forwarded_label.dart';
 import 'package:prysm/l10n/l10n_extensions.dart';
 
 class ChatScreen extends StatefulWidget {
@@ -109,6 +114,10 @@ class ChatScreen extends StatefulWidget {
   final Widget? torStatusAction;
   final DetachedChatClient? detachedClient;
   final String? initialScrollToMessageId;
+  final List<Conversation> shareableConversations;
+  final List<Contact> contacts;
+  final Group? Function(String groupId)? groupById;
+  final String? userAvatarBase64;
 
   const ChatScreen({
     required this.userId,
@@ -126,6 +135,10 @@ class ChatScreen extends StatefulWidget {
     this.torStatusAction,
     this.detachedClient,
     this.initialScrollToMessageId,
+    this.shareableConversations = const [],
+    this.contacts = const [],
+    this.groupById,
+    this.userAvatarBase64,
     super.key,
   });
 
@@ -1455,6 +1468,15 @@ class _ChatScreenState extends State<ChatScreen> {
           _controller.setReplyToMessage(message);
         },
       ),
+      if (canForwardMessage(message))
+        PrysmListRow(
+          leading: const Icon(PrysmIcons.forward),
+          title: context.l10n.forward,
+          onTap: () {
+            Navigator.pop(context);
+            _openForward(message);
+          },
+        ),
       PrysmListRow(
         leading: const Icon(PrysmIcons.selectAll),
         title: context.l10n.select,
@@ -1477,6 +1499,22 @@ class _ChatScreenState extends State<ChatScreen> {
       context: context,
       onReactionSelected: (emoji) => _controller.onReactionSelected(message, emoji),
       actionTiles: tiles,
+    );
+  }
+
+  Future<void> _openForward(Message message) {
+    return openForwardMessagePicker(
+      context: context,
+      message: message,
+      sourceKind: DetachedChatKind.direct,
+      sourceConversationId: widget.peerId,
+      userId: widget.userId,
+      userName: widget.userName,
+      userAvatarBase64: widget.userAvatarBase64,
+      keyManager: widget.keyManager,
+      conversations: widget.shareableConversations,
+      contacts: widget.contacts,
+      groupById: widget.groupById ?? (_) => null,
     );
   }
 
@@ -2146,6 +2184,10 @@ class _ChatScreenState extends State<ChatScreen> {
       timeString: timeString,
       tickWidget: tickWidget,
       decryptFromDb: () => _decryptImageFromDb(message.id),
+      caption: MessageForwardedLabel(
+        message: message,
+        color: prysmBubbleMetaColor(context, isSentByMe: isSentByMe),
+      ),
       ),
     );
   }
@@ -2188,6 +2230,10 @@ class _ChatScreenState extends State<ChatScreen> {
       timeString: timeString,
       isSentByMe: isSentByMe,
       tickWidget: tickWidget,
+      caption: MessageForwardedLabel(
+        message: message,
+        color: prysmBubbleMetaColor(context, isSentByMe: isSentByMe),
+      ),
       uploadProgress: isSentByMe
           ? FileTransferProgress.uploadFor(message.id)
           : null,
@@ -2232,6 +2278,7 @@ class _ChatScreenState extends State<ChatScreen> {
           crossAxisAlignment: CrossAxisAlignment.start,
           mainAxisSize: MainAxisSize.min,
           children: [
+            MessageForwardedLabel(message: message, color: metaColor),
             _replyQuoteFor(message, isSentByMe),
             LinkedMessageText(
               text: message.text,
@@ -2298,6 +2345,10 @@ class _ChatScreenState extends State<ChatScreen> {
       isSentByMe: isSentByMe,
       timeString: timeString,
       tickWidget: tickWidget,
+      caption: MessageForwardedLabel(
+        message: message,
+        color: prysmBubbleMetaColor(context, isSentByMe: isSentByMe),
+      ),
       decryptAudio: message.source.startsWith('audio:')
           ? null
           : (encryptedSource) async {

--- a/lib/screens/detached_chat_shell.dart
+++ b/lib/screens/detached_chat_shell.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/widgets.dart';
 import 'package:prysm/ui/core/prysm_progress.dart';
 import 'package:prysm/models/contact.dart';
+import 'package:prysm/models/conversation.dart';
 import 'package:prysm/models/detached_chat_launch.dart';
 import 'package:prysm/models/group.dart';
 import 'package:prysm/screens/chat.dart';
@@ -9,6 +10,7 @@ import 'package:prysm/screens/self_chat_screen.dart';
 import 'package:prysm/services/active_conversation_tracker.dart';
 import 'package:prysm/services/detached_chat_client.dart';
 import 'package:prysm/services/settings_service.dart';
+import 'package:prysm/services/shareable_conversations.dart';
 import 'package:prysm/util/db_helper.dart';
 import 'package:prysm/util/key_manager.dart';
 import 'package:prysm/util/tor_service.dart';
@@ -40,6 +42,7 @@ class _DetachedChatShellState extends State<DetachedChatShell> with WindowListen
   Contact? _contact;
   Group? _group;
   List<Contact> _contacts = const [];
+  List<Conversation> _shareableConversations = const [];
 
   @override
   void initState() {
@@ -63,6 +66,12 @@ class _DetachedChatShellState extends State<DetachedChatShell> with WindowListen
 
       await _client.init();
 
+      final users = await DBHelper.getUsers();
+      _contacts = users.map((map) => Contact.fromMap(map)).toList();
+      _shareableConversations = await ShareableConversations.loadFromDb(
+        localUserId: widget.launch.userId,
+      );
+
       switch (widget.launch.chatKind!) {
         case DetachedChatKind.direct:
           final user = await DBHelper.getUserById(widget.launch.conversationId);
@@ -76,8 +85,6 @@ class _DetachedChatShellState extends State<DetachedChatShell> with WindowListen
             throw StateError('Group not found');
           }
           _group = Group.fromMap(groupRow);
-          final users = await DBHelper.getUsers();
-          _contacts = users.map((map) => Contact.fromMap(map)).toList();
         case DetachedChatKind.self:
           break;
       }
@@ -94,6 +101,16 @@ class _DetachedChatShellState extends State<DetachedChatShell> with WindowListen
         _error = e.toString();
       });
     }
+  }
+
+  Group? _groupById(String groupId) {
+    for (final conv in _shareableConversations) {
+      if (conv is GroupConversation && conv.id == groupId) {
+        return conv.group;
+      }
+    }
+    if (_group?.id == groupId) return _group;
+    return null;
   }
 
   void _syncActiveConversationTracker() {
@@ -169,6 +186,10 @@ class _DetachedChatShellState extends State<DetachedChatShell> with WindowListen
           reloadUsers: () {},
           onCloseChat: _closeWindow,
           detachedClient: _client,
+          shareableConversations: _shareableConversations,
+          contacts: _contacts,
+          groupById: _groupById,
+          userAvatarBase64: widget.launch.avatarBase64,
         );
       case DetachedChatKind.group:
         final group = _group!;
@@ -180,6 +201,10 @@ class _DetachedChatShellState extends State<DetachedChatShell> with WindowListen
           reloadConversations: () {},
           onCloseChat: _closeWindow,
           detachedClient: _client,
+          shareableConversations: _shareableConversations,
+          groupById: _groupById,
+          userName: widget.launch.userName,
+          userAvatarBase64: widget.launch.avatarBase64,
         );
       case DetachedChatKind.self:
         return SelfChatScreen(
@@ -190,6 +215,9 @@ class _DetachedChatShellState extends State<DetachedChatShell> with WindowListen
           onCloseChat: _closeWindow,
           reloadSidebar: () {},
           detachedClient: _client,
+          shareableConversations: _shareableConversations,
+          contacts: _contacts,
+          groupById: _groupById,
         );
     }
   }

--- a/lib/screens/group_chat.dart
+++ b/lib/screens/group_chat.dart
@@ -21,7 +21,11 @@ import 'package:image_picker/image_picker.dart';
 import 'package:prysm/constants/group_constants.dart';
 import 'package:prysm/database/messages.dart';
 import 'package:prysm/models/contact.dart';
+import 'package:prysm/models/conversation.dart';
+import 'package:prysm/models/detached_chat_launch.dart';
 import 'package:prysm/models/group.dart';
+import 'package:prysm/screens/widgets/forward_message_flow.dart';
+import 'package:prysm/screens/widgets/message_forwarded_label.dart';
 import 'package:prysm/screens/group_settings_screen.dart';
 import 'package:prysm/ui/chat/prysm_bubble_renderer.dart';
 import 'package:prysm/ui/chat/prysm_chat_composer_column.dart';
@@ -91,6 +95,10 @@ class GroupChatScreen extends StatefulWidget {
   final Widget? torStatusAction;
   final DetachedChatClient? detachedClient;
   final String? initialScrollToMessageId;
+  final List<Conversation> shareableConversations;
+  final Group? Function(String groupId)? groupById;
+  final String? userName;
+  final String? userAvatarBase64;
 
   const GroupChatScreen({
     required this.userId,
@@ -102,6 +110,10 @@ class GroupChatScreen extends StatefulWidget {
     this.torStatusAction,
     this.detachedClient,
     this.initialScrollToMessageId,
+    this.shareableConversations = const [],
+    this.groupById,
+    this.userName,
+    this.userAvatarBase64,
     super.key,
   });
 
@@ -511,6 +523,15 @@ class _GroupChatScreenState extends State<GroupChatScreen> {
             _controller.setReplyToMessage(message);
           },
         ),
+        if (canForwardMessage(message))
+          PrysmListRow(
+            leading: const Icon(PrysmIcons.forward),
+            title: context.l10n.forward,
+            onTap: () {
+              Navigator.pop(context);
+              _openForward(message);
+            },
+          ),
         PrysmListRow(
           leading: const Icon(PrysmIcons.selectAll),
           title: context.l10n.select,
@@ -528,6 +549,22 @@ class _GroupChatScreenState extends State<GroupChatScreen> {
           },
         ),
       ],
+    );
+  }
+
+  Future<void> _openForward(Message message) {
+    return openForwardMessagePicker(
+      context: context,
+      message: message,
+      sourceKind: DetachedChatKind.group,
+      sourceConversationId: widget.group.id,
+      userId: widget.userId,
+      userName: widget.userName,
+      userAvatarBase64: widget.userAvatarBase64,
+      keyManager: widget.keyManager,
+      conversations: widget.shareableConversations,
+      contacts: widget.contacts,
+      groupById: widget.groupById ?? (_) => null,
     );
   }
 
@@ -1348,6 +1385,10 @@ class _GroupChatScreenState extends State<GroupChatScreen> {
               crossAxisAlignment: CrossAxisAlignment.start,
               mainAxisSize: MainAxisSize.min,
               children: [
+                MessageForwardedLabel(
+                  message: message,
+                  color: tickColor.withAlpha(180),
+                ),
                 _replyQuoteFor(message, isSentByMe),
                 LinkedMessageText(
                   text: message.text,
@@ -1545,6 +1586,10 @@ class _GroupChatScreenState extends State<GroupChatScreen> {
           timeString: timeString,
           tickWidget: tickWidget,
           decryptFromDb: () => _decryptGroupImageFromDb(message.id),
+          caption: MessageForwardedLabel(
+            message: message,
+            color: context.prysmStyle.tokens.textMuted,
+          ),
         ),
       ],
     );
@@ -1578,6 +1623,10 @@ class _GroupChatScreenState extends State<GroupChatScreen> {
             isSentByMe: isSentByMe,
             timeString: timeString,
             tickWidget: _buildStatusWidget(message, isSentByMe, tickColor),
+            caption: MessageForwardedLabel(
+              message: message,
+              color: tickColor.withAlpha(180),
+            ),
             decryptAudio: message.source.startsWith('audio:')
                 ? null
                 : (_) async {
@@ -1604,6 +1653,10 @@ class _GroupChatScreenState extends State<GroupChatScreen> {
           timeString: timeString,
           isSentByMe: isSentByMe,
           tickWidget: _buildStatusWidget(message, isSentByMe, tickColor),
+          caption: MessageForwardedLabel(
+            message: message,
+            color: tickColor.withAlpha(180),
+          ),
           header: _senderLabel(message.authorId, isSentByMe),
           resolveBytes: () async {
             final rows = await MessagesDb.getMessageById(

--- a/lib/screens/home/home_screen.dart
+++ b/lib/screens/home/home_screen.dart
@@ -91,6 +91,7 @@ import 'package:prysm/util/qr_platform.dart';
 import 'package:prysm/util/tor_connection_notifier.dart';
 import 'package:prysm/services/sync_coordinator.dart';
 import 'package:prysm/services/wake_hint_service.dart';
+import 'package:prysm/services/shareable_conversations.dart';
 import 'package:prysm/l10n/l10n_extensions.dart';
 
 class HomeScreen extends StatefulWidget {
@@ -850,13 +851,10 @@ class _HomeScreenState extends State<HomeScreen> with WidgetsBindingObserver {
   }
 
   List<Conversation> get _shareableConversations {
-    return conversations.where((conversation) {
-      if (conversation is DirectConversation &&
-          BlockService.instance.isBlocked(conversation.id)) {
-        return false;
-      }
-      return !(_conversationPrefs[conversation.id]?.isArchived ?? false);
-    }).toList();
+    return ShareableConversations.filter(
+      conversations: conversations,
+      prefs: _conversationPrefs,
+    );
   }
 
   Group? _groupById(String groupId) {
@@ -2342,6 +2340,9 @@ class _HomeScreenState extends State<HomeScreen> with WidgetsBindingObserver {
         onCloseChat: () => clearChat(),
         reloadSidebar: () => loadUsers(),
         initialScrollToMessageId: scrollId,
+        shareableConversations: _shareableConversations,
+        contacts: contacts,
+        groupById: _groupById,
       );
     }
     if (selectedConversation is GroupConversation) {
@@ -2371,6 +2372,10 @@ class _HomeScreenState extends State<HomeScreen> with WidgetsBindingObserver {
         onCloseChat: () => clearChat(),
         torStatusAction: widget.decoyMode ? null : _buildTorAppBarAction(),
         initialScrollToMessageId: scrollId,
+        shareableConversations: _shareableConversations,
+        groupById: _groupById,
+        userName: appUser.name,
+        userAvatarBase64: appUser.avatarBase64,
       );
     }
     if (selectedContact != null) {
@@ -2405,6 +2410,10 @@ class _HomeScreenState extends State<HomeScreen> with WidgetsBindingObserver {
         onCloseChat: () => clearChat(),
         torStatusAction: widget.decoyMode ? null : _buildTorAppBarAction(),
         initialScrollToMessageId: scrollId,
+        shareableConversations: _shareableConversations,
+        contacts: contacts,
+        groupById: _groupById,
+        userAvatarBase64: appUser.avatarBase64,
       );
     }
     return _buildEmptyHomeState();

--- a/lib/screens/self_chat_screen.dart
+++ b/lib/screens/self_chat_screen.dart
@@ -33,6 +33,11 @@ import 'package:prysm/ui/chat/prysm_constrained_composer.dart';
 import 'package:prysm/ui/chat/prysm_chat_list.dart';
 import 'package:prysm/ui/chat/chat_search_bar.dart';
 import 'package:prysm/models/conversation.dart';
+import 'package:prysm/models/contact.dart';
+import 'package:prysm/models/detached_chat_launch.dart';
+import 'package:prysm/models/group.dart';
+import 'package:prysm/screens/widgets/forward_message_flow.dart';
+import 'package:prysm/screens/widgets/message_forwarded_label.dart';
 import 'package:prysm/util/scroll_to_chat_message.dart';
 import 'package:prysm/ui/chat/prysm_date_header.dart';
 import 'package:prysm/ui/prysm_scaffold.dart';
@@ -52,6 +57,9 @@ class SelfChatScreen extends StatefulWidget {
   final VoidCallback reloadSidebar;
   final DetachedChatClient? detachedClient;
   final String? initialScrollToMessageId;
+  final List<Conversation> shareableConversations;
+  final List<Contact> contacts;
+  final Group? Function(String groupId)? groupById;
 
   const SelfChatScreen({
     required this.userId,
@@ -62,6 +70,9 @@ class SelfChatScreen extends StatefulWidget {
     required this.reloadSidebar,
     this.detachedClient,
     this.initialScrollToMessageId,
+    this.shareableConversations = const [],
+    this.contacts = const [],
+    this.groupById,
     super.key,
   });
 
@@ -368,6 +379,15 @@ class _SelfChatScreenState extends State<SelfChatScreen> {
         mainAxisSize: MainAxisSize.min,
         children: [
           if (text.isNotEmpty) copyMessageTile(context: context, text: text),
+          if (canForwardMessage(message))
+            PrysmListRow(
+              leading: const Icon(PrysmIcons.forward),
+              title: context.l10n.forward,
+              onTap: () {
+                Navigator.pop(ctx);
+                _openForward(message);
+              },
+            ),
           PrysmListRow(
             leading: const Icon(PrysmIcons.deleteOutline),
             title: context.l10n.delete,
@@ -378,6 +398,22 @@ class _SelfChatScreenState extends State<SelfChatScreen> {
           ),
         ],
       ),
+    );
+  }
+
+  Future<void> _openForward(Message message) {
+    return openForwardMessagePicker(
+      context: context,
+      message: message,
+      sourceKind: DetachedChatKind.self,
+      sourceConversationId: DetachedChatLaunch.selfConversationId,
+      userId: widget.userId,
+      userName: widget.userName,
+      userAvatarBase64: widget.avatarBase64,
+      keyManager: widget.keyManager,
+      conversations: widget.shareableConversations,
+      contacts: widget.contacts,
+      groupById: widget.groupById ?? (_) => null,
     );
   }
 
@@ -419,6 +455,10 @@ class _SelfChatScreenState extends State<SelfChatScreen> {
           crossAxisAlignment: CrossAxisAlignment.start,
           mainAxisSize: MainAxisSize.min,
           children: [
+            MessageForwardedLabel(
+              message: message,
+              color: tokens.onAccent.withValues(alpha: 0.75),
+            ),
             LinkedMessageText(
               text: message.text,
               textColor: tokens.onAccent,
@@ -575,6 +615,10 @@ class _SelfChatScreenState extends State<SelfChatScreen> {
       timeString: timeString,
       tickWidget: const SizedBox.shrink(),
       decryptFromDb: () => _service.decryptImageFromDb(message.id),
+      caption: MessageForwardedLabel(
+        message: message,
+        color: context.prysmStyle.tokens.textMuted,
+      ),
     );
   }
 
@@ -595,6 +639,10 @@ class _SelfChatScreenState extends State<SelfChatScreen> {
         isSentByMe: true,
         timeString: timeString,
         tickWidget: const SizedBox.shrink(),
+        caption: MessageForwardedLabel(
+          message: message,
+          color: context.prysmStyle.tokens.textMuted,
+        ),
         decryptAudio: message.source.startsWith('audio:')
             ? null
             : (encryptedSource) => CryptoWire.decryptFile(
@@ -614,6 +662,10 @@ class _SelfChatScreenState extends State<SelfChatScreen> {
       timeString: timeString,
       isSentByMe: true,
       tickWidget: const SizedBox.shrink(),
+      caption: MessageForwardedLabel(
+        message: message,
+        color: context.prysmStyle.tokens.textMuted,
+      ),
       resolveBytes: () => FileAttachmentResolver.resolve(
         message,
         keyManager: widget.keyManager,

--- a/lib/screens/share_target_picker_screen.dart
+++ b/lib/screens/share_target_picker_screen.dart
@@ -18,7 +18,13 @@ import 'package:prysm/ui/core/prysm_text_field.dart';
 import 'package:prysm/ui/core/prysm_toast.dart';
 import 'package:prysm/ui/prysm_scaffold.dart';
 import 'package:prysm/util/key_manager.dart';
+import 'package:prysm/ui/core/prysm_switch.dart';
 import 'package:prysm/l10n/l10n_extensions.dart';
+
+typedef ShareCustomSend = Future<void> Function(
+  ShareTarget target, {
+  required bool markForwarded,
+});
 
 class ShareTargetPickerScreen extends StatefulWidget {
   const ShareTargetPickerScreen({
@@ -30,6 +36,8 @@ class ShareTargetPickerScreen extends StatefulWidget {
     required this.contacts,
     required this.keyManager,
     required this.groupById,
+    this.showForwardedToggle = false,
+    this.customSend,
     super.key,
   });
 
@@ -41,6 +49,8 @@ class ShareTargetPickerScreen extends StatefulWidget {
   final List<Contact> contacts;
   final KeyManager keyManager;
   final Group? Function(String groupId) groupById;
+  final bool showForwardedToggle;
+  final ShareCustomSend? customSend;
 
   @override
   State<ShareTargetPickerScreen> createState() =>
@@ -51,6 +61,7 @@ class _ShareTargetPickerScreenState extends State<ShareTargetPickerScreen> {
   final _searchController = TextEditingController();
   String _searchQuery = '';
   bool _sending = false;
+  bool _markForwarded = true;
 
   @override
   void dispose() {
@@ -139,6 +150,22 @@ class _ShareTargetPickerScreenState extends State<ShareTargetPickerScreen> {
     if (_sending) return;
     setState(() => _sending = true);
 
+    final customSend = widget.customSend;
+    if (customSend != null) {
+      try {
+        await customSend(row.target, markForwarded: _markForwarded);
+        if (!mounted) return;
+        setState(() => _sending = false);
+        showPrysmToast(context, context.l10n.sentTo(row.target.displayName));
+        Navigator.of(context).pop();
+      } catch (e) {
+        if (!mounted) return;
+        setState(() => _sending = false);
+        showPrysmToast(context, context.l10n.couldNotForwardE('$e'));
+      }
+      return;
+    }
+
     final result = await ShareSendService.send(
       target: row.target,
       content: widget.content,
@@ -153,7 +180,7 @@ class _ShareTargetPickerScreenState extends State<ShareTargetPickerScreen> {
 
     if (result.success) {
       PendingShareStore.instance.clear();
-      showPrysmToast(context, 'Sent to ${row.target.displayName}');
+      showPrysmToast(context, context.l10n.sentTo(row.target.displayName));
       Navigator.of(context).pop(row.target);
       return;
     }
@@ -175,7 +202,9 @@ class _ShareTargetPickerScreenState extends State<ShareTargetPickerScreen> {
     final tokens = context.prysmTokens;
 
     return PrysmPage(
-      title: context.l10n.shareToPrysm,
+      title: widget.showForwardedToggle
+          ? context.l10n.forward
+          : context.l10n.shareToPrysm,
       leading: PrysmIconButton(
         icon: PrysmIcons.close,
         onPressed: _sending ? null : _cancel,
@@ -197,6 +226,14 @@ class _ShareTargetPickerScreenState extends State<ShareTargetPickerScreen> {
                   ),
                 ),
               ),
+              if (widget.showForwardedToggle)
+                PrysmSwitchRow(
+                  title: context.l10n.showAsForwarded,
+                  value: _markForwarded,
+                  onChanged: _sending
+                      ? null
+                      : (value) => setState(() => _markForwarded = value),
+                ),
               Padding(
                 padding: const EdgeInsets.symmetric(horizontal: 16),
                 child: PrysmTextField(

--- a/lib/screens/widgets/file_attachment_bubble.dart
+++ b/lib/screens/widgets/file_attachment_bubble.dart
@@ -26,6 +26,7 @@ class FileAttachmentBubble extends StatefulWidget {
   final Widget tickWidget;
   final Future<Uint8List> Function() resolveBytes;
   final Widget? header;
+  final Widget? caption;
   final ValueNotifier<double>? downloadProgress;
   final ValueNotifier<double>? uploadProgress;
 
@@ -37,6 +38,7 @@ class FileAttachmentBubble extends StatefulWidget {
     required this.resolveBytes,
     this.fileSize,
     this.header,
+    this.caption,
     this.downloadProgress,
     this.uploadProgress,
     super.key,
@@ -359,6 +361,7 @@ class _FileAttachmentBubbleState extends State<FileAttachmentBubble> {
             child: Column(
               crossAxisAlignment: CrossAxisAlignment.start,
               children: [
+                if (widget.caption != null) widget.caption!,
                 if (_category == FilePreviewCategory.blocked)
                   Padding(
                     padding: const EdgeInsets.only(bottom: 6),

--- a/lib/screens/widgets/forward_message_flow.dart
+++ b/lib/screens/widgets/forward_message_flow.dart
@@ -1,0 +1,70 @@
+import 'package:flutter/widgets.dart';
+import 'package:prysm/l10n/l10n_extensions.dart';
+import 'package:prysm/models/chat/prysm_message.dart';
+import 'package:prysm/models/contact.dart';
+import 'package:prysm/models/conversation.dart';
+import 'package:prysm/models/detached_chat_launch.dart';
+import 'package:prysm/models/group.dart';
+import 'package:prysm/models/shared_content.dart';
+import 'package:prysm/screens/share_target_picker_screen.dart';
+import 'package:prysm/services/message_forward_service.dart';
+import 'package:prysm/services/settings_service.dart';
+import 'package:prysm/ui/core/prysm_app.dart';
+import 'package:prysm/util/key_manager.dart';
+import 'package:prysm/util/message_modify_policy.dart';
+
+Future<void> openForwardMessagePicker({
+  required BuildContext context,
+  required Message message,
+  required DetachedChatKind sourceKind,
+  required String sourceConversationId,
+  required String userId,
+  required KeyManager keyManager,
+  required List<Conversation> conversations,
+  required List<Contact> contacts,
+  required Group? Function(String groupId) groupById,
+  String? userName,
+  String? userAvatarBase64,
+}) async {
+  if (!canForwardMessage(message)) return;
+
+  final settings = SettingsService();
+  await Navigator.of(context).push(
+    PrysmPageRoute(
+      page: ShareTargetPickerScreen(
+        content: SharedContent(
+          kind: SharedContentKind.text,
+          text: _preview(message, context),
+        ),
+        conversations: conversations,
+        userId: userId,
+        userName: userName ?? settings.username ?? userId,
+        userAvatarBase64: userAvatarBase64 ?? settings.avatar,
+        contacts: contacts,
+        keyManager: keyManager,
+        groupById: groupById,
+        showForwardedToggle: true,
+        customSend: (target, {required markForwarded}) {
+          return MessageForwardService.forward(
+            message: message,
+            target: target,
+            markForwarded: markForwarded,
+            sourceKind: sourceKind,
+            sourceConversationId: sourceConversationId,
+            userId: userId,
+            keyManager: keyManager,
+            contacts: contacts,
+            groupById: groupById,
+          );
+        },
+      ),
+    ),
+  );
+}
+
+String _preview(Message message, BuildContext context) {
+  if (message is TextMessage) return message.text;
+  if (message is FileMessage) return message.name;
+  if (message is ImageMessage) return context.l10n.image;
+  return '';
+}

--- a/lib/screens/widgets/image_message_bubble.dart
+++ b/lib/screens/widgets/image_message_bubble.dart
@@ -19,6 +19,7 @@ class ImageMessageBubble extends StatefulWidget {
   final Widget tickWidget;
   final Future<Uint8List> Function()? decryptFromDb;
   final Widget? senderLabel;
+  final Widget? caption;
   final ValueNotifier<double>? downloadProgress;
 
   const ImageMessageBubble({
@@ -28,6 +29,7 @@ class ImageMessageBubble extends StatefulWidget {
     required this.tickWidget,
     this.decryptFromDb,
     this.senderLabel,
+    this.caption,
     this.downloadProgress,
     super.key,
   });
@@ -184,6 +186,7 @@ class _ImageMessageBubbleState extends State<ImageMessageBubble> {
       crossAxisAlignment: crossAlign,
       children: [
         if (widget.senderLabel != null) widget.senderLabel!,
+        if (widget.caption != null) widget.caption!,
         _buildImageArea(context),
         const SizedBox(height: 4),
         Row(

--- a/lib/screens/widgets/message_forwarded_label.dart
+++ b/lib/screens/widgets/message_forwarded_label.dart
@@ -1,0 +1,36 @@
+import 'package:flutter/widgets.dart';
+import 'package:prysm/l10n/l10n_extensions.dart';
+import 'package:prysm/models/chat/prysm_message.dart';
+import 'package:prysm/theme/prysm_style_scope.dart';
+
+/// Italic "Forwarded" caption shown at the top of a bubble.
+class MessageForwardedLabel extends StatelessWidget {
+  const MessageForwardedLabel({
+    this.message,
+    this.metadata,
+    this.color,
+    super.key,
+  });
+
+  final Message? message;
+  final Map<String, dynamic>? metadata;
+  final Color? color;
+
+  bool get _visible =>
+      (metadata ?? message?.metadata)?['forwarded'] == true;
+
+  @override
+  Widget build(BuildContext context) {
+    if (!_visible) return const SizedBox.shrink();
+    return Padding(
+      padding: const EdgeInsets.only(bottom: 2),
+      child: Text(
+        context.l10n.forwarded,
+        style: context.prysmStyle.captionStyle.copyWith(
+          fontStyle: FontStyle.italic,
+          color: color ?? context.prysmStyle.tokens.textMuted,
+        ),
+      ),
+    );
+  }
+}

--- a/lib/screens/widgets/voice_message_bubble.dart
+++ b/lib/screens/widgets/voice_message_bubble.dart
@@ -27,6 +27,7 @@ class VoiceMessageBubble extends StatefulWidget {
 
   /// Decrypt encrypted audio payload to WAV bytes (1:1 received messages).
   final Future<Uint8List?> Function(String encryptedSource)? decryptAudio;
+  final Widget? caption;
 
   const VoiceMessageBubble({
     required this.message,
@@ -34,6 +35,7 @@ class VoiceMessageBubble extends StatefulWidget {
     required this.timeString,
     required this.tickWidget,
     this.decryptAudio,
+    this.caption,
     super.key,
   });
 
@@ -321,7 +323,12 @@ class _VoiceMessageBubbleState extends State<VoiceMessageBubble> {
               color: bubbleColor,
               borderRadius: BorderRadius.circular(14),
             ),
-            child: Row(
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                if (widget.caption != null) widget.caption!,
+                Row(
               mainAxisSize: MainAxisSize.min,
               crossAxisAlignment: CrossAxisAlignment.center,
               children: [
@@ -388,6 +395,8 @@ class _VoiceMessageBubbleState extends State<VoiceMessageBubble> {
                     ],
                   ),
                 ),
+              ],
+            ),
               ],
             ),
           ),

--- a/lib/server/inbound_message_router.dart
+++ b/lib/server/inbound_message_router.dart
@@ -672,6 +672,7 @@ class InboundMessageRouter {
         'status': messageStatus,
         if (data['replyTo'] != null) 'replyTo': data['replyTo'],
         'viewOnce': (data['viewOnce'] == true || data['viewOnce'] == 1) ? 1 : 0,
+        if (data['forwarded'] == true || data['forwarded'] == 1) 'forwarded': 1,
         'expiresAt': ?expiresAt,
       }, localId);
     } catch (e) {

--- a/lib/services/chat_service.dart
+++ b/lib/services/chat_service.dart
@@ -93,6 +93,7 @@ class ChatService {
             fileName: row['fileName'] as String?,
             fileSize: row['fileSize'] as int?,
             viewOnce: (row['viewOnce'] ?? 0) == 1,
+            forwarded: (row['forwarded'] ?? 0) == 1,
             expiresAt: row['expiresAt'] as int?,
             timestamp: row['timestamp'] as int?,
           ),
@@ -208,6 +209,7 @@ class ChatService {
     String text, {
     String? replyToId,
     String? messageId,
+    bool forwarded = false,
   }) async {
     if (BlockService.instance.isBlocked(peerId)) return null;
     if (peerIdentity == null) return null;
@@ -238,6 +240,7 @@ class ChatService {
       'timestamp': timestamp,
       'replyTo': replyToId,
       'expiresAt': ?expiresAt,
+      if (forwarded) 'forwarded': 1,
     }, notifyListeners: false);
 
     await MessageSearchIndexService.indexBestEffort(
@@ -261,6 +264,7 @@ class ChatService {
       encryptedForPeer,
       'text',
       replyToId: replyToId,
+      forwarded: forwarded,
       expiresAt: expiresAt,
       timestamp: timestamp,
     );
@@ -284,6 +288,7 @@ class ChatService {
         encryptedForPeer,
         'text',
         replyToId: replyToId,
+        forwarded: forwarded,
         expiresAt: expiresAt,
         timestamp: timestamp,
       );
@@ -300,6 +305,7 @@ class ChatService {
     String? replyToId,
     String? messageId,
     bool viewOnce = false,
+    bool forwarded = false,
   }) async {
     if (BlockService.instance.isBlocked(peerId)) return null;
     if (peerIdentity == null) return null;
@@ -333,6 +339,7 @@ class ChatService {
       'status': 'pending',
       'viewOnce': viewOnce ? 1 : 0,
       'expiresAt': ?expiresAt,
+      if (forwarded) 'forwarded': 1,
     }, notifyListeners: false);
 
     // ponytail: guard instead of a viewOnce param on indexOutboundFile — the
@@ -377,6 +384,7 @@ class ChatService {
       fileSize: bytes.length,
       replyToId: replyToId,
       viewOnce: viewOnce,
+      forwarded: forwarded,
       expiresAt: expiresAt,
       timestamp: timestamp,
     );
@@ -407,6 +415,7 @@ class ChatService {
         fileSize: bytes.length,
         replyToId: replyToId,
         viewOnce: viewOnce,
+        forwarded: forwarded,
         expiresAt: expiresAt,
         timestamp: timestamp,
       );
@@ -554,6 +563,7 @@ class ChatService {
             fileName: msg['fileName'],
             fileSize: msg['fileSize'],
             viewOnce: (msg['viewOnce'] ?? 0) == 1,
+            forwarded: (msg['forwarded'] ?? 0) == 1,
             expiresAt: msg['expiresAt'] as int?,
             timestamp: msg['timestamp'] as int?,
           );
@@ -611,6 +621,7 @@ class ChatService {
     String? fileName,
     int? fileSize,
     bool viewOnce = false,
+    bool forwarded = false,
     int? expiresAt,
     int? timestamp,
   }) {
@@ -633,6 +644,7 @@ class ChatService {
         fileSize: fileSize,
         replyToId: replyToId,
         viewOnce: viewOnce,
+        forwarded: forwarded,
         expiresAt: expiresAt,
         timestamp: wireTimestamp,
       );
@@ -658,6 +670,7 @@ class ChatService {
           'fileSize': fileSize,
           'replyTo': replyToId,
           'viewOnce': viewOnce,
+          if (forwarded) 'forwarded': true,
           'timestamp': wireTimestamp,
           'expiresAt': ?expiresAt,
         },
@@ -684,6 +697,7 @@ class ChatService {
     required int fileSize,
     String? replyToId,
     bool viewOnce = false,
+    bool forwarded = false,
     int? expiresAt,
     int? timestamp,
   }) async {
@@ -724,6 +738,7 @@ class ChatService {
         peerPayload: encrypted,
         replyToId: replyToId,
         viewOnce: viewOnce,
+        forwarded: forwarded,
         expiresAt: expiresAt,
         timestamp: timestamp,
       );
@@ -903,6 +918,7 @@ class ChatService {
       fileName: msg['fileName'] as String?,
       fileSize: msg['fileSize'] as int?,
       viewOnce: (msg['viewOnce'] ?? 0) == 1,
+      forwarded: (msg['forwarded'] ?? 0) == 1,
       expiresAt: msg['expiresAt'] as int?,
       timestamp: msg['timestamp'] as int?,
     );
@@ -937,6 +953,7 @@ class ChatService {
     String? fileName,
     int? fileSize,
     bool viewOnce = false,
+    bool forwarded = false,
     int? expiresAt,
     int? timestamp,
   }) async {
@@ -951,6 +968,7 @@ class ChatService {
       'timestamp': timestamp ?? DateTime.now().millisecondsSinceEpoch,
       'replyTo': replyToId,
       'viewOnce': viewOnce ? 1 : 0,
+      if (forwarded) 'forwarded': 1,
       'expiresAt': ?expiresAt,
     });
   }

--- a/lib/services/detached_chat_bridge.dart
+++ b/lib/services/detached_chat_bridge.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:typed_data';
 
 import 'package:prysm/models/chat/prysm_message.dart';
@@ -60,6 +61,7 @@ class DetachedChatBridge {
       required text,
       replyToId,
       required messageId,
+      forwarded = false,
     }) {
       return _sendText(
         chatKind: chatKind,
@@ -67,6 +69,7 @@ class DetachedChatBridge {
         text: text,
         replyToId: replyToId,
         messageId: messageId,
+        forwarded: forwarded,
         userId: userId,
         keyManager: keyManager,
         contacts: contacts(),
@@ -82,6 +85,7 @@ class DetachedChatBridge {
       replyToId,
       required messageId,
       viewOnce = false,
+      forwarded = false,
     }) {
       return _sendFile(
         chatKind: chatKind,
@@ -92,6 +96,7 @@ class DetachedChatBridge {
         replyToId: replyToId,
         messageId: messageId,
         viewOnce: viewOnce,
+        forwarded: forwarded,
         userId: userId,
         keyManager: keyManager,
         contacts: contacts(),
@@ -282,6 +287,7 @@ class DetachedChatBridge {
     required String text,
     String? replyToId,
     required String messageId,
+    bool forwarded = false,
     required String userId,
     required KeyManager keyManager,
     required List<Contact> contacts,
@@ -293,10 +299,12 @@ class DetachedChatBridge {
       text: text,
       replyToId: replyToId,
       messageId: messageId,
+      forwarded: forwarded,
       userId: userId,
       keyManager: keyManager,
       contacts: contacts,
       groupById: groupById,
+      waitForDelivery: false,
     );
   }
 
@@ -309,6 +317,7 @@ class DetachedChatBridge {
     String? replyToId,
     required String messageId,
     bool viewOnce = false,
+    bool forwarded = false,
     required String userId,
     required KeyManager keyManager,
     required List<Contact> contacts,
@@ -323,11 +332,40 @@ class DetachedChatBridge {
       replyToId: replyToId,
       messageId: messageId,
       viewOnce: viewOnce,
+      forwarded: forwarded,
       userId: userId,
       keyManager: keyManager,
       contacts: contacts,
       groupById: groupById,
+      waitForDelivery: false,
     );
+  }
+
+  /// Share/forward must not wait on the Tor timeout — same as composer send:
+  /// insert as pending, retry from the queue, dispose when the attempt finishes.
+  static String _enqueueOutbound({
+    required Future<String?> Function() send,
+    required void Function() dispose,
+    required DetachedChatKind chatKind,
+    required String conversationId,
+    required String messageId,
+  }) {
+    unawaited(() async {
+      try {
+        final id = await send();
+        if (id != null) {
+          await _notifyStatus(
+            chatKind: chatKind,
+            conversationId: conversationId,
+            messageId: messageId,
+            status: 'sent',
+          );
+        }
+      } finally {
+        dispose();
+      }
+    }());
+    return messageId;
   }
 
   static Future<String?> _sendText({
@@ -336,10 +374,12 @@ class DetachedChatBridge {
     required String text,
     String? replyToId,
     required String messageId,
+    bool forwarded = false,
     required String userId,
     required KeyManager keyManager,
     required List<Contact> contacts,
     required Group? Function(String groupId) groupById,
+    bool waitForDelivery = true,
   }) async {
     switch (chatKind) {
       case DetachedChatKind.direct:
@@ -356,11 +396,26 @@ class DetachedChatBridge {
           keyManager: keyManager,
         );
         await service.initialize(contact?.publicKeyPem);
-        final id = await service.sendTextMessage(
+        if (service.peerIdentity == null) {
+          service.dispose();
+          return null;
+        }
+        Future<String?> send() => service.sendTextMessage(
           text,
           replyToId: replyToId,
           messageId: messageId,
+          forwarded: forwarded,
         );
+        if (!waitForDelivery) {
+          return _enqueueOutbound(
+            send: send,
+            dispose: service.dispose,
+            chatKind: chatKind,
+            conversationId: conversationId,
+            messageId: messageId,
+          );
+        }
+        final id = await send();
         service.dispose();
         if (id != null) {
           await _notifyStatus(
@@ -373,7 +428,12 @@ class DetachedChatBridge {
         return id;
       case DetachedChatKind.self:
         final id = await SelfChatService(userId: userId, keyManager: keyManager)
-            .sendTextMessage(text, replyToId: replyToId, messageId: messageId);
+            .sendTextMessage(
+          text,
+          replyToId: replyToId,
+          messageId: messageId,
+          forwarded: forwarded,
+        );
         await _notifyStatus(
           chatKind: chatKind,
           conversationId: conversationId,
@@ -391,12 +451,27 @@ class DetachedChatBridge {
           keyManager: keyManager,
           groupService: groupService,
         );
-        await chatService.initialize();
-        final id = await chatService.sendTextMessage(
+        final ready = await chatService.initialize();
+        if (!ready) {
+          chatService.dispose();
+          return null;
+        }
+        Future<String?> send() => chatService.sendTextMessage(
           text,
           replyToId: replyToId,
           messageId: messageId,
+          forwarded: forwarded,
         );
+        if (!waitForDelivery) {
+          return _enqueueOutbound(
+            send: send,
+            dispose: chatService.dispose,
+            chatKind: chatKind,
+            conversationId: conversationId,
+            messageId: messageId,
+          );
+        }
+        final id = await send();
         chatService.dispose();
         if (id != null) {
           await _notifyStatus(
@@ -419,10 +494,12 @@ class DetachedChatBridge {
     String? replyToId,
     required String messageId,
     bool viewOnce = false,
+    bool forwarded = false,
     required String userId,
     required KeyManager keyManager,
     required List<Contact> contacts,
     required Group? Function(String groupId) groupById,
+    bool waitForDelivery = true,
   }) async {
     switch (chatKind) {
       case DetachedChatKind.direct:
@@ -439,14 +516,29 @@ class DetachedChatBridge {
           keyManager: keyManager,
         );
         await service.initialize(contact?.publicKeyPem);
-        final id = await service.sendFileMessage(
+        if (service.peerIdentity == null) {
+          service.dispose();
+          return null;
+        }
+        Future<String?> send() => service.sendFileMessage(
           bytes,
           fileName,
           type,
           replyToId: replyToId,
           messageId: messageId,
           viewOnce: viewOnce,
+          forwarded: forwarded,
         );
+        if (!waitForDelivery) {
+          return _enqueueOutbound(
+            send: send,
+            dispose: service.dispose,
+            chatKind: chatKind,
+            conversationId: conversationId,
+            messageId: messageId,
+          );
+        }
+        final id = await send();
         service.dispose();
         if (id != null) {
           await _notifyStatus(
@@ -466,6 +558,7 @@ class DetachedChatBridge {
           replyToId: replyToId,
           messageId: messageId,
           viewOnce: viewOnce,
+          forwarded: forwarded,
         );
         await _notifyStatus(
           chatKind: chatKind,
@@ -482,15 +575,30 @@ class DetachedChatBridge {
           keyManager: keyManager,
           groupService: groupService,
         );
-        await chatService.initialize();
-        final id = await chatService.sendFileMessage(
+        final ready = await chatService.initialize();
+        if (!ready) {
+          chatService.dispose();
+          return null;
+        }
+        Future<String?> send() => chatService.sendFileMessage(
           bytes,
           fileName,
           type,
           replyToId: replyToId,
           messageId: messageId,
           viewOnce: viewOnce,
+          forwarded: forwarded,
         );
+        if (!waitForDelivery) {
+          return _enqueueOutbound(
+            send: send,
+            dispose: chatService.dispose,
+            chatKind: chatKind,
+            conversationId: conversationId,
+            messageId: messageId,
+          );
+        }
+        final id = await send();
         chatService.dispose();
         if (id != null) {
           await _notifyStatus(

--- a/lib/services/detached_chat_bridge.dart
+++ b/lib/services/detached_chat_bridge.dart
@@ -353,14 +353,19 @@ class DetachedChatBridge {
     unawaited(() async {
       try {
         final id = await send();
-        if (id != null) {
-          await _notifyStatus(
-            chatKind: chatKind,
-            conversationId: conversationId,
-            messageId: messageId,
-            status: 'sent',
-          );
-        }
+        await _notifyStatus(
+          chatKind: chatKind,
+          conversationId: conversationId,
+          messageId: messageId,
+          status: id != null ? 'sent' : 'failed',
+        );
+      } catch (_) {
+        await _notifyStatus(
+          chatKind: chatKind,
+          conversationId: conversationId,
+          messageId: messageId,
+          status: 'failed',
+        );
       } finally {
         dispose();
       }

--- a/lib/services/detached_chat_client.dart
+++ b/lib/services/detached_chat_client.dart
@@ -72,6 +72,7 @@ class DetachedChatClient {
     required String text,
     String? replyToId,
     required String messageId,
+    bool forwarded = false,
   }) async {
     return _hostChannel.invokeMethod<String>(
       'sendText',
@@ -81,6 +82,7 @@ class DetachedChatClient {
         'text': text,
         'replyToId': replyToId,
         'messageId': messageId,
+        'forwarded': forwarded,
       },
     );
   }
@@ -92,6 +94,7 @@ class DetachedChatClient {
     String? replyToId,
     required String messageId,
     bool viewOnce = false,
+    bool forwarded = false,
   }) async {
     return _hostChannel.invokeMethod<String>(
       'sendFile',
@@ -103,6 +106,7 @@ class DetachedChatClient {
         'replyToId': replyToId,
         'messageId': messageId,
         'viewOnce': viewOnce,
+        'forwarded': forwarded,
         'bytes': bytes,
       },
     );

--- a/lib/services/detached_chat_host.dart
+++ b/lib/services/detached_chat_host.dart
@@ -20,6 +20,7 @@ typedef DetachedSendTextFn = Future<String?> Function({
   required String text,
   String? replyToId,
   required String messageId,
+  bool forwarded,
 });
 
 typedef DetachedSendFileFn = Future<String?> Function({
@@ -31,6 +32,7 @@ typedef DetachedSendFileFn = Future<String?> Function({
   String? replyToId,
   required String messageId,
   bool viewOnce,
+  bool forwarded,
 });
 
 typedef DetachedSendVoiceFn = Future<String?> Function({
@@ -144,6 +146,7 @@ class DetachedChatHost {
           text: args['text'] as String,
           replyToId: args['replyToId'] as String?,
           messageId: args['messageId'] as String,
+          forwarded: args['forwarded'] as bool? ?? false,
         );
       case 'sendFile':
         final args = (call.arguments as Map?)?.cast<String, dynamic>() ?? {};
@@ -158,6 +161,7 @@ class DetachedChatHost {
           replyToId: args['replyToId'] as String?,
           messageId: args['messageId'] as String,
           viewOnce: args['viewOnce'] as bool? ?? false,
+          forwarded: args['forwarded'] as bool? ?? false,
         );
       case 'sendVoice':
         final args = (call.arguments as Map?)?.cast<String, dynamic>() ?? {};

--- a/lib/services/file_transfer_handler.dart
+++ b/lib/services/file_transfer_handler.dart
@@ -31,6 +31,7 @@ class _InboundTransfer {
     required this.scheme,
     this.replyTo,
     this.viewOnce = false,
+    this.forwarded = false,
   }) : buffer = Uint8List(ciphertextSize),
        receivedChunks = List<bool>.filled(totalChunks, false),
        lastActivity = DateTime.now();
@@ -50,6 +51,7 @@ class _InboundTransfer {
   final String scheme;
   final String? replyTo;
   final bool viewOnce;
+  final bool forwarded;
 
   final Uint8List buffer;
   final List<bool> receivedChunks;
@@ -238,7 +240,8 @@ class FileTransferHandler {
           base64Encode(existing.nonce) == payload['nonce'] &&
           mapEquals(existing.wrappedKey, payload['wrappedKey']) &&
           existing.replyTo == payload['replyTo'] &&
-          existing.viewOnce == (payload['viewOnce'] == true);
+          existing.viewOnce == (payload['viewOnce'] == true) &&
+          existing.forwarded == (payload['forwarded'] == true);
       if (sameTransfer) {
         Logging.debug(
           'begin duplicate transfer=$transferId message=${payload['messageId']} '
@@ -302,6 +305,7 @@ class FileTransferHandler {
       scheme: scheme,
       replyTo: payload['replyTo'] as String?,
       viewOnce: payload['viewOnce'] == true,
+      forwarded: payload['forwarded'] == true,
     );
 
     FileTransferProgress.setDownload(
@@ -417,6 +421,7 @@ class FileTransferHandler {
       'timestamp': session.timestamp,
       if (session.replyTo != null) 'replyTo': session.replyTo,
       'viewOnce': session.viewOnce,
+      if (session.forwarded) 'forwarded': true,
     };
 
     try {

--- a/lib/services/file_transfer_sender.dart
+++ b/lib/services/file_transfer_sender.dart
@@ -74,6 +74,7 @@ class FileTransferSender {
     required String peerPayload,
     String? replyToId,
     bool viewOnce = false,
+    bool forwarded = false,
     int? expiresAt,
     int? timestamp,
   }) async {
@@ -150,6 +151,7 @@ class FileTransferSender {
               'chunkSize': chunkSize,
               'replyTo': ?replyToId,
               'viewOnce': viewOnce,
+              if (forwarded) 'forwarded': true,
               'expiresAt': ?expiresAt,
             },
             bypassQueue: true,

--- a/lib/services/group_chat_service.dart
+++ b/lib/services/group_chat_service.dart
@@ -142,6 +142,7 @@ class GroupChatService {
     String text, {
     String? replyToId,
     String? messageId,
+    bool forwarded = false,
   }) async {
     await _refreshSession();
     if (_groupKey == null) return null;
@@ -176,6 +177,7 @@ class GroupChatService {
       'timestamp': timestamp,
       'replyTo': replyToId,
       'expiresAt': ?expiresAt,
+      if (forwarded) 'forwarded': 1,
     });
 
     await MessageSearchIndexService.indexBestEffort(
@@ -206,6 +208,7 @@ class GroupChatService {
         type: groupTextType,
         replyToId: replyToId,
         timestamp: timestamp,
+        forwarded: forwarded,
         expiresAt: expiresAt,
       );
       if (success) {
@@ -218,6 +221,7 @@ class GroupChatService {
           type: groupTextType,
           replyToId: replyToId,
           timestamp: timestamp,
+          forwarded: forwarded,
           expiresAt: expiresAt,
         );
       }
@@ -246,6 +250,7 @@ class GroupChatService {
     String? replyToId,
     String? messageId,
     bool viewOnce = false,
+    bool forwarded = false,
   }) async {
     await _refreshSession();
     if (_groupKey == null) return null;
@@ -277,6 +282,7 @@ class GroupChatService {
       'status': 'pending',
       'viewOnce': viewOnce ? 1 : 0,
       'expiresAt': ?expiresAt,
+      if (forwarded) 'forwarded': 1,
     });
 
     if (!viewOnce) {
@@ -313,6 +319,7 @@ class GroupChatService {
         fileName: fileName,
         fileSize: bytes.length,
         viewOnce: viewOnce,
+        forwarded: forwarded,
         expiresAt: expiresAt,
       );
       if (success) {
@@ -328,6 +335,7 @@ class GroupChatService {
           fileName: fileName,
           fileSize: bytes.length,
           viewOnce: viewOnce,
+          forwarded: forwarded,
           expiresAt: expiresAt,
         );
       }
@@ -484,6 +492,7 @@ class GroupChatService {
             fileName: msg['fileName'] as String?,
             fileSize: msg['fileSize'] as int?,
             viewOnce: (msg['viewOnce'] ?? 0) == 1,
+            forwarded: (msg['forwarded'] ?? 0) == 1,
             expiresAt: msg['expiresAt'] as int?,
           );
 
@@ -530,6 +539,7 @@ class GroupChatService {
     String? fileName,
     int? fileSize,
     bool viewOnce = false,
+    bool forwarded = false,
     int? expiresAt,
   }) async {
     if (TorRuntimeGate.blocked) return false;
@@ -559,6 +569,7 @@ class GroupChatService {
           fileName: fileName,
           fileSize: fileSize,
           viewOnce: viewOnce,
+          forwarded: forwarded,
           expiresAt: expiresAt,
           timeout: timeout,
         ),
@@ -580,6 +591,7 @@ class GroupChatService {
     String? fileName,
     int? fileSize,
     bool viewOnce = false,
+    bool forwarded = false,
     Duration timeout = const Duration(seconds: 30),
     int? expiresAt,
   }) async {
@@ -595,6 +607,7 @@ class GroupChatService {
       'fileName': ?fileName,
       'fileSize': ?fileSize,
       if (viewOnce) 'viewOnce': true,
+      if (forwarded) 'forwarded': true,
       'expiresAt': ?expiresAt,
     };
     await _postman.postGroup(
@@ -622,6 +635,7 @@ class GroupChatService {
     String? fileName,
     int? fileSize,
     bool viewOnce = false,
+    bool forwarded = false,
     int? expiresAt,
   }) async {
     await PendingMessageDbHelper.insertPendingMessage({
@@ -638,6 +652,7 @@ class GroupChatService {
       'fileName': ?fileName,
       'fileSize': ?fileSize,
       'viewOnce': viewOnce ? 1 : 0,
+      if (forwarded) 'forwarded': 1,
       'expiresAt': ?expiresAt,
     });
   }
@@ -727,6 +742,7 @@ class GroupChatService {
           fileName: msg['fileName'] as String?,
           fileSize: msg['fileSize'] as int?,
           viewOnce: (msg['viewOnce'] ?? 0) == 1,
+          forwarded: (msg['forwarded'] ?? 0) == 1,
           expiresAt: msg['expiresAt'] as int?,
         );
         if (success) {
@@ -781,6 +797,7 @@ class GroupChatService {
     final fileName = row['fileName'] as String?;
     final fileSize = row['fileSize'] as int?;
     final viewOnce = (row['viewOnce'] ?? 0) == 1;
+    final forwarded = (row['forwarded'] ?? 0) == 1;
     final expiresAt = row['expiresAt'] as int?;
 
     await MessagesDb.updateMessageStatus(messageId, 'pending', groupId: groupId);
@@ -799,6 +816,7 @@ class GroupChatService {
         fileName: fileName,
         fileSize: fileSize,
         viewOnce: viewOnce,
+        forwarded: forwarded,
         expiresAt: expiresAt,
       );
       if (success) {
@@ -814,6 +832,7 @@ class GroupChatService {
           fileName: fileName,
           fileSize: fileSize,
           viewOnce: viewOnce,
+          forwarded: forwarded,
           expiresAt: expiresAt,
         );
       }

--- a/lib/services/message_forward_service.dart
+++ b/lib/services/message_forward_service.dart
@@ -1,0 +1,171 @@
+import 'dart:typed_data';
+
+import 'package:prysm/constants/group_constants.dart';
+import 'package:prysm/crypto/wire.dart';
+import 'package:prysm/database/messages.dart';
+import 'package:prysm/database/self_messages_db.dart';
+import 'package:prysm/models/chat/prysm_message.dart';
+import 'package:prysm/models/contact.dart';
+import 'package:prysm/models/detached_chat_launch.dart';
+import 'package:prysm/models/group.dart';
+import 'package:prysm/models/share_target.dart';
+import 'package:prysm/services/detached_chat_bridge.dart';
+import 'package:prysm/services/file_attachment_resolver.dart';
+import 'package:prysm/services/group_service.dart';
+import 'package:prysm/services/message_view_mapper.dart';
+import 'package:prysm/util/key_manager.dart';
+import 'package:prysm/util/message_modify_policy.dart';
+import 'package:uuid/uuid.dart';
+
+/// Decrypts a message from its DB row and sends a new copy to [target].
+class MessageForwardService {
+  MessageForwardService._();
+
+  static Future<void> forward({
+    required Message message,
+    required ShareTarget target,
+    required bool markForwarded,
+    required DetachedChatKind sourceKind,
+    required String sourceConversationId,
+    required String userId,
+    required KeyManager keyManager,
+    required List<Contact> contacts,
+    required Group? Function(String groupId) groupById,
+  }) async {
+    if (!canForwardMessage(message)) {
+      throw StateError('Message cannot be forwarded');
+    }
+
+    final messageId = const Uuid().v4();
+
+    if (message is TextMessage) {
+      final id = await DetachedChatBridge.sendSharedText(
+        chatKind: target.kind,
+        conversationId: target.conversationId,
+        text: message.text,
+        messageId: messageId,
+        forwarded: markForwarded,
+        userId: userId,
+        keyManager: keyManager,
+        contacts: contacts,
+        groupById: groupById,
+      );
+      if (id == null) {
+        throw StateError('Send failed');
+      }
+      return;
+    }
+
+    final row = await _sourceRow(
+      messageId: message.id,
+      sourceKind: sourceKind,
+      sourceConversationId: sourceConversationId,
+    );
+    final bytes = await _decryptMedia(
+      row: row,
+      sourceKind: sourceKind,
+      sourceConversationId: sourceConversationId,
+      userId: userId,
+      keyManager: keyManager,
+    );
+    if (bytes.isEmpty) {
+      throw StateError('Could not decrypt media');
+    }
+
+    final spec = _mediaSpec(message, row);
+    final id = await DetachedChatBridge.sendSharedFile(
+      chatKind: target.kind,
+      conversationId: target.conversationId,
+      bytes: bytes,
+      fileName: spec.name,
+      type: spec.type,
+      messageId: messageId,
+      forwarded: markForwarded,
+      userId: userId,
+      keyManager: keyManager,
+      contacts: contacts,
+      groupById: groupById,
+    );
+    if (id == null) {
+      throw StateError('Send failed');
+    }
+  }
+
+  static Future<Map<String, dynamic>> _sourceRow({
+    required String messageId,
+    required DetachedChatKind sourceKind,
+    required String sourceConversationId,
+  }) async {
+    switch (sourceKind) {
+      case DetachedChatKind.direct:
+        final rows = await MessagesDb.getMessageById(messageId);
+        if (rows.isEmpty) throw StateError('Message not found');
+        return rows.first;
+      case DetachedChatKind.group:
+        final rows = await MessagesDb.getMessageById(
+          messageId,
+          groupId: sourceConversationId,
+        );
+        if (rows.isEmpty) throw StateError('Message not found');
+        return rows.first;
+      case DetachedChatKind.self:
+        final rows = await SelfMessagesDb.getMessageById(messageId);
+        if (rows.isEmpty) throw StateError('Message not found');
+        return rows.first;
+    }
+  }
+
+  static Future<Uint8List> _decryptMedia({
+    required Map<String, dynamic> row,
+    required DetachedChatKind sourceKind,
+    required String sourceConversationId,
+    required String userId,
+    required KeyManager keyManager,
+  }) async {
+    final wire = row['message'] as String? ?? '';
+    if (wire.isEmpty) {
+      throw StateError('Empty message payload');
+    }
+    switch (sourceKind) {
+      case DetachedChatKind.direct:
+        return FileAttachmentResolver.decryptEncryptedSource(
+          wire,
+          keyManager,
+          senderId: row['senderId'] as String?,
+          localUserId: userId,
+        );
+      case DetachedChatKind.group:
+        final groupService = GroupService(
+          keyManager: keyManager,
+          userId: userId,
+        );
+        return MessageViewMapper(keyManager: keyManager).decryptGroupFileBytes(
+          getDecryptedGroupKey: groupService.getDecryptedGroupKey,
+          groupId: sourceConversationId,
+          row: row,
+        );
+      case DetachedChatKind.self:
+        return CryptoWire.decryptFile(wire, keyManager.identity);
+    }
+  }
+
+  static ({String name, String type}) _mediaSpec(
+    Message message,
+    Map<String, dynamic> row,
+  ) {
+    final dbType = row['type'] as String? ?? '';
+    final dbName = row['fileName'] as String?;
+    if (message is ImageMessage ||
+        dbType == 'image' ||
+        dbType == groupImageType) {
+      return (name: dbName ?? 'image.jpg', type: 'image');
+    }
+    if (message is FileMessage &&
+        (message.name.contains('voice_message') ||
+            dbType == 'audio' ||
+            dbType == groupAudioType)) {
+      return (name: 'voice_message.wav', type: 'audio');
+    }
+    return (name: dbName ?? (message as FileMessage).name, type: 'file');
+  }
+}

--- a/lib/services/self_chat_service.dart
+++ b/lib/services/self_chat_service.dart
@@ -22,6 +22,7 @@ class SelfChatService {
     String text, {
     String? replyToId,
     String? messageId,
+    bool forwarded = false,
   }) async {
     final id = messageId ?? const Uuid().v4();
     final timestamp = DateTime.now().millisecondsSinceEpoch;
@@ -33,6 +34,7 @@ class SelfChatService {
       'type': 'text',
       'timestamp': timestamp,
       'replyTo': replyToId,
+      if (forwarded) 'forwarded': 1,
     });
 
     await MessageSearchIndexService.indexBestEffort(
@@ -56,6 +58,7 @@ class SelfChatService {
     String? replyToId,
     String? messageId,
     bool viewOnce = false,
+    bool forwarded = false,
   }) async {
     final id = messageId ?? const Uuid().v4();
     final timestamp = DateTime.now().millisecondsSinceEpoch;
@@ -75,6 +78,7 @@ class SelfChatService {
       'timestamp': timestamp,
       'replyTo': replyToId,
       'viewOnce': viewOnce ? 1 : 0,
+      if (forwarded) 'forwarded': 1,
     });
 
     // ponytail: guard instead of a viewOnce param on indexOutboundFile — a

--- a/lib/services/shareable_conversations.dart
+++ b/lib/services/shareable_conversations.dart
@@ -1,0 +1,40 @@
+import 'package:prysm/models/contact.dart';
+import 'package:prysm/models/conversation.dart';
+import 'package:prysm/models/conversation_preferences.dart';
+import 'package:prysm/models/group.dart';
+import 'package:prysm/services/block_service.dart';
+import 'package:prysm/services/conversation_preferences_service.dart';
+import 'package:prysm/util/db_helper.dart';
+
+/// Conversations that can receive a share or forward.
+class ShareableConversations {
+  ShareableConversations._();
+
+  static List<Conversation> filter({
+    required List<Conversation> conversations,
+    required Map<String, ConversationPreferences> prefs,
+  }) {
+    return conversations.where((conversation) {
+      if (conversation is DirectConversation &&
+          BlockService.instance.isBlocked(conversation.id)) {
+        return false;
+      }
+      return !(prefs[conversation.id]?.isArchived ?? false);
+    }).toList();
+  }
+
+  static Future<List<Conversation>> loadFromDb({
+    required String localUserId,
+  }) async {
+    final users = await DBHelper.getUsers();
+    final groups = await DBHelper.getGroups();
+    final prefs = await ConversationPreferencesService.instance.getAll();
+    final conversations = <Conversation>[
+      ...users
+          .where((map) => map['id'] != localUserId)
+          .map((map) => DirectConversation(Contact.fromMap(map))),
+      ...groups.map((map) => GroupConversation(Group.fromMap(map))),
+    ];
+    return filter(conversations: conversations, prefs: prefs);
+  }
+}

--- a/lib/ui/core/prysm_icons.dart
+++ b/lib/ui/core/prysm_icons.dart
@@ -85,6 +85,7 @@ abstract final class PrysmIcons {
   static const flipCameraAndroid = CupertinoIcons.camera_rotate;
   static const folderOpen = CupertinoIcons.folder;
   static const folderOpenOutlined = CupertinoIcons.folder;
+  static const forward = CupertinoIcons.arrowshape_turn_up_right;
   static const group = CupertinoIcons.person_2;
   static const groupAdd = CupertinoIcons.person_add_solid;
   static const groupAddOutlined = CupertinoIcons.person_add;

--- a/lib/util/message_modify_policy.dart
+++ b/lib/util/message_modify_policy.dart
@@ -19,11 +19,21 @@ bool canDeleteForEveryone(Message message, String currentUserId) {
   return message.authorId == currentUserId;
 }
 
+bool canForwardMessage(Message message) {
+  if (isMessageDeleted(message)) return false;
+  if (message is PrysmCallMessage) return false;
+  if (message.metadata?['viewOnce'] == true) return false;
+  return message is TextMessage ||
+      message is ImageMessage ||
+      message is FileMessage;
+}
+
 Map<String, Object?> metadataFromDbRow(Map<String, dynamic> row) {
   final meta = <String, Object?>{};
   if (row['deletedAt'] != null) meta['deleted'] = true;
   if (row['editedAt'] != null) meta['edited'] = true;
   if (row['expiresAt'] != null) meta['expiresAt'] = row['expiresAt'];
+  if ((row['forwarded'] ?? 0) == 1) meta['forwarded'] = true;
   return meta;
 }
 

--- a/lib/util/pending_message_db_helper.dart
+++ b/lib/util/pending_message_db_helper.dart
@@ -37,7 +37,7 @@ class PendingMessageDbHelper {
 
     final db = await openDatabase(
       path,
-      version: 5,
+      version: 6,
       singleInstance: true,
       // PRAGMA key must be the first statement on the connection.
       onConfigure: (db) async {
@@ -59,7 +59,8 @@ class PendingMessageDbHelper {
             viewOnce INTEGER DEFAULT 0,
             groupId TEXT,
             targetMemberId TEXT,
-            expiresAt INTEGER
+            expiresAt INTEGER,
+            forwarded INTEGER DEFAULT 0
           )
         ''');
         await db.execute('CREATE INDEX idx_pending_receiver ON pending_messages(receiverId)');
@@ -89,6 +90,14 @@ class PendingMessageDbHelper {
           final columns = await db.rawQuery('PRAGMA table_info(pending_messages)');
           if (!columns.any((col) => col['name'] == 'expiresAt')) {
             await db.execute('ALTER TABLE pending_messages ADD COLUMN expiresAt INTEGER');
+          }
+        }
+        if (oldVersion < 6) {
+          final columns = await db.rawQuery('PRAGMA table_info(pending_messages)');
+          if (!columns.any((col) => col['name'] == 'forwarded')) {
+            await db.execute(
+              'ALTER TABLE pending_messages ADD COLUMN forwarded INTEGER DEFAULT 0',
+            );
           }
         }
       },

--- a/test/chat_screen_controller_characterization_test.dart
+++ b/test/chat_screen_controller_characterization_test.dart
@@ -52,7 +52,8 @@ Future<Database> _openMessagesDb() async {
       groupId TEXT,
       deletedAt INTEGER,
       editedAt INTEGER,
-      expiresAt INTEGER
+      expiresAt INTEGER,
+      forwarded INTEGER NOT NULL DEFAULT 0
     )
   ''');
   await MessageReadReceiptsDb.createTable(db);

--- a/test/chat_service_characterization_test.dart
+++ b/test/chat_service_characterization_test.dart
@@ -36,7 +36,8 @@ Future<Database> _openPendingDb() async {
       replyTo TEXT,
       viewOnce INTEGER DEFAULT 0,
       groupId TEXT,
-      targetMemberId TEXT
+      targetMemberId TEXT,
+      forwarded INTEGER DEFAULT 0
     )
   ''');
   return db;
@@ -95,7 +96,8 @@ Future<Database> _openMessagesDb() async {
       groupId TEXT,
       deletedAt INTEGER,
       editedAt INTEGER,
-      expiresAt INTEGER
+      expiresAt INTEGER,
+      forwarded INTEGER NOT NULL DEFAULT 0
     )
   ''');
   return db;
@@ -450,6 +452,30 @@ void main() {
       expect(stored.first['status'], 'sent');
       expect(await PendingMessageDbHelper.getPendingMessages(receiverId: peerId),
           isEmpty);
+    });
+
+    test('sendTextMessage includes forwarded on the wire when set', () async {
+      TorRuntimeGate.resetForTest();
+      final postman = _FakePostman();
+      final service = ChatService(
+        userId: userId,
+        peerId: peerId,
+        keyManager: keyManager,
+        postman: postman,
+      );
+      addTearDown(service.dispose);
+      service.peerIdentity = IdentityPublicKeys(
+        signPublic: await peerKeyPair.signPublicKey,
+        agreePublic: await peerKeyPair.agreePublicKey,
+        fingerprint: 'test',
+      );
+
+      final id = await service.sendTextMessage('hello', forwarded: true);
+
+      expect(postman.directCalls, hasLength(1));
+      expect(postman.directCalls.single.payload['forwarded'], isTrue);
+      final stored = await MessagesDb.getMessageById(id!);
+      expect(stored.first['forwarded'], 1);
     });
 
     test(

--- a/test/chat_service_chunked_file_test.dart
+++ b/test/chat_service_chunked_file_test.dart
@@ -100,7 +100,8 @@ Future<Database> _openMessagesDb() async {
       groupId TEXT,
       deletedAt INTEGER,
       editedAt INTEGER,
-      expiresAt INTEGER
+      expiresAt INTEGER,
+      forwarded INTEGER NOT NULL DEFAULT 0
     )
   ''');
   return db;

--- a/test/chat_service_pending_delete_test.dart
+++ b/test/chat_service_pending_delete_test.dart
@@ -81,7 +81,8 @@ Future<Database> _openMessagesDb() async {
       groupId TEXT,
       deletedAt INTEGER,
       editedAt INTEGER,
-      expiresAt INTEGER
+      expiresAt INTEGER,
+      forwarded INTEGER NOT NULL DEFAULT 0
     )
   ''');
   await MessageSchemaMigrations.createMessageSearchFtsTable(db);

--- a/test/disappearing_messages_test.dart
+++ b/test/disappearing_messages_test.dart
@@ -33,7 +33,8 @@ Future<Database> _openMessagesDb() async {
       groupId TEXT,
       deletedAt INTEGER,
       editedAt INTEGER,
-      expiresAt INTEGER
+      expiresAt INTEGER,
+      forwarded INTEGER NOT NULL DEFAULT 0
     )
   ''');
   await MessageSchemaMigrations.createReactionsTable(db);

--- a/test/file_transfer_handler_test.dart
+++ b/test/file_transfer_handler_test.dart
@@ -58,6 +58,7 @@ void main() {
         'ciphertextSize': ciphertext.length,
         'totalChunks': totalChunks,
         'chunkSize': chunkSize,
+        'forwarded': true,
       },
       peerOnion: 'peer.onion',
       localOnion: 'local.onion',
@@ -91,6 +92,7 @@ void main() {
     expect(endResult['ok'], isTrue);
     expect(testRouter.lastProcessed?['id'], 'msg-1');
     expect(testRouter.lastProcessed?['type'], 'file');
+    expect(testRouter.lastProcessed?['forwarded'], isTrue);
 
     final wire = testRouter.lastProcessed?['message'] as String;
     final envelope = CryptoEnvelope.tryParse(wire);

--- a/test/group_chat_service_test.dart
+++ b/test/group_chat_service_test.dart
@@ -109,7 +109,8 @@ Future<Database> _openMessagesDb() async {
       groupId TEXT,
       deletedAt INTEGER,
       editedAt INTEGER,
-      expiresAt INTEGER
+      expiresAt INTEGER,
+      forwarded INTEGER NOT NULL DEFAULT 0
     )
   ''');
   await MessageSchemaMigrations.createMessageSearchFtsTable(db);

--- a/test/inbound_message_router_test.dart
+++ b/test/inbound_message_router_test.dart
@@ -48,7 +48,8 @@ Future<Database> _openMessagesDb() async {
       groupId TEXT,
       deletedAt INTEGER,
       editedAt INTEGER,
-      expiresAt INTEGER
+      expiresAt INTEGER,
+      forwarded INTEGER NOT NULL DEFAULT 0
     )
   ''');
   await MessageSchemaMigrations.createMessageSearchFtsTable(db);
@@ -265,5 +266,33 @@ void main() {
         expect(refreshCount, 0);
       },
     );
+
+    test('inbound chat message persists forwarded', () async {
+      final aliceKm = KeyManager.fromIdentity(alice);
+      final wire = await aliceKm.encryptForPeer(
+        'hello',
+        localPublic,
+        peerId: 'local.onion',
+      );
+
+      final result = await router.handleMessage({
+        'id': 'fwd-1',
+        'senderId': 'alice.onion',
+        'receiverId': 'local.onion',
+        'message': wire,
+        'type': 'text',
+        'timestamp': 1,
+        'forwarded': true,
+      });
+
+      expect(result.statusCode, 200);
+      final rows = await messagesDb.query(
+        'messages',
+        where: 'id = ?',
+        whereArgs: ['fwd-1'],
+      );
+      expect(rows, hasLength(1));
+      expect(rows.single['forwarded'], 1);
+    });
   });
 }

--- a/test/message_actions_characterization_test.dart
+++ b/test/message_actions_characterization_test.dart
@@ -60,7 +60,8 @@ Future<Database> _openMessagesDb() async {
       groupId TEXT,
       deletedAt INTEGER,
       editedAt INTEGER,
-      expiresAt INTEGER
+      expiresAt INTEGER,
+      forwarded INTEGER NOT NULL DEFAULT 0
     )
   ''');
   await MessageReactionsDb.createTable(db);

--- a/test/message_actions_service_test.dart
+++ b/test/message_actions_service_test.dart
@@ -50,7 +50,8 @@ Future<Database> _openMessagesDb() async {
       groupId TEXT,
       deletedAt INTEGER,
       editedAt INTEGER,
-      expiresAt INTEGER
+      expiresAt INTEGER,
+      forwarded INTEGER NOT NULL DEFAULT 0
     )
   ''');
   await MessageReactionsDb.createTable(db);

--- a/test/message_forward_ui_test.dart
+++ b/test/message_forward_ui_test.dart
@@ -1,0 +1,67 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:prysm/models/contact.dart';
+import 'package:prysm/models/conversation.dart';
+import 'package:prysm/models/shared_content.dart';
+import 'package:prysm/screens/share_target_picker_screen.dart';
+import 'package:prysm/screens/widgets/message_forwarded_label.dart';
+import 'package:prysm/ui/core/prysm_switch.dart';
+import 'package:prysm/util/key_manager.dart';
+
+import 'pump_prysm_l10n.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  testWidgets('Forwarded label shows only when metadata is set', (tester) async {
+    await pumpWithPrysmL10n(
+      tester,
+      const MessageForwardedLabel(metadata: {'forwarded': true}),
+    );
+    expect(find.text('Forwarded'), findsOneWidget);
+
+    await pumpWithPrysmL10n(
+      tester,
+      const MessageForwardedLabel(),
+    );
+    expect(find.text('Forwarded'), findsNothing);
+  });
+
+  testWidgets('forward picker toggle defaults on', (tester) async {
+    await pumpWithPrysmL10n(
+      tester,
+      ShareTargetPickerScreen(
+        content: const SharedContent(
+          kind: SharedContentKind.text,
+          text: 'hello',
+        ),
+        conversations: [
+          DirectConversation(
+            Contact(
+              id: 'peer.onion',
+              name: 'Peer',
+              avatarUrl: '',
+              identityJson: '{}',
+            ),
+          ),
+        ],
+        userId: 'me.onion',
+        userName: 'Me',
+        userAvatarBase64: null,
+        contacts: const [],
+        keyManager: KeyManager(),
+        groupById: (_) => null,
+        showForwardedToggle: true,
+        customSend: (_, {required markForwarded}) async {},
+      ),
+      width: 400,
+    );
+    await tester.pump();
+
+    expect(find.text('Show as forwarded'), findsOneWidget);
+    expect(tester.widget<PrysmSwitch>(find.byType(PrysmSwitch)).value, isTrue);
+
+    await tester.tap(find.byType(PrysmSwitch));
+    await tester.pump();
+    expect(tester.widget<PrysmSwitch>(find.byType(PrysmSwitch)).value, isFalse);
+  });
+}

--- a/test/message_modify_policy_test.dart
+++ b/test/message_modify_policy_test.dart
@@ -71,4 +71,82 @@ void main() {
       isTrue,
     );
   });
+
+  test('metadataFromDbRow maps forwarded=1', () {
+    expect(metadataFromDbRow({'forwarded': 1})['forwarded'], isTrue);
+    expect(metadataFromDbRow({'forwarded': 0})['forwarded'], isNull);
+    expect(metadataFromDbRow({})['forwarded'], isNull);
+  });
+
+  test('canForwardMessage allows text image file and voice', () {
+    expect(
+      canForwardMessage(
+        TextMessage(id: 't', authorId: 'a', text: 'hi'),
+      ),
+      isTrue,
+    );
+    expect(
+      canForwardMessage(
+        ImageMessage(id: 'i', authorId: 'a', source: 'x', size: 1),
+      ),
+      isTrue,
+    );
+    expect(
+      canForwardMessage(
+        FileMessage(
+          id: 'f',
+          authorId: 'a',
+          name: 'doc.pdf',
+          source: 'x',
+          size: 1,
+        ),
+      ),
+      isTrue,
+    );
+    expect(
+      canForwardMessage(
+        FileMessage(
+          id: 'v',
+          authorId: 'a',
+          name: 'voice_message.wav',
+          source: 'x',
+          size: 1,
+        ),
+      ),
+      isTrue,
+    );
+  });
+
+  test('canForwardMessage rejects deleted view-once and call events', () {
+    expect(
+      canForwardMessage(
+        markMessageDeleted(TextMessage(id: 't', authorId: 'a', text: 'hi')),
+      ),
+      isFalse,
+    );
+    expect(
+      canForwardMessage(
+        ImageMessage(
+          id: 'i',
+          authorId: 'a',
+          source: 'x',
+          size: 1,
+          metadata: const {'viewOnce': true},
+        ),
+      ),
+      isFalse,
+    );
+    expect(
+      canForwardMessage(
+        PrysmCallMessage(
+          id: 'c',
+          authorId: 'a',
+          durationMs: 0,
+          callStatus: 'missed',
+          direction: 'inbound',
+        ),
+      ),
+      isFalse,
+    );
+  });
 }

--- a/test/message_modify_service_test.dart
+++ b/test/message_modify_service_test.dart
@@ -72,7 +72,8 @@ Future<Database> _openMessagesDb() async {
       groupId TEXT,
       deletedAt INTEGER,
       editedAt INTEGER,
-      expiresAt INTEGER
+      expiresAt INTEGER,
+      forwarded INTEGER NOT NULL DEFAULT 0
     )
   ''');
   await MessageReactionsDb.createTable(db);

--- a/test/message_schema_migrations_test.dart
+++ b/test/message_schema_migrations_test.dart
@@ -71,7 +71,7 @@ void main() {
       expect(columns, containsAll(<String>[
         'id', 'senderId', 'receiverId', 'message', 'type', 'fileName',
         'fileSize', 'timestamp', 'status', 'replyTo', 'readAt', 'viewOnce',
-        'viewed', 'groupId', 'deletedAt', 'editedAt',
+        'viewed', 'groupId', 'deletedAt', 'editedAt', 'forwarded',
       ]));
 
       expect(await _tableExists(db, 'message_reactions'), isTrue);
@@ -194,6 +194,7 @@ void main() {
       final columns = _columnNames(await db.rawQuery('PRAGMA table_info(messages)'));
       expect(columns, containsAll(<String>[
         'readAt', 'viewOnce', 'viewed', 'groupId', 'deletedAt', 'editedAt',
+        'forwarded',
       ]));
       expect(await _tableExists(db, 'message_reactions'), isTrue);
       expect(await _tableExists(db, 'message_read_receipts'), isTrue);
@@ -369,6 +370,57 @@ void main() {
         ['m1'],
       );
       expect(fts.single['rowid'], byId['m1']!['ftsRowid']);
+
+      await db.close();
+    });
+  });
+
+  group('v16 forwarded column', () {
+    test('onCreate includes forwarded on messages and self_messages', () async {
+      final db = await _openBareDb();
+      await MessageSchemaMigrations.onCreate(
+        db,
+        MessageSchemaMigrations.dbVersion,
+      );
+
+      final messageCols =
+          _columnNames(await db.rawQuery('PRAGMA table_info(messages)'));
+      expect(messageCols, contains('forwarded'));
+      final selfCols =
+          _columnNames(await db.rawQuery('PRAGMA table_info(self_messages)'));
+      expect(selfCols, contains('forwarded'));
+
+      await db.close();
+    });
+
+    test('upgrade from v15 adds forwarded to messages and self_messages',
+        () async {
+      final db = await _openBareDb();
+      await MessageSchemaMigrations.onCreate(
+        db,
+        MessageSchemaMigrations.dbVersion,
+      );
+      await db.execute('ALTER TABLE messages DROP COLUMN forwarded');
+      await db.execute('ALTER TABLE self_messages DROP COLUMN forwarded');
+      expect(
+        _columnNames(await db.rawQuery('PRAGMA table_info(messages)')),
+        isNot(contains('forwarded')),
+      );
+
+      await MessageSchemaMigrations.onUpgrade(
+        db,
+        15,
+        MessageSchemaMigrations.dbVersion,
+      );
+
+      expect(
+        _columnNames(await db.rawQuery('PRAGMA table_info(messages)')),
+        contains('forwarded'),
+      );
+      expect(
+        _columnNames(await db.rawQuery('PRAGMA table_info(self_messages)')),
+        contains('forwarded'),
+      );
 
       await db.close();
     });

--- a/test/messages_db_characterization_test.dart
+++ b/test/messages_db_characterization_test.dart
@@ -35,7 +35,8 @@ Future<Database> _openMessagesDb() async {
       groupId TEXT,
       deletedAt INTEGER,
       editedAt INTEGER,
-      expiresAt INTEGER
+      expiresAt INTEGER,
+      forwarded INTEGER NOT NULL DEFAULT 0
     )
   ''');
   await MessageSchemaMigrations.createMessageSearchFtsTable(db);

--- a/test/pending_queue_reconciler_test.dart
+++ b/test/pending_queue_reconciler_test.dart
@@ -52,7 +52,8 @@ Future<Database> _openMessagesDb() async {
       groupId TEXT,
       deletedAt INTEGER,
       editedAt INTEGER,
-      expiresAt INTEGER
+      expiresAt INTEGER,
+      forwarded INTEGER NOT NULL DEFAULT 0
     )
   ''');
   await MessageSchemaMigrations.createMessageSearchFtsTable(db);

--- a/test/pending_queue_reconciler_test.dart
+++ b/test/pending_queue_reconciler_test.dart
@@ -25,7 +25,8 @@ Future<Database> _openPendingDb() async {
       replyTo TEXT,
       viewOnce INTEGER DEFAULT 0,
       groupId TEXT,
-      targetMemberId TEXT
+      targetMemberId TEXT,
+      forwarded INTEGER DEFAULT 0
     )
   ''');
   return db;
@@ -233,18 +234,24 @@ void main() {
         'type': 'text',
         'timestamp': 1,
         'status': 'pending',
+        'forwarded': 1,
       });
 
+      Map<String, dynamic>? sentRow;
       final markedSent = <String>[];
       final reconciler = buildReconciler(
         requeued: [],
-        sendPending: (row) async => true,
+        sendPending: (row) async {
+          sentRow = row;
+          return true;
+        },
         markedSent: markedSent,
       );
 
       await reconciler.flushOnce();
 
       expect(markedSent, ['msg-1']);
+      expect(sentRow?['forwarded'], 1);
       final remaining = await PendingMessageDbHelper.getPendingMessages(
         receiverId: peerId,
       );

--- a/test/security/database_opener_concurrency_test.dart
+++ b/test/security/database_opener_concurrency_test.dart
@@ -129,7 +129,7 @@ void main() {
     'DBHelper: two concurrent first calls share one open and migrate once',
     () async {
       final path = '${tempDir.path}/prysm/chat_app.db';
-      await buildPlaintextDatabase(path, 10);
+      await buildPlaintextDatabase(path, 16);
 
       final dbs = await Future.wait([DBHelper.database, DBHelper.database]);
 
@@ -150,7 +150,7 @@ void main() {
     'migrate once',
     () async {
       final path = '${tempDir.path}/prysm/pending_messages.db';
-      await buildPlaintextDatabase(path, 5);
+      await buildPlaintextDatabase(path, 6);
 
       final dbs = await Future.wait([
         PendingMessageDbHelper.database,

--- a/test/security/group_inbound_claim_resolve_test.dart
+++ b/test/security/group_inbound_claim_resolve_test.dart
@@ -245,7 +245,8 @@ Future<void> _createMessagesTable(Database db) async {
       groupId TEXT,
       deletedAt INTEGER,
       editedAt INTEGER,
-      expiresAt INTEGER
+      expiresAt INTEGER,
+      forwarded INTEGER NOT NULL DEFAULT 0
     )
   ''');
 }

--- a/test/security/group_message_anti_replay_test.dart
+++ b/test/security/group_message_anti_replay_test.dart
@@ -56,7 +56,8 @@ Future<void> _createMessagesTable(Database db) async {
       groupId TEXT,
       deletedAt INTEGER,
       editedAt INTEGER,
-      expiresAt INTEGER
+      expiresAt INTEGER,
+      forwarded INTEGER NOT NULL DEFAULT 0
     )
   ''');
   await MessageSchemaMigrations.createMessageSearchFtsTable(db);

--- a/test/security/group_message_legacy_scheme_test.dart
+++ b/test/security/group_message_legacy_scheme_test.dart
@@ -53,7 +53,8 @@ Future<Database> _openMessagesDb() async {
       groupId TEXT,
       deletedAt INTEGER,
       editedAt INTEGER,
-      expiresAt INTEGER
+      expiresAt INTEGER,
+      forwarded INTEGER NOT NULL DEFAULT 0
     )
   ''');
   return db;


### PR DESCRIPTION
- Introduced a new 'forwarded' field in the message schema to support message forwarding.
- Updated database migration to include the 'forwarded' column in relevant tables.
- Enhanced localization files for English and Italian to include new strings related to message forwarding.
- Implemented UI changes in chat screens to allow users to forward messages and display forwarded message labels.
- Added functionality to toggle forwarding status when sharing messages.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added message forwarding for text, images, files, and voice messages across direct, group, and self chats.
  * Added recipient selection, message previews, and an option to mark forwarded messages.
  * Forwarded messages now display an indicator and original sender.
  * Added English and Italian translations for forwarding actions and errors.

* **Bug Fixes**
  * Forwarded status is preserved when sending, receiving, retrying, and transferring messages.
  * Forwarding is restricted for deleted, call, and view-once messages.

* **Tests**
  * Added coverage for forwarding behavior, labels, persistence, migrations, and transfer handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->